### PR TITLE
OAuth connectors & UX: Salesforce connector (consumer + producer), http-producer OAuth output, OAuth providers settings page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,6 +172,7 @@ docker-compose.override.yml
 /src/postgres-consumer
 /src/postgres-producer
 /src/salesforce-consumer
+/src/salesforce-producer
 /src/tenant-consumer
 /src/webhook-consumer
 /src/cmd/management-api/management-api

--- a/.gitignore
+++ b/.gitignore
@@ -171,6 +171,7 @@ docker-compose.override.yml
 /src/migrate-secrets
 /src/postgres-consumer
 /src/postgres-producer
+/src/salesforce-consumer
 /src/tenant-consumer
 /src/webhook-consumer
 /src/cmd/management-api/management-api

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -525,6 +525,28 @@ services:
       - vrsky-network
     restart: unless-stopped
 
+  # Salesforce Consumer - polls Salesforce via SOQL, authed by an OAuth grant (#79)
+  salesforce-consumer:
+    build:
+      context: .
+      dockerfile: src/cmd/salesforce-consumer/Dockerfile
+    container_name: vrsky-salesforce-consumer
+    environment:
+      NATS_URL: "nats://nats:4222"
+      DATABASE_URL: "postgres://postgres:management_password@postgres-management:5432/management_db?sslmode=disable"
+      LOG_LEVEL: "info"
+      # OAuth token resolution (#75): fetch access tokens for the configured grant.
+      MGMT_API_URL: "http://management-api:3000"
+      OAUTH_TOKEN_SERVICE_SECRET: "${OAUTH_TOKEN_SERVICE_SECRET:-dev-oauth-service-secret-change-me}"
+    depends_on:
+      nats:
+        condition: service_healthy
+      postgres-management:
+        condition: service_healthy
+    networks:
+      - vrsky-network
+    restart: unless-stopped
+
   data-filter:
     build:
       context: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -407,6 +407,9 @@ services:
       # Aux HTTP port the SDK serves the /events SSE stream on (UI connects here).
       WORKER_HTTP_PORT: "9400"
       NATS_SUBSCRIPTION_TOPIC: "vrsky.data.*.pipeline.*"
+      # OAuth output (#97): resolve access tokens for nodes with auth_type=oauth.
+      MGMT_API_URL: "http://management-api:3000"
+      OAUTH_TOKEN_SERVICE_SECRET: "${OAUTH_TOKEN_SERVICE_SECRET:-dev-oauth-service-secret-change-me}"
     ports:
       - "127.0.0.1:9400:9400"
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -550,6 +550,27 @@ services:
       - vrsky-network
     restart: unless-stopped
 
+  # Salesforce Producer - writes pipeline records to Salesforce (REST + Bulk API), OAuth-authed (#79)
+  salesforce-producer:
+    build:
+      context: .
+      dockerfile: src/cmd/salesforce-producer/Dockerfile
+    container_name: vrsky-salesforce-producer
+    environment:
+      NATS_URL: "nats://nats:4222"
+      DATABASE_URL: "postgres://postgres:management_password@postgres-management:5432/management_db?sslmode=disable"
+      LOG_LEVEL: "info"
+      MGMT_API_URL: "http://management-api:3000"
+      OAUTH_TOKEN_SERVICE_SECRET: "${OAUTH_TOKEN_SERVICE_SECRET:-dev-oauth-service-secret-change-me}"
+    depends_on:
+      nats:
+        condition: service_healthy
+      postgres-management:
+        condition: service_healthy
+    networks:
+      - vrsky-network
+    restart: unless-stopped
+
   data-filter:
     build:
       context: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -404,6 +404,9 @@ services:
       NATS_URL: "nats://nats:4222"
       DATABASE_URL: "postgres://postgres:management_password@postgres-management:5432/management_db?sslmode=disable"
       LOG_LEVEL: "info"
+      # Must match management-api's ENCRYPTION_KEY — the resolver decrypts
+      # *_secret_id references (e.g. an encrypted auth-header value) before sending.
+      ENCRYPTION_KEY: "${ENCRYPTION_KEY:-0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef}"
       # Aux HTTP port the SDK serves the /events SSE stream on (UI connects here).
       WORKER_HTTP_PORT: "9400"
       NATS_SUBSCRIPTION_TOPIC: "vrsky.data.*.pipeline.*"
@@ -485,6 +488,9 @@ services:
       NATS_URL: "nats://nats:4222"
       DATABASE_URL: "postgres://postgres:management_password@postgres-management:5432/management_db?sslmode=disable"
       LOG_LEVEL: "info"
+      # Must match management-api's ENCRYPTION_KEY — the resolver decrypts
+      # *_secret_id references (e.g. the target-DB password) before connecting.
+      ENCRYPTION_KEY: "${ENCRYPTION_KEY:-0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef}"
       # Aux HTTP port the SDK serves /events (SSE) + /test-connection on (UI connects here).
       WORKER_HTTP_PORT: "9500"
       NATS_SUBSCRIPTION_TOPIC: "vrsky.data.*.pipeline.*"

--- a/src/cmd/api-consumer/api_poller.go
+++ b/src/cmd/api-consumer/api_poller.go
@@ -127,16 +127,18 @@ func (s *APIConsumerService) callEndpoint(ctx context.Context, client *http.Clie
 		if err != nil {
 			return nil, fmt.Errorf("failed to create request: %w", err)
 		}
-		if endpoint.AuthType == "oauth" {
+		switch {
+		case endpoint.AuthType == "oauth" && endpoint.OAuthGrantID == "":
+			// OAuth selected but no grant (e.g. the grant was revoked, which
+			// clears the selection on the node). Rather than blocking the poll
+			// — or calling /oauth/grants//token with an empty id and getting an
+			// opaque 500 — fall back to sending unauthenticated and warn. A
+			// proper "reconnect required" hint in the UI is tracked in #98.
+			logger.Warn("OAuth endpoint has no grant selected; polling without authentication (reconnect the grant to authenticate)",
+				"url", url)
+		case endpoint.AuthType == "oauth":
 			if s.oauthTokens == nil || !s.oauthTokens.Configured() {
 				return nil, fmt.Errorf("endpoint uses OAuth but token resolution is not configured (set MGMT_API_URL + OAUTH_TOKEN_SERVICE_SECRET)")
-			}
-			// No grant selected (e.g. the grant was revoked, which clears the
-			// selection on the node). Fail fast with a clear message instead of
-			// calling /oauth/grants//token with an empty id and getting an
-			// opaque 500/301.
-			if endpoint.OAuthGrantID == "" {
-				return nil, fmt.Errorf("endpoint uses OAuth but no connection is selected — pick (or reconnect) an OAuth grant for this endpoint")
 			}
 			var tok string
 			if forceRefresh {
@@ -148,7 +150,7 @@ func (s *APIConsumerService) callEndpoint(ctx context.Context, client *http.Clie
 				return nil, fmt.Errorf("resolve oauth token: %w", err)
 			}
 			req.Header.Set("Authorization", "Bearer "+tok)
-		} else {
+		default:
 			applyAuth(req, endpoint.AuthType, endpoint.AuthValue)
 		}
 		req.Header.Set("User-Agent", "VRSky-API-Consumer/1.0")
@@ -162,7 +164,7 @@ func (s *APIConsumerService) callEndpoint(ctx context.Context, client *http.Clie
 	}
 	// On a 401 for an OAuth endpoint, the token may have been revoked or
 	// rotated server-side; refresh and retry once before giving up.
-	if resp.StatusCode == http.StatusUnauthorized && endpoint.AuthType == "oauth" {
+	if resp.StatusCode == http.StatusUnauthorized && endpoint.AuthType == "oauth" && endpoint.OAuthGrantID != "" {
 		_ = resp.Body.Close()
 		logger.Info("OAuth endpoint returned 401; refreshing token and retrying once",
 			"grant_id", endpoint.OAuthGrantID)

--- a/src/cmd/api-consumer/api_poller.go
+++ b/src/cmd/api-consumer/api_poller.go
@@ -131,6 +131,13 @@ func (s *APIConsumerService) callEndpoint(ctx context.Context, client *http.Clie
 			if s.oauthTokens == nil || !s.oauthTokens.Configured() {
 				return nil, fmt.Errorf("endpoint uses OAuth but token resolution is not configured (set MGMT_API_URL + OAUTH_TOKEN_SERVICE_SECRET)")
 			}
+			// No grant selected (e.g. the grant was revoked, which clears the
+			// selection on the node). Fail fast with a clear message instead of
+			// calling /oauth/grants//token with an empty id and getting an
+			// opaque 500/301.
+			if endpoint.OAuthGrantID == "" {
+				return nil, fmt.Errorf("endpoint uses OAuth but no connection is selected — pick (or reconnect) an OAuth grant for this endpoint")
+			}
 			var tok string
 			if forceRefresh {
 				tok, err = s.oauthTokens.ForceToken(ctx, tenantID, endpoint.OAuthGrantID)

--- a/src/cmd/http-producer/main.go
+++ b/src/cmd/http-producer/main.go
@@ -208,6 +208,12 @@ func (p *httpProducer) sendHTTPRequest(ctx context.Context, connectionID string,
 			req.Header.Set(k, v)
 		}
 		if httpCfg.AuthType == "oauth" {
+			// No grant selected (e.g. the grant was revoked, which clears the
+			// selection on the node). Fail fast with a clear message instead of
+			// calling /oauth/grants//token with an empty id.
+			if httpCfg.OAuthGrantID == "" {
+				return nil, fmt.Errorf("output uses OAuth but no connection is selected — pick (or reconnect) an OAuth grant for this destination")
+			}
 			tok, terr := p.resolveToken(ctx, env.TenantID, httpCfg.OAuthGrantID, force)
 			if terr != nil {
 				return nil, fmt.Errorf("resolve oauth token: %w", terr)

--- a/src/cmd/http-producer/main.go
+++ b/src/cmd/http-producer/main.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/ValueRetail/vrsky/pkg/crypto"
 	"github.com/ValueRetail/vrsky/pkg/envelope"
+	"github.com/ValueRetail/vrsky/pkg/oauthtoken"
 	"github.com/ValueRetail/vrsky/pkg/sdk"
 )
 
@@ -44,6 +45,12 @@ type httpProducer struct {
 	eventSubsMu    sync.RWMutex
 	recentEvents   map[string][]HTTPEvent
 	recentEventsMu sync.RWMutex
+
+	// OAuth output (#97): resolve a grant's access token for nodes with
+	// auth_type=oauth. resolveToken is defaulted in Configure to the oauthtoken
+	// client; tests inject a stub.
+	tokens       *oauthtoken.Client
+	resolveToken func(ctx context.Context, tenantID, grantID string, force bool) (string, error)
 }
 
 type HTTPEvent struct {
@@ -59,6 +66,8 @@ type HTTPConfig struct {
 	URL            string            `json:"url"`
 	Method         string            `json:"method"`
 	Headers        map[string]string `json:"headers"`
+	AuthType       string            `json:"auth_type"`      // "", "none", or "oauth"
+	OAuthGrantID   string            `json:"oauth_grant_id"` // grant id when auth_type=oauth
 	PredecessorID  string
 	PredIsConsumer bool
 }
@@ -85,6 +94,20 @@ func (p *httpProducer) Configure(ctx context.Context, res *sdk.Resources) error 
 	}
 	p.eventSubs = make(map[string][]chan HTTPEvent)
 	p.recentEvents = make(map[string][]HTTPEvent)
+
+	// OAuth output (#97): resolve access tokens for nodes with auth_type=oauth.
+	p.tokens = oauthtoken.New(os.Getenv("MGMT_API_URL"), os.Getenv("OAUTH_TOKEN_SERVICE_SECRET"))
+	if p.resolveToken == nil {
+		p.resolveToken = func(ctx context.Context, tenantID, grantID string, force bool) (string, error) {
+			if !p.tokens.Configured() {
+				return "", errors.New("node uses OAuth but token resolution is not configured (set MGMT_API_URL + OAUTH_TOKEN_SERVICE_SECRET)")
+			}
+			if force {
+				return p.tokens.ForceToken(ctx, tenantID, grantID)
+			}
+			return p.tokens.Token(ctx, tenantID, grantID)
+		}
+	}
 
 	// Serve the live SSE event stream on the SDK auxiliary HTTP port
 	// (WORKER_HTTP_PORT, 9400 in compose) via the custom-handler hook — the UI
@@ -161,34 +184,59 @@ func (p *httpProducer) sendHTTPRequest(ctx context.Context, connectionID string,
 		method = "POST"
 	}
 
-	req, err := http.NewRequestWithContext(ctx, method, httpCfg.URL, bytes.NewReader(env.Payload))
-	if err != nil {
+	// Bad URL won't improve on retry — drop early (validated once).
+	if _, err := http.NewRequestWithContext(ctx, method, httpCfg.URL, nil); err != nil {
 		p.emitEvent(connectionID, HTTPEvent{
 			Type: "error", Message: "Failed to create request: " + err.Error(),
 			Time: now(),
 		})
-		return nil // bad URL — won't improve on retry
-	}
-
-	if env.ContentType != "" {
-		req.Header.Set("Content-Type", env.ContentType)
-	} else {
-		req.Header.Set("Content-Type", "application/json")
-	}
-	req.Header.Set("X-Message-ID", env.ID)
-	for k, v := range httpCfg.Headers {
-		req.Header.Set(k, v)
+		return nil
 	}
 
 	client := &http.Client{Timeout: 30 * time.Second}
-	resp, err := client.Do(req)
+	// buildAndSend creates a fresh request (re-readable body) per attempt and,
+	// for auth_type=oauth, attaches a Bearer token. force=true refreshes it.
+	buildAndSend := func(force bool) (*http.Response, error) {
+		req, _ := http.NewRequestWithContext(ctx, method, httpCfg.URL, bytes.NewReader(env.Payload))
+		if env.ContentType != "" {
+			req.Header.Set("Content-Type", env.ContentType)
+		} else {
+			req.Header.Set("Content-Type", "application/json")
+		}
+		req.Header.Set("X-Message-ID", env.ID)
+		for k, v := range httpCfg.Headers {
+			req.Header.Set(k, v)
+		}
+		if httpCfg.AuthType == "oauth" {
+			tok, terr := p.resolveToken(ctx, env.TenantID, httpCfg.OAuthGrantID, force)
+			if terr != nil {
+				return nil, fmt.Errorf("resolve oauth token: %w", terr)
+			}
+			req.Header.Set("Authorization", "Bearer "+tok)
+		}
+		return client.Do(req)
+	}
+
+	resp, err := buildAndSend(false)
 	if err != nil {
 		p.logger.Error("HTTP request failed", "error", err, "connection_id", connectionID)
 		p.emitEvent(connectionID, HTTPEvent{
 			Type: "error", Message: err.Error(),
 			Time: now(),
 		})
-		return fmt.Errorf("transport: %w", err) // retriable
+		return fmt.Errorf("transport: %w", err) // retriable (transport or token-service hiccup)
+	}
+
+	// OAuth: an access token may have expired between resolution and the call —
+	// refresh once and retry (mirrors api-consumer's callEndpoint).
+	if resp.StatusCode == http.StatusUnauthorized && httpCfg.AuthType == "oauth" {
+		_ = resp.Body.Close()
+		p.emitEvent(connectionID, HTTPEvent{Type: "info", Message: "401 — refreshing OAuth token and retrying", Time: now()})
+		resp, err = buildAndSend(true)
+		if err != nil {
+			p.emitEvent(connectionID, HTTPEvent{Type: "error", Message: err.Error(), Time: now()})
+			return fmt.Errorf("after token refresh: %w", err) // retriable
+		}
 	}
 	defer resp.Body.Close()
 
@@ -272,9 +320,11 @@ func (p *httpProducer) getHTTPConfigs(ctx context.Context, connectionID, tenantI
 		var nodeConfig struct {
 			Type string `json:"type"`
 			HTTP struct {
-				URL     string            `json:"url"`
-				Method  string            `json:"method"`
-				Headers map[string]string `json:"headers"`
+				URL          string            `json:"url"`
+				Method       string            `json:"method"`
+				Headers      map[string]string `json:"headers"`
+				AuthType     string            `json:"auth_type"`
+				OAuthGrantID string            `json:"oauth_grant_id"`
 			} `json:"http"`
 		}
 		if err := json.Unmarshal(node.Config, &nodeConfig); err != nil {
@@ -303,6 +353,8 @@ func (p *httpProducer) getHTTPConfigs(ctx context.Context, connectionID, tenantI
 			URL:            nodeConfig.HTTP.URL,
 			Method:         nodeConfig.HTTP.Method,
 			Headers:        nodeConfig.HTTP.Headers,
+			AuthType:       nodeConfig.HTTP.AuthType,
+			OAuthGrantID:   nodeConfig.HTTP.OAuthGrantID,
 			PredecessorID:  predID,
 			PredIsConsumer: predIsConsumer,
 		})

--- a/src/cmd/http-producer/main.go
+++ b/src/cmd/http-producer/main.go
@@ -207,13 +207,15 @@ func (p *httpProducer) sendHTTPRequest(ctx context.Context, connectionID string,
 		for k, v := range httpCfg.Headers {
 			req.Header.Set(k, v)
 		}
-		if httpCfg.AuthType == "oauth" {
-			// No grant selected (e.g. the grant was revoked, which clears the
-			// selection on the node). Fail fast with a clear message instead of
-			// calling /oauth/grants//token with an empty id.
-			if httpCfg.OAuthGrantID == "" {
-				return nil, fmt.Errorf("output uses OAuth but no connection is selected — pick (or reconnect) an OAuth grant for this destination")
-			}
+		if httpCfg.AuthType == "oauth" && httpCfg.OAuthGrantID == "" {
+			// OAuth selected but no grant (e.g. the grant was revoked, which
+			// clears the selection on the node). Rather than blocking the send
+			// — or calling /oauth/grants//token with an empty id and getting an
+			// opaque 500 — fall back to sending unauthenticated and warn. A
+			// proper "reconnect required" hint in the UI is tracked in #98.
+			p.logger.Warn("OAuth output has no grant selected; sending without authentication (reconnect the grant to authenticate)",
+				"connection_id", connectionID, "url", httpCfg.URL)
+		} else if httpCfg.AuthType == "oauth" {
 			tok, terr := p.resolveToken(ctx, env.TenantID, httpCfg.OAuthGrantID, force)
 			if terr != nil {
 				return nil, fmt.Errorf("resolve oauth token: %w", terr)
@@ -235,7 +237,7 @@ func (p *httpProducer) sendHTTPRequest(ctx context.Context, connectionID string,
 
 	// OAuth: an access token may have expired between resolution and the call —
 	// refresh once and retry (mirrors api-consumer's callEndpoint).
-	if resp.StatusCode == http.StatusUnauthorized && httpCfg.AuthType == "oauth" {
+	if resp.StatusCode == http.StatusUnauthorized && httpCfg.AuthType == "oauth" && httpCfg.OAuthGrantID != "" {
 		_ = resp.Body.Close()
 		p.emitEvent(connectionID, HTTPEvent{Type: "info", Message: "401 — refreshing OAuth token and retrying", Time: now()})
 		resp, err = buildAndSend(true)

--- a/src/cmd/http-producer/producer_test.go
+++ b/src/cmd/http-producer/producer_test.go
@@ -174,3 +174,57 @@ func TestHTTPProducer_OAuthRefreshOn401(t *testing.T) {
 		t.Errorf("retry Authorization = %v, want Bearer tok-refreshed", a)
 	}
 }
+
+// TestHTTPProducer_OAuthEmptyGrantNoCall verifies the empty-grant guard: an
+// auth_type=oauth node whose grant was cleared (e.g. revoked) must fail fast
+// without ever resolving a token or hitting the destination — instead of
+// calling /oauth/grants//token with an empty id and getting an opaque 500.
+func TestHTTPProducer_OAuthEmptyGrantNoCall(t *testing.T) {
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+	const connID = "conn-oauth-empty"
+	// auth_type=oauth but oauth_grant_id is absent (cleared on revoke).
+	nodes := fmt.Sprintf(`[{"id":"prod1","type":"producer","config":{"type":"http","http":{"url":%q,"method":"POST","auth_type":"oauth"}}}]`, srv.URL)
+	mock.MatchExpectationsInOrder(false)
+	for i := 0; i < 5; i++ {
+		mock.ExpectQuery("FROM connections WHERE id").
+			WithArgs(connID).
+			WillReturnRows(sqlmock.NewRows([]string{"nodes", "edges"}).
+				AddRow([]byte(nodes), []byte(`[]`)))
+	}
+
+	var resolveCalls atomic.Int32
+	p := &httpProducer{
+		resolveToken: func(_ context.Context, _, _ string, _ bool) (string, error) {
+			resolveCalls.Add(1)
+			return "should-not-be-used", nil
+		},
+	}
+	h := harness.NewProducerHarness(t, p, harness.Options{Name: "http-producer", DB: db})
+
+	env := envelope.New()
+	env.ID = "oauth-empty-1"
+	env.IntegrationID = connID
+	env.TenantID = "tenant-1"
+	env.Payload = []byte(`{"x":1}`)
+	h.Publish(t, env)
+
+	// Give the runner time to (not) act.
+	time.Sleep(700 * time.Millisecond)
+	if got := atomic.LoadInt32(&hits); got != 0 {
+		t.Errorf("destination was hit %d times; expected 0 (no grant → no send)", got)
+	}
+	if got := resolveCalls.Load(); got != 0 {
+		t.Errorf("resolveToken called %d times; expected 0 (guard should short-circuit before token resolution)", got)
+	}
+}

--- a/src/cmd/http-producer/producer_test.go
+++ b/src/cmd/http-producer/producer_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -105,5 +106,71 @@ func TestHTTPProducer_4xxIsAcked(t *testing.T) {
 	time.Sleep(500 * time.Millisecond)
 	if got := atomic.LoadInt32(&hits); got != 1 {
 		t.Errorf("expected exactly 1 request (4xx acked, no retry), got %d", got)
+	}
+}
+
+// TestHTTPProducer_OAuthRefreshOn401 verifies the #97 OAuth output path: an
+// auth_type=oauth node attaches a Bearer token; on a 401 the producer refreshes
+// the token (force) and retries once, succeeding without dead-lettering.
+func TestHTTPProducer_OAuthRefreshOn401(t *testing.T) {
+	var calls int32
+	var lastAuth atomic.Value
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&calls, 1)
+		lastAuth.Store(r.Header.Get("Authorization"))
+		if n == 1 {
+			w.WriteHeader(http.StatusUnauthorized) // stale token
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+	const connID = "conn-oauth"
+	nodes := fmt.Sprintf(`[{"id":"prod1","type":"producer","config":{"type":"http","http":{"url":%q,"method":"POST","auth_type":"oauth","oauth_grant_id":"g1"}}}]`, srv.URL)
+	mock.MatchExpectationsInOrder(false)
+	for i := 0; i < 3; i++ {
+		mock.ExpectQuery("FROM connections WHERE id").
+			WithArgs(connID).
+			WillReturnRows(sqlmock.NewRows([]string{"nodes", "edges"}).
+				AddRow([]byte(nodes), []byte(`[]`)))
+	}
+
+	var forced atomic.Bool
+	p := &httpProducer{
+		resolveToken: func(_ context.Context, _, grantID string, force bool) (string, error) {
+			if force {
+				forced.Store(true)
+				return "tok-refreshed", nil
+			}
+			return "tok-stale", nil
+		},
+	}
+	h := harness.NewProducerHarness(t, p, harness.Options{Name: "http-producer", DB: db})
+
+	env := envelope.New()
+	env.ID = "oauth-env-1"
+	env.IntegrationID = connID
+	env.TenantID = "tenant-1"
+	env.Payload = []byte(`{"x":1}`)
+	h.Publish(t, env)
+
+	harness.Eventually(t, 5*time.Second, "endpoint hit twice (401 then 200)", func() bool {
+		return atomic.LoadInt32(&calls) >= 2
+	})
+	time.Sleep(400 * time.Millisecond)
+	if got := atomic.LoadInt32(&calls); got != 2 {
+		t.Errorf("expected exactly 2 requests (401 then refreshed 200), got %d", got)
+	}
+	if !forced.Load() {
+		t.Error("expected a forced token refresh on the 401 retry")
+	}
+	if a := lastAuth.Load(); a == nil || a.(string) != "Bearer tok-refreshed" {
+		t.Errorf("retry Authorization = %v, want Bearer tok-refreshed", a)
 	}
 }

--- a/src/cmd/http-producer/producer_test.go
+++ b/src/cmd/http-producer/producer_test.go
@@ -175,14 +175,17 @@ func TestHTTPProducer_OAuthRefreshOn401(t *testing.T) {
 	}
 }
 
-// TestHTTPProducer_OAuthEmptyGrantNoCall verifies the empty-grant guard: an
-// auth_type=oauth node whose grant was cleared (e.g. revoked) must fail fast
-// without ever resolving a token or hitting the destination — instead of
-// calling /oauth/grants//token with an empty id and getting an opaque 500.
-func TestHTTPProducer_OAuthEmptyGrantNoCall(t *testing.T) {
+// TestHTTPProducer_OAuthEmptyGrantSendsUnauthenticated verifies the empty-grant
+// fallback: an auth_type=oauth node whose grant was cleared (e.g. revoked) must
+// still deliver — sending WITHOUT an Authorization header and without ever
+// resolving a token — rather than blocking or calling /oauth/grants//token with
+// an empty id. (The UI "reconnect required" hint is tracked in #98.)
+func TestHTTPProducer_OAuthEmptyGrantSendsUnauthenticated(t *testing.T) {
 	var hits int32
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	var gotAuth atomic.Value
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		atomic.AddInt32(&hits, 1)
+		gotAuth.Store(r.Header.Get("Authorization"))
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer srv.Close()
@@ -219,12 +222,13 @@ func TestHTTPProducer_OAuthEmptyGrantNoCall(t *testing.T) {
 	env.Payload = []byte(`{"x":1}`)
 	h.Publish(t, env)
 
-	// Give the runner time to (not) act.
-	time.Sleep(700 * time.Millisecond)
-	if got := atomic.LoadInt32(&hits); got != 0 {
-		t.Errorf("destination was hit %d times; expected 0 (no grant → no send)", got)
+	harness.Eventually(t, 5*time.Second, "destination received the (unauthenticated) POST", func() bool {
+		return atomic.LoadInt32(&hits) >= 1
+	})
+	if a := gotAuth.Load(); a != nil && a.(string) != "" {
+		t.Errorf("Authorization = %q; expected empty (no grant → no bearer)", a)
 	}
 	if got := resolveCalls.Load(); got != 0 {
-		t.Errorf("resolveToken called %d times; expected 0 (guard should short-circuit before token resolution)", got)
+		t.Errorf("resolveToken called %d times; expected 0 (no grant → never resolve a token)", got)
 	}
 }

--- a/src/cmd/salesforce-consumer/Dockerfile
+++ b/src/cmd/salesforce-consumer/Dockerfile
@@ -1,5 +1,5 @@
 # Multi-stage build for minimal image size
-FROM golang:1.24-alpine AS builder
+FROM golang:1.22-alpine AS builder
 
 WORKDIR /app
 

--- a/src/cmd/salesforce-consumer/Dockerfile
+++ b/src/cmd/salesforce-consumer/Dockerfile
@@ -1,0 +1,27 @@
+# Multi-stage build for minimal image size
+FROM golang:1.24-alpine AS builder
+
+WORKDIR /app
+
+COPY src/go.mod src/go.sum ./
+RUN go mod download
+
+COPY src/ ./
+
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
+    -ldflags="-w -s" \
+    -o salesforce-consumer \
+    ./cmd/salesforce-consumer
+
+FROM alpine:3.19
+
+RUN apk --no-cache add ca-certificates curl
+
+WORKDIR /app
+COPY --from=builder /app/salesforce-consumer .
+
+# The SDK runner serves /health on HEALTH_PORT (default 8080).
+HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
+    CMD curl -f http://localhost:8080/health || exit 1
+
+ENTRYPOINT ["./salesforce-consumer"]

--- a/src/cmd/salesforce-consumer/consumer_test.go
+++ b/src/cmd/salesforce-consumer/consumer_test.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+
+	"github.com/ValueRetail/vrsky/pkg/sdk/harness"
+)
+
+// TestSalesforceConsumer_RoundTrip drives the SDK-refactored salesforce-consumer
+// end-to-end with zero Docker: a connection start command makes it read its
+// config from a mocked management DB, run a SOQL query against a fake Salesforce
+// REST endpoint (token resolution stubbed), and publish the records onto the
+// data stream.
+func TestSalesforceConsumer_RoundTrip(t *testing.T) {
+	const (
+		connID = "sf-conn-1"
+		tenant = "tenant-x"
+	)
+
+	// Fake Salesforce query endpoint.
+	var gotAuth, gotQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotQuery = r.URL.Query().Get("q")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"totalSize":2,"done":true,"records":[{"Id":"001","Name":"Acme"},{"Id":"002","Name":"Globex"}]}`))
+	}))
+	defer srv.Close()
+
+	// Management DB: connection lookup + status write.
+	mgmtDB, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer mgmtDB.Close()
+	mock.MatchExpectationsInOrder(false)
+	nodes := fmt.Sprintf(`[{"id":"c1","type":"consumer","config":{"type":"salesforce","salesforce":{"instance_url":%q,"oauth_grant_id":"g1","soql":"SELECT Id, Name FROM Account"}}}]`, srv.URL)
+	for i := 0; i < 2; i++ {
+		mock.ExpectQuery("SELECT nodes FROM connections").
+			WithArgs(connID, tenant).
+			WillReturnRows(sqlmock.NewRows([]string{"nodes"}).AddRow([]byte(nodes)))
+	}
+	mock.ExpectExec("UPDATE connections SET status").WillReturnResult(sqlmock.NewResult(0, 1))
+
+	c := &salesforceConsumer{
+		resolveToken: func(context.Context, string, string, bool) (string, error) { return "fake-token", nil },
+	}
+	h := harness.NewConsumerHarness(t, c, harness.Options{Name: "salesforce-consumer", DB: mgmtDB})
+
+	time.Sleep(200 * time.Millisecond)
+	cmd, _ := json.Marshal(map[string]string{"connection_id": connID, "tenant_id": tenant})
+	if err := h.NATS().Publish("vrsky.commands."+tenant+".connection.start", cmd); err != nil {
+		t.Fatalf("publish start: %v", err)
+	}
+
+	got := h.ExpectEnvelope(t, harness.MatchTenant(tenant), 5*time.Second)
+	if got.IntegrationID != connID {
+		t.Errorf("integration id = %q, want %q", got.IntegrationID, connID)
+	}
+	var records []map[string]any
+	if err := json.Unmarshal(got.Payload, &records); err != nil {
+		t.Fatalf("payload not a JSON array: %v", err)
+	}
+	if len(records) != 2 {
+		t.Errorf("expected 2 records, got %d", len(records))
+	}
+	if gotAuth != "Bearer fake-token" {
+		t.Errorf("Salesforce request auth = %q, want Bearer fake-token", gotAuth)
+	}
+	if gotQuery != "SELECT Id, Name FROM Account" {
+		t.Errorf("SOQL = %q", gotQuery)
+	}
+}

--- a/src/cmd/salesforce-consumer/main.go
+++ b/src/cmd/salesforce-consumer/main.go
@@ -1,0 +1,24 @@
+// Command salesforce-consumer ingests Salesforce records into the pipeline by
+// running a SOQL query against the org's REST API, authenticated with an OAuth
+// grant (#75). It is an SDK Consumer: the runner owns NATS/DB/health/signals/
+// shutdown; this binary subscribes to the connection command subjects, and for
+// each active connection polls Salesforce and publishes the records.
+//
+// PR 1 of #79 (Salesforce connector): SOQL poll only. CDC / platform events and
+// the REST/Bulk producer come in later PRs.
+package main
+
+import (
+	"context"
+	"log/slog"
+	"os"
+
+	"github.com/ValueRetail/vrsky/pkg/sdk"
+)
+
+func main() {
+	if err := sdk.RunConsumer(context.Background(), "salesforce-consumer", &salesforceConsumer{}); err != nil {
+		slog.Error("salesforce-consumer exited", "error", err)
+		os.Exit(1)
+	}
+}

--- a/src/cmd/salesforce-consumer/service.go
+++ b/src/cmd/salesforce-consumer/service.go
@@ -1,0 +1,371 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	_ "github.com/lib/pq"
+	"github.com/nats-io/nats.go"
+
+	"github.com/ValueRetail/vrsky/pkg/envelope"
+	"github.com/ValueRetail/vrsky/pkg/oauthtoken"
+	"github.com/ValueRetail/vrsky/pkg/sdk"
+)
+
+const defaultAPIVersion = "v60.0"
+
+// salesforceConsumer polls Salesforce via SOQL per active connection and
+// publishes the resulting records into the pipeline. It is an SDK Consumer:
+// Configure wires deps, Run subscribes to command subjects and blocks, Stop
+// cancels pollers.
+type salesforceConsumer struct {
+	sdk.BaseConsumer
+
+	db      *sql.DB
+	nc      *nats.Conn
+	publish sdk.PublishFunc
+	logger  *slog.Logger
+
+	httpClient *http.Client
+	tokens     *oauthtoken.Client
+	// resolveToken returns an access token for a grant. Defaulted in Configure
+	// to the oauthtoken client; tests inject a stub (so the consumer can run
+	// without a live management-api).
+	resolveToken func(ctx context.Context, tenantID, grantID string, force bool) (string, error)
+
+	active map[string]context.CancelFunc
+	mu     sync.RWMutex
+
+	startSub *nats.Subscription
+	stopSub  *nats.Subscription
+}
+
+// SalesforceConfig is the per-node configuration (config.salesforce).
+type SalesforceConfig struct {
+	InstanceURL         string `json:"instance_url"`   // e.g. https://myorg.my.salesforce.com
+	OAuthGrantID        string `json:"oauth_grant_id"` // grant to authenticate with (#75)
+	SOQL                string `json:"soql"`           // e.g. SELECT Id, Name FROM Account
+	PollIntervalSeconds int    `json:"poll_interval_seconds"`
+	APIVersion          string `json:"api_version"` // optional, default v60.0
+}
+
+type nodeConfig struct {
+	Type       string            `json:"type"`
+	Salesforce *SalesforceConfig `json:"salesforce"`
+}
+
+type node struct {
+	ID     string          `json:"id"`
+	Type   string          `json:"type"`
+	Config json.RawMessage `json:"config"`
+}
+
+type commandMessage struct {
+	ConnectionID string `json:"connection_id"`
+	TenantID     string `json:"tenant_id"`
+}
+
+// Configure wires dependencies. Called once before Run.
+func (s *salesforceConsumer) Configure(ctx context.Context, res *sdk.Resources) error {
+	if res.DB == nil {
+		return errors.New("salesforce-consumer requires DATABASE_URL (per-connection config lives in the connections table)")
+	}
+	s.db = res.DB
+	s.nc = res.NATS
+	s.logger = res.Logger
+	s.active = make(map[string]context.CancelFunc)
+	if s.httpClient == nil {
+		s.httpClient = &http.Client{Timeout: 60 * time.Second}
+	}
+	s.tokens = oauthtoken.New(os.Getenv("MGMT_API_URL"), os.Getenv("OAUTH_TOKEN_SERVICE_SECRET"))
+	if s.resolveToken == nil {
+		s.resolveToken = func(ctx context.Context, tenantID, grantID string, force bool) (string, error) {
+			if !s.tokens.Configured() {
+				return "", errors.New("OAuth token resolution not configured (set MGMT_API_URL + OAUTH_TOKEN_SERVICE_SECRET)")
+			}
+			if force {
+				return s.tokens.ForceToken(ctx, tenantID, grantID)
+			}
+			return s.tokens.Token(ctx, tenantID, grantID)
+		}
+	}
+	res.Health.SetReady(true)
+	return nil
+}
+
+// Run subscribes to the connection command subjects and blocks until ctx is
+// cancelled. Per-connection polling is driven from the command handlers.
+func (s *salesforceConsumer) Run(ctx context.Context, publish sdk.PublishFunc) error {
+	s.publish = publish
+
+	startSub, err := s.nc.Subscribe("vrsky.commands.*.connection.start", s.handleStartCommand)
+	if err != nil {
+		return fmt.Errorf("subscribe start commands: %w", err)
+	}
+	s.startSub = startSub
+
+	stopSub, err := s.nc.Subscribe("vrsky.commands.*.connection.stop", s.handleStopCommand)
+	if err != nil {
+		return fmt.Errorf("subscribe stop commands: %w", err)
+	}
+	s.stopSub = stopSub
+
+	s.logger.Info("Subscribed to NATS command topics")
+	<-ctx.Done()
+	return nil
+}
+
+// Stop cancels all pollers. The SDK runner calls this after Run returns.
+func (s *salesforceConsumer) Stop(ctx context.Context) error {
+	if s.startSub != nil {
+		_ = s.startSub.Unsubscribe()
+	}
+	if s.stopSub != nil {
+		_ = s.stopSub.Unsubscribe()
+	}
+	s.mu.Lock()
+	for id, cancel := range s.active {
+		s.logger.Info("Stopping salesforce poller", "connection_id", id)
+		cancel()
+	}
+	s.active = make(map[string]context.CancelFunc)
+	s.mu.Unlock()
+	select {
+	case <-ctx.Done():
+	case <-time.After(2 * time.Second):
+	}
+	return nil
+}
+
+func (s *salesforceConsumer) handleStartCommand(msg *nats.Msg) {
+	var cmd commandMessage
+	if err := json.Unmarshal(msg.Data, &cmd); err != nil {
+		s.logger.Error("parse start command", "error", err)
+		return
+	}
+	logger := s.logger.With("connection_id", cmd.ConnectionID, "tenant_id", cmd.TenantID)
+
+	s.mu.RLock()
+	_, exists := s.active[cmd.ConnectionID]
+	s.mu.RUnlock()
+	if exists {
+		logger.Warn("Salesforce poller already running")
+		return
+	}
+
+	cfg, err := s.getSalesforceConfig(cmd.ConnectionID, cmd.TenantID)
+	if err != nil {
+		logger.Debug("Not a Salesforce consumer for this connection", "error", err)
+		return
+	}
+	if cfg.InstanceURL == "" || cfg.OAuthGrantID == "" || cfg.SOQL == "" {
+		logger.Error("Salesforce config incomplete (need instance_url, oauth_grant_id, soql)")
+		return
+	}
+	if cfg.APIVersion == "" {
+		cfg.APIVersion = defaultAPIVersion
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	s.mu.Lock()
+	s.active[cmd.ConnectionID] = cancel
+	s.mu.Unlock()
+	_ = s.updateConnectionStatus(cmd.ConnectionID, cmd.TenantID, "running")
+
+	logger.Info("Starting Salesforce poller", "instance_url", cfg.InstanceURL, "interval", cfg.PollIntervalSeconds)
+	go s.runPoller(ctx, cmd.ConnectionID, cmd.TenantID, cfg)
+}
+
+func (s *salesforceConsumer) handleStopCommand(msg *nats.Msg) {
+	var cmd commandMessage
+	if err := json.Unmarshal(msg.Data, &cmd); err != nil {
+		s.logger.Error("parse stop command", "error", err)
+		return
+	}
+	s.mu.Lock()
+	cancel, exists := s.active[cmd.ConnectionID]
+	if exists {
+		cancel()
+		delete(s.active, cmd.ConnectionID)
+	}
+	s.mu.Unlock()
+	if exists {
+		_ = s.updateConnectionStatus(cmd.ConnectionID, cmd.TenantID, "stopped")
+		s.logger.Info("Salesforce poller stopped", "connection_id", cmd.ConnectionID)
+	}
+}
+
+func (s *salesforceConsumer) runPoller(ctx context.Context, connID, tenantID string, cfg *SalesforceConfig) {
+	logger := s.logger.With("connection_id", connID)
+	if err := s.queryAndPublish(ctx, connID, tenantID, cfg, logger); err != nil && ctx.Err() == nil {
+		logger.Error("Salesforce query failed", "error", err)
+	}
+	if cfg.PollIntervalSeconds <= 0 {
+		return // one-shot
+	}
+	ticker := time.NewTicker(time.Duration(cfg.PollIntervalSeconds) * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := s.queryAndPublish(ctx, connID, tenantID, cfg, logger); err != nil && ctx.Err() == nil {
+				logger.Error("Salesforce query failed", "error", err)
+			}
+		}
+	}
+}
+
+// queryResponse is the shape of the Salesforce REST query response.
+type queryResponse struct {
+	TotalSize      int               `json:"totalSize"`
+	Done           bool              `json:"done"`
+	NextRecordsURL string            `json:"nextRecordsUrl"`
+	Records        []json.RawMessage `json:"records"`
+}
+
+// queryAndPublish runs the SOQL query (following pagination) and publishes each
+// page's records as one JSON-array envelope.
+func (s *salesforceConsumer) queryAndPublish(ctx context.Context, connID, tenantID string, cfg *SalesforceConfig, logger *slog.Logger) error {
+	base := strings.TrimRight(cfg.InstanceURL, "/")
+	next := fmt.Sprintf("/services/data/%s/query/?q=%s", cfg.APIVersion, url.QueryEscape(cfg.SOQL))
+
+	page := 0
+	total := 0
+	for next != "" {
+		page++
+		body, err := s.get(ctx, tenantID, cfg.OAuthGrantID, base+next)
+		if err != nil {
+			return err
+		}
+		var qr queryResponse
+		if err := json.Unmarshal(body, &qr); err != nil {
+			return fmt.Errorf("parse query response: %w", err)
+		}
+		if len(qr.Records) > 0 {
+			if err := s.publishRecords(ctx, connID, tenantID, qr.Records); err != nil {
+				return fmt.Errorf("publish records: %w", err)
+			}
+			total += len(qr.Records)
+		}
+		if qr.Done || qr.NextRecordsURL == "" {
+			break
+		}
+		next = qr.NextRecordsURL
+	}
+	logger.Info("Salesforce query complete", "records", total, "pages", page)
+	return nil
+}
+
+// get performs an authenticated GET, refreshing the token once on a 401.
+func (s *salesforceConsumer) get(ctx context.Context, tenantID, grantID, fullURL string) ([]byte, error) {
+	do := func(force bool) (*http.Response, error) {
+		tok, err := s.resolveToken(ctx, tenantID, grantID, force)
+		if err != nil {
+			return nil, fmt.Errorf("resolve OAuth token: %w", err)
+		}
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, fullURL, nil)
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Authorization", "Bearer "+tok)
+		req.Header.Set("Accept", "application/json")
+		return s.httpClient.Do(req)
+	}
+
+	resp, err := do(false)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode == http.StatusUnauthorized {
+		_ = resp.Body.Close()
+		s.logger.Info("Salesforce returned 401; refreshing token and retrying once", "grant_id", grantID)
+		resp, err = do(true)
+		if err != nil {
+			return nil, fmt.Errorf("request after token refresh: %w", err)
+		}
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 16<<20)) // 16 MiB cap
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("salesforce %s: %s", resp.Status, strings.TrimSpace(string(body)))
+	}
+	return body, nil
+}
+
+func (s *salesforceConsumer) publishRecords(ctx context.Context, connID, tenantID string, records []json.RawMessage) error {
+	payload, err := json.Marshal(records)
+	if err != nil {
+		return err
+	}
+	env := envelope.New()
+	env.TenantID = tenantID
+	env.IntegrationID = connID
+	env.ContentType = "application/json"
+	env.Source = "salesforce-consumer"
+	env.Payload = payload
+	env.PayloadSize = int64(len(payload))
+	env.StepHistory = []string{"salesforce-consumer"}
+	env.Metadata = map[string]interface{}{"record_count": len(records), "filename": "salesforce.json"}
+	return s.publish(ctx, env)
+}
+
+// --- DB helpers ---
+
+type connectionRow struct {
+	Nodes json.RawMessage
+}
+
+// getSalesforceConfig loads the connection and extracts its Salesforce consumer
+// node config. // lint:tenant-ok — lookup is scoped by (id, tenant_id).
+func (s *salesforceConsumer) getSalesforceConfig(connectionID, tenantID string) (*SalesforceConfig, error) {
+	var row connectionRow
+	err := s.db.QueryRow(
+		`SELECT nodes FROM connections WHERE id = $1 AND tenant_id = $2`,
+		connectionID, tenantID,
+	).Scan(&row.Nodes)
+	if err != nil {
+		return nil, fmt.Errorf("connection not found: %w", err)
+	}
+
+	var nodes []node
+	if err := json.Unmarshal(row.Nodes, &nodes); err != nil {
+		return nil, fmt.Errorf("parse nodes: %w", err)
+	}
+	for _, n := range nodes {
+		if n.Type != "consumer" {
+			continue
+		}
+		var nc nodeConfig
+		if err := json.Unmarshal(n.Config, &nc); err != nil {
+			continue
+		}
+		if nc.Type == "salesforce" && nc.Salesforce != nil {
+			return nc.Salesforce, nil
+		}
+	}
+	return nil, errors.New("no salesforce consumer node found")
+}
+
+func (s *salesforceConsumer) updateConnectionStatus(connectionID, tenantID, status string) error {
+	var query string
+	if status == "running" {
+		query = `UPDATE connections SET status = $1, started_at = NOW(), updated_at = NOW() WHERE id = $2 AND tenant_id = $3`
+	} else {
+		query = `UPDATE connections SET status = $1, stopped_at = NOW(), updated_at = NOW() WHERE id = $2 AND tenant_id = $3`
+	}
+	_, err := s.db.Exec(query, status, connectionID, tenantID)
+	return err
+}

--- a/src/cmd/salesforce-producer/Dockerfile
+++ b/src/cmd/salesforce-producer/Dockerfile
@@ -1,5 +1,5 @@
 # Multi-stage build for minimal image size
-FROM golang:1.24-alpine AS builder
+FROM golang:1.22-alpine AS builder
 
 WORKDIR /app
 

--- a/src/cmd/salesforce-producer/Dockerfile
+++ b/src/cmd/salesforce-producer/Dockerfile
@@ -1,0 +1,27 @@
+# Multi-stage build for minimal image size
+FROM golang:1.24-alpine AS builder
+
+WORKDIR /app
+
+COPY src/go.mod src/go.sum ./
+RUN go mod download
+
+COPY src/ ./
+
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
+    -ldflags="-w -s" \
+    -o salesforce-producer \
+    ./cmd/salesforce-producer
+
+FROM alpine:3.19
+
+RUN apk --no-cache add ca-certificates curl
+
+WORKDIR /app
+COPY --from=builder /app/salesforce-producer .
+
+# The SDK runner serves /health on HEALTH_PORT (default 8080).
+HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
+    CMD curl -f http://localhost:8080/health || exit 1
+
+ENTRYPOINT ["./salesforce-producer"]

--- a/src/cmd/salesforce-producer/main.go
+++ b/src/cmd/salesforce-producer/main.go
@@ -1,0 +1,21 @@
+// Command salesforce-producer writes pipeline records into Salesforce, using
+// the REST sObject API for small batches and Bulk API 2.0 for batches ≥ 200
+// (#79 PR 2). Authenticated with an OAuth grant (#75). It is an SDK Producer:
+// the runner owns NATS/JetStream/health/signals/shutdown; this binary
+// implements Configure + Deliver.
+package main
+
+import (
+	"context"
+	"log/slog"
+	"os"
+
+	"github.com/ValueRetail/vrsky/pkg/sdk"
+)
+
+func main() {
+	if err := sdk.RunProducer(context.Background(), "salesforce-producer", &salesforceProducer{}); err != nil {
+		slog.Error("salesforce-producer exited", "error", err)
+		os.Exit(1)
+	}
+}

--- a/src/cmd/salesforce-producer/producer_test.go
+++ b/src/cmd/salesforce-producer/producer_test.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+
+	"github.com/ValueRetail/vrsky/pkg/envelope"
+	"github.com/ValueRetail/vrsky/pkg/sdk/harness"
+)
+
+func mockConn(mock sqlmock.Sqlmock, connID, instanceURL, operation string) {
+	nodes := fmt.Sprintf(
+		`[{"id":"p1","type":"producer","config":{"type":"salesforce","salesforce":{"instance_url":%q,"oauth_grant_id":"g1","object":"Account","operation":%q,"external_id_field":"ExtId__c"}}}]`,
+		instanceURL, operation)
+	mock.MatchExpectationsInOrder(false)
+	for i := 0; i < 3; i++ {
+		mock.ExpectQuery("FROM connections WHERE id").
+			WithArgs(connID).
+			WillReturnRows(sqlmock.NewRows([]string{"nodes", "edges"}).AddRow([]byte(nodes), []byte(`[]`)))
+	}
+}
+
+// TestSalesforceProducer_RESTInsert: a small batch goes through the REST sObject
+// API with a Bearer token.
+func TestSalesforceProducer_RESTInsert(t *testing.T) {
+	const connID = "sfp-rest"
+	var posted atomic.Int32
+	var auth atomic.Value
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/sobjects/Account") {
+			posted.Add(1)
+			auth.Store(r.Header.Get("Authorization"))
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"id":"001","success":true}`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+	mockConn(mock, connID, srv.URL, "insert")
+
+	p := &salesforceProducer{
+		resolveToken: func(context.Context, string, string, bool) (string, error) { return "tok", nil },
+	}
+	h := harness.NewProducerHarness(t, p, harness.Options{Name: "salesforce-producer", DB: db})
+
+	env := envelope.New()
+	env.ID = "sfp-1"
+	env.IntegrationID = connID
+	env.TenantID = "tenant-1"
+	env.Payload = []byte(`{"Name":"Acme"}`)
+	h.Publish(t, env)
+
+	harness.Eventually(t, 5*time.Second, "record POSTed to Salesforce REST", func() bool {
+		return posted.Load() == 1
+	})
+	if a := auth.Load(); a == nil || a.(string) != "Bearer tok" {
+		t.Errorf("auth = %v, want Bearer tok", a)
+	}
+}
+
+// TestSalesforceProducer_BulkAPI: a batch ≥ threshold uses Bulk API 2.0
+// (create job → upload CSV → close), not per-record REST.
+func TestSalesforceProducer_BulkAPI(t *testing.T) {
+	const connID = "sfp-bulk"
+	var create, upload, closed atomic.Bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/jobs/ingest"):
+			create.Store(true)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"id":"job-1","state":"Open"}`))
+		case r.Method == http.MethodPut && strings.Contains(r.URL.Path, "/jobs/ingest/job-1/batches"):
+			upload.Store(true)
+			w.WriteHeader(http.StatusCreated)
+		case r.Method == http.MethodPatch && strings.HasSuffix(r.URL.Path, "/jobs/ingest/job-1"):
+			closed.Store(true)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"id":"job-1","state":"UploadComplete"}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+	mockConn(mock, connID, srv.URL, "insert")
+
+	p := &salesforceProducer{
+		bulkThreshold: 2, // force bulk for a tiny batch
+		resolveToken:  func(context.Context, string, string, bool) (string, error) { return "tok", nil },
+	}
+	h := harness.NewProducerHarness(t, p, harness.Options{Name: "salesforce-producer", DB: db})
+
+	env := envelope.New()
+	env.ID = "sfp-bulk-1"
+	env.IntegrationID = connID
+	env.TenantID = "tenant-1"
+	env.Payload = []byte(`[{"Name":"Acme"},{"Name":"Globex"}]`)
+	h.Publish(t, env)
+
+	harness.Eventually(t, 5*time.Second, "bulk job created → uploaded → closed", func() bool {
+		return create.Load() && upload.Load() && closed.Load()
+	})
+}

--- a/src/cmd/salesforce-producer/service.go
+++ b/src/cmd/salesforce-producer/service.go
@@ -205,7 +205,13 @@ func (p *salesforceProducer) restWrite(ctx context.Context, tenantID string, cfg
 			method = http.MethodPost
 			u = fmt.Sprintf("%s/services/data/%s/sobjects/%s", base, cfg.APIVersion, cfg.Object)
 		}
-		body, _ := json.Marshal(rec)
+		body, err := json.Marshal(rec)
+		if err != nil {
+			// A record that can't be marshalled won't improve on retry — skip
+			// it (poison record) rather than sending an empty/invalid body.
+			p.logger.Error("skipping unmarshalable record", "object", cfg.Object, "error", err)
+			continue
+		}
 		status, respBody, err := p.doRequest(ctx, tenantID, cfg.OAuthGrantID, method, u, "application/json", body)
 		if err != nil {
 			if transient == nil {

--- a/src/cmd/salesforce-producer/service.go
+++ b/src/cmd/salesforce-producer/service.go
@@ -1,0 +1,466 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/csv"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"os"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	_ "github.com/lib/pq"
+
+	"github.com/ValueRetail/vrsky/pkg/envelope"
+	"github.com/ValueRetail/vrsky/pkg/oauthtoken"
+	"github.com/ValueRetail/vrsky/pkg/sdk"
+)
+
+const (
+	defaultAPIVersion = "v60.0"
+	// bulkThreshold: batches at or above this use Bulk API 2.0 instead of
+	// per-record REST calls (#79 acceptance criterion #3).
+	defaultBulkThreshold = 200
+)
+
+// salesforceProducer writes pipeline records into Salesforce. It is an SDK
+// Producer: Configure wires deps, Deliver writes one envelope's records to
+// every matching Salesforce producer node for the connection.
+type salesforceProducer struct {
+	sdk.BaseProducer
+
+	db     *sql.DB
+	logger *slog.Logger
+
+	httpClient    *http.Client
+	tokens        *oauthtoken.Client
+	resolveToken  func(ctx context.Context, tenantID, grantID string, force bool) (string, error)
+	bulkThreshold int
+
+	cache     map[string][]*sfTarget
+	cacheTime map[string]time.Time
+	cacheTTL  time.Duration
+	cacheMu   sync.RWMutex
+}
+
+// SalesforceProducerConfig is the per-node configuration (config.salesforce).
+type SalesforceProducerConfig struct {
+	InstanceURL     string `json:"instance_url"`
+	OAuthGrantID    string `json:"oauth_grant_id"`
+	Object          string `json:"object"`            // sObject, e.g. "Account"
+	Operation       string `json:"operation"`         // "insert" (default) or "upsert"
+	ExternalIDField string `json:"external_id_field"` // required for upsert
+	APIVersion      string `json:"api_version"`       // default v60.0
+}
+
+type sfTarget struct {
+	cfg            SalesforceProducerConfig
+	predecessorID  string
+	predIsConsumer bool
+}
+
+// errBadPayload marks an envelope whose payload isn't JSON (poison message).
+var errBadPayload = errors.New("payload is not valid JSON")
+
+// Configure wires dependencies. Called once by the runner before Deliver.
+func (p *salesforceProducer) Configure(ctx context.Context, res *sdk.Resources) error {
+	if res.DB == nil {
+		return errors.New("salesforce-producer requires DATABASE_URL (per-connection config lives in the connections table)")
+	}
+	p.db = res.DB
+	p.logger = res.Logger
+	if p.httpClient == nil {
+		p.httpClient = &http.Client{Timeout: 60 * time.Second}
+	}
+	if p.bulkThreshold == 0 {
+		p.bulkThreshold = defaultBulkThreshold
+	}
+	p.cache = make(map[string][]*sfTarget)
+	p.cacheTime = make(map[string]time.Time)
+	if p.cacheTTL == 0 {
+		p.cacheTTL = 5 * time.Minute
+	}
+	p.tokens = oauthtoken.New(os.Getenv("MGMT_API_URL"), os.Getenv("OAUTH_TOKEN_SERVICE_SECRET"))
+	if p.resolveToken == nil {
+		p.resolveToken = func(ctx context.Context, tenantID, grantID string, force bool) (string, error) {
+			if !p.tokens.Configured() {
+				return "", errors.New("OAuth token resolution not configured (set MGMT_API_URL + OAUTH_TOKEN_SERVICE_SECRET)")
+			}
+			if force {
+				return p.tokens.ForceToken(ctx, tenantID, grantID)
+			}
+			return p.tokens.Token(ctx, tenantID, grantID)
+		}
+	}
+	p.logger.Info("salesforce-producer configured", "bulk_threshold", p.bulkThreshold)
+	return nil
+}
+
+// Deliver writes the envelope's records into every matching Salesforce target.
+// Transient failures (5xx, network, token, bulk-job errors) → sdk.Retriable; a
+// non-JSON payload → sdk.Permanent. A missing producer config for the connection
+// is not an error.
+func (p *salesforceProducer) Deliver(ctx context.Context, env *envelope.Envelope) error {
+	connID := env.IntegrationID
+	if connID == "" {
+		return nil
+	}
+	targets, err := p.getTargets(ctx, connID, env.TenantID)
+	if err != nil {
+		p.logger.Debug("No Salesforce producer config", "connection_id", connID, "error", err)
+		return nil
+	}
+
+	records, err := parseRecords(env.Payload)
+	if err != nil {
+		if errors.Is(err, errBadPayload) {
+			p.logger.Error("dropping: payload is not valid JSON", "error", err, "envelope_id", env.ID)
+			return sdk.Permanent(err)
+		}
+		return sdk.Retriable(err)
+	}
+	if len(records) == 0 {
+		return nil
+	}
+
+	lastProcessedBy := ""
+	if env.Metadata != nil {
+		if v, ok := env.Metadata["_last_processed_by"].(string); ok {
+			lastProcessedBy = v
+		}
+	}
+
+	var transient error
+	for _, t := range targets {
+		if t.predIsConsumer && lastProcessedBy != "" {
+			continue
+		}
+		if !t.predIsConsumer && t.predecessorID != "" && lastProcessedBy != t.predecessorID {
+			continue
+		}
+		if err := p.writeRecords(ctx, env.TenantID, &t.cfg, records); err != nil && transient == nil {
+			transient = err
+		}
+	}
+	if transient != nil {
+		return sdk.Retriable(transient)
+	}
+	return nil
+}
+
+func (p *salesforceProducer) writeRecords(ctx context.Context, tenantID string, cfg *SalesforceProducerConfig, records []map[string]any) error {
+	if cfg.Object == "" {
+		p.logger.Error("Salesforce producer missing object; skipping")
+		return nil
+	}
+	if cfg.APIVersion == "" {
+		cfg.APIVersion = defaultAPIVersion
+	}
+	op := cfg.Operation
+	if op == "" {
+		op = "insert"
+	}
+	if op == "upsert" && cfg.ExternalIDField == "" {
+		p.logger.Error("Salesforce upsert requires external_id_field; skipping", "object", cfg.Object)
+		return nil
+	}
+
+	if len(records) >= p.bulkThreshold {
+		return p.bulkWrite(ctx, tenantID, cfg, op, records)
+	}
+	return p.restWrite(ctx, tenantID, cfg, op, records)
+}
+
+// restWrite writes records one-by-one via the REST sObject API. Per-record 4xx
+// errors are logged and skipped (poison record); transient errors are returned.
+func (p *salesforceProducer) restWrite(ctx context.Context, tenantID string, cfg *SalesforceProducerConfig, op string, records []map[string]any) error {
+	base := strings.TrimRight(cfg.InstanceURL, "/")
+	var transient error
+	ok := 0
+	for _, rec := range records {
+		var method, u string
+		if op == "upsert" {
+			extVal, _ := rec[cfg.ExternalIDField].(string)
+			if extVal == "" {
+				if v, present := rec[cfg.ExternalIDField]; present {
+					extVal = fmt.Sprint(v)
+				}
+			}
+			if extVal == "" {
+				p.logger.Error("upsert record missing external id value; skipping", "field", cfg.ExternalIDField)
+				continue
+			}
+			method = http.MethodPatch
+			u = fmt.Sprintf("%s/services/data/%s/sobjects/%s/%s/%s", base, cfg.APIVersion, cfg.Object, cfg.ExternalIDField, url.PathEscape(extVal))
+		} else {
+			method = http.MethodPost
+			u = fmt.Sprintf("%s/services/data/%s/sobjects/%s", base, cfg.APIVersion, cfg.Object)
+		}
+		body, _ := json.Marshal(rec)
+		status, respBody, err := p.doRequest(ctx, tenantID, cfg.OAuthGrantID, method, u, "application/json", body)
+		if err != nil {
+			if transient == nil {
+				transient = err
+			}
+			continue
+		}
+		switch {
+		case status >= 200 && status < 300:
+			ok++
+		case status >= 500 || status == http.StatusTooManyRequests:
+			if transient == nil {
+				transient = fmt.Errorf("salesforce %d: %s", status, truncate(respBody))
+			}
+		default: // 4xx — bad record, won't improve on retry
+			p.logger.Error("Salesforce rejected record", "status", status, "object", cfg.Object, "body", truncate(respBody))
+		}
+	}
+	p.logger.Info("Salesforce REST write", "object", cfg.Object, "op", op, "ok", ok, "total", len(records))
+	return transient
+}
+
+// bulkWrite ingests records via Bulk API 2.0: create job → upload CSV → close.
+func (p *salesforceProducer) bulkWrite(ctx context.Context, tenantID string, cfg *SalesforceProducerConfig, op string, records []map[string]any) error {
+	base := strings.TrimRight(cfg.InstanceURL, "/")
+
+	jobReq := map[string]string{"object": cfg.Object, "operation": op, "contentType": "CSV", "lineEnding": "LF"}
+	if op == "upsert" {
+		jobReq["externalIdFieldName"] = cfg.ExternalIDField
+	}
+	jobBody, _ := json.Marshal(jobReq)
+	status, respBody, err := p.doRequest(ctx, tenantID, cfg.OAuthGrantID, http.MethodPost,
+		fmt.Sprintf("%s/services/data/%s/jobs/ingest", base, cfg.APIVersion), "application/json", jobBody)
+	if err != nil {
+		return err
+	}
+	if status < 200 || status >= 300 {
+		return fmt.Errorf("create bulk job %d: %s", status, truncate(respBody))
+	}
+	var job struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(respBody, &job); err != nil || job.ID == "" {
+		return fmt.Errorf("bulk job response missing id: %s", truncate(respBody))
+	}
+
+	csvData, err := recordsToCSV(records)
+	if err != nil {
+		return fmt.Errorf("build CSV: %w", err)
+	}
+	status, respBody, err = p.doRequest(ctx, tenantID, cfg.OAuthGrantID, http.MethodPut,
+		fmt.Sprintf("%s/services/data/%s/jobs/ingest/%s/batches", base, cfg.APIVersion, job.ID), "text/csv", csvData)
+	if err != nil {
+		return err
+	}
+	if status < 200 || status >= 300 {
+		return fmt.Errorf("upload bulk data %d: %s", status, truncate(respBody))
+	}
+
+	closeBody := []byte(`{"state":"UploadComplete"}`)
+	status, respBody, err = p.doRequest(ctx, tenantID, cfg.OAuthGrantID, http.MethodPatch,
+		fmt.Sprintf("%s/services/data/%s/jobs/ingest/%s", base, cfg.APIVersion, job.ID), "application/json", closeBody)
+	if err != nil {
+		return err
+	}
+	if status < 200 || status >= 300 {
+		return fmt.Errorf("close bulk job %d: %s", status, truncate(respBody))
+	}
+	p.logger.Info("Salesforce Bulk API job submitted", "object", cfg.Object, "op", op, "job_id", job.ID, "records", len(records))
+	return nil
+}
+
+// doRequest performs an authenticated request, refreshing the token once on 401.
+func (p *salesforceProducer) doRequest(ctx context.Context, tenantID, grantID, method, fullURL, contentType string, body []byte) (int, []byte, error) {
+	send := func(force bool) (*http.Response, error) {
+		tok, err := p.resolveToken(ctx, tenantID, grantID, force)
+		if err != nil {
+			return nil, fmt.Errorf("resolve OAuth token: %w", err)
+		}
+		req, err := http.NewRequestWithContext(ctx, method, fullURL, bytes.NewReader(body))
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Authorization", "Bearer "+tok)
+		req.Header.Set("Content-Type", contentType)
+		req.Header.Set("Accept", "application/json")
+		return p.httpClient.Do(req)
+	}
+	resp, err := send(false)
+	if err != nil {
+		return 0, nil, err
+	}
+	if resp.StatusCode == http.StatusUnauthorized {
+		_ = resp.Body.Close()
+		p.logger.Info("Salesforce returned 401; refreshing token and retrying once", "grant_id", grantID)
+		resp, err = send(true)
+		if err != nil {
+			return 0, nil, fmt.Errorf("request after token refresh: %w", err)
+		}
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	return resp.StatusCode, respBody, nil
+}
+
+// --- helpers ---
+
+func parseRecords(payload []byte) ([]map[string]any, error) {
+	trimmed := bytes.TrimSpace(payload)
+	if len(trimmed) == 0 {
+		return nil, nil
+	}
+	switch trimmed[0] {
+	case '[':
+		var rows []map[string]any
+		if err := json.Unmarshal(trimmed, &rows); err != nil {
+			return nil, fmt.Errorf("%w: %v", errBadPayload, err)
+		}
+		return rows, nil
+	case '{':
+		var one map[string]any
+		if err := json.Unmarshal(trimmed, &one); err != nil {
+			return nil, fmt.Errorf("%w: %v", errBadPayload, err)
+		}
+		return []map[string]any{one}, nil
+	default:
+		return nil, errBadPayload
+	}
+}
+
+// recordsToCSV renders records to CSV with a header = the sorted union of keys.
+func recordsToCSV(records []map[string]any) ([]byte, error) {
+	keySet := map[string]struct{}{}
+	for _, r := range records {
+		for k := range r {
+			keySet[k] = struct{}{}
+		}
+	}
+	keys := make([]string, 0, len(keySet))
+	for k := range keySet {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var buf bytes.Buffer
+	w := csv.NewWriter(&buf)
+	if err := w.Write(keys); err != nil {
+		return nil, err
+	}
+	for _, r := range records {
+		row := make([]string, len(keys))
+		for i, k := range keys {
+			row[i] = csvValue(r[k])
+		}
+		if err := w.Write(row); err != nil {
+			return nil, err
+		}
+	}
+	w.Flush()
+	return buf.Bytes(), w.Error()
+}
+
+func csvValue(v any) string {
+	switch t := v.(type) {
+	case nil:
+		return ""
+	case string:
+		return t
+	case map[string]any, []any:
+		b, _ := json.Marshal(t)
+		return string(b)
+	default:
+		return fmt.Sprint(t)
+	}
+}
+
+func truncate(b []byte) string {
+	s := strings.TrimSpace(string(b))
+	if len(s) > 300 {
+		return s[:300] + "…"
+	}
+	return s
+}
+
+type node struct {
+	ID     string          `json:"id"`
+	Type   string          `json:"type"`
+	Config json.RawMessage `json:"config"`
+}
+
+// getTargets returns the connection's Salesforce producer targets (cached).
+// lint:tenant-ok — connection lookup by PK; tenant scoping enforced upstream at deploy.
+func (p *salesforceProducer) getTargets(ctx context.Context, connID, tenantID string) ([]*sfTarget, error) {
+	p.cacheMu.RLock()
+	if ts, ok := p.cache[connID]; ok && time.Since(p.cacheTime[connID]) < p.cacheTTL {
+		p.cacheMu.RUnlock()
+		return ts, nil
+	}
+	p.cacheMu.RUnlock()
+
+	var nodesJSON, edgesJSON []byte
+	if err := p.db.QueryRowContext(ctx, `SELECT nodes, edges FROM connections WHERE id = $1`, connID).
+		Scan(&nodesJSON, &edgesJSON); err != nil {
+		return nil, fmt.Errorf("connection not found: %w", err)
+	}
+	var nodes []node
+	if err := json.Unmarshal(nodesJSON, &nodes); err != nil {
+		return nil, fmt.Errorf("parse nodes: %w", err)
+	}
+	var edges []struct {
+		Source string `json:"source"`
+		Target string `json:"target"`
+	}
+	if edgesJSON != nil {
+		_ = json.Unmarshal(edgesJSON, &edges)
+	}
+
+	var targets []*sfTarget
+	for _, n := range nodes {
+		if n.Type != "producer" {
+			continue
+		}
+		var nc struct {
+			Type       string                    `json:"type"`
+			Salesforce *SalesforceProducerConfig `json:"salesforce"`
+		}
+		if err := json.Unmarshal(n.Config, &nc); err != nil {
+			continue
+		}
+		if nc.Type != "salesforce" || nc.Salesforce == nil || nc.Salesforce.Object == "" {
+			continue
+		}
+		var predID string
+		var predIsConsumer bool
+		for _, e := range edges {
+			if e.Target == n.ID {
+				predID = e.Source
+				for _, m := range nodes {
+					if m.ID == predID && m.Type == "consumer" {
+						predIsConsumer = true
+						break
+					}
+				}
+				break
+			}
+		}
+		targets = append(targets, &sfTarget{cfg: *nc.Salesforce, predecessorID: predID, predIsConsumer: predIsConsumer})
+	}
+	if len(targets) == 0 {
+		return nil, errors.New("no salesforce producer node found")
+	}
+
+	p.cacheMu.Lock()
+	p.cache[connID] = targets
+	p.cacheTime[connID] = time.Now()
+	p.cacheMu.Unlock()
+	return targets, nil
+}

--- a/src/pkg/managementapi/repo_oauth.go
+++ b/src/pkg/managementapi/repo_oauth.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/lib/pq"
 
 	"github.com/ValueRetail/vrsky/pkg/crypto"
@@ -99,15 +100,23 @@ func (r *PostgresRepository) CreateGrant(ctx context.Context, g *oauth.Grant, ac
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	// Secret names just need to be tenant-unique. Including grant intent in
-	// the name makes operator inspection easier.
-	accessSec, err := createSecretTx(ctx, tx, g.TenantID, "oauth-access:"+g.ProviderName, accessCt)
+	// Generate the grant ID up-front so it can be embedded in the secret
+	// names. Secret names are unique per (tenant_id, name); deriving them from
+	// just the provider name collided whenever a tenant connected the same
+	// provider more than once (re-auth, second grant) → "duplicate key value
+	// violates unique constraint secrets_tenant_id_name_key". The grant ID
+	// makes each name globally unique while still being operator-readable.
+	if g.ID == "" {
+		g.ID = uuid.New().String()
+	}
+
+	accessSec, err := createSecretTx(ctx, tx, g.TenantID, "oauth-access:"+g.ProviderName+":"+g.ID, accessCt)
 	if err != nil {
 		return fmt.Errorf("persist access secret: %w", err)
 	}
 	var refreshSecID sql.NullString
 	if refreshCt != "" {
-		s, err := createSecretTx(ctx, tx, g.TenantID, "oauth-refresh:"+g.ProviderName, refreshCt)
+		s, err := createSecretTx(ctx, tx, g.TenantID, "oauth-refresh:"+g.ProviderName+":"+g.ID, refreshCt)
 		if err != nil {
 			return fmt.Errorf("persist refresh secret: %w", err)
 		}
@@ -117,10 +126,10 @@ func (r *PostgresRepository) CreateGrant(ctx context.Context, g *oauth.Grant, ac
 
 	const q = `
 		INSERT INTO oauth_grants (
-		    tenant_id, provider_id, provider_type, provider_name,
+		    id, tenant_id, provider_id, provider_type, provider_name,
 		    connection_id, user_identifier, scopes_granted,
 		    access_token_secret_id, refresh_token_secret_id, expires_at
-		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
 		RETURNING id, created_at, updated_at`
 	var connID sql.NullString
 	if g.ConnectionID != nil {
@@ -134,7 +143,7 @@ func (r *PostgresRepository) CreateGrant(ctx context.Context, g *oauth.Grant, ac
 	}
 	var createdAt, updatedAt time.Time
 	err = tx.QueryRowContext(ctx, q,
-		g.TenantID, g.ProviderID, g.ProviderType, g.ProviderName,
+		g.ID, g.TenantID, g.ProviderID, g.ProviderType, g.ProviderName,
 		connID, userIdent, pq.Array(g.ScopesGranted),
 		accessSec, refreshSecID, g.ExpiresAt,
 	).Scan(&g.ID, &createdAt, &updatedAt)

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -22,6 +22,7 @@ import ApiKeyPage from './pages/ApiKeyPage'
 import AuditPage from './pages/AuditPage'
 import UsersPage from './pages/UsersPage'
 import UsagePage from './pages/UsagePage'
+import OAuthProvidersPage from './pages/OAuthProvidersPage'
 
 function App() {
   const { confirmDialog, hideConfirmDialog } = useUIStore()
@@ -79,6 +80,7 @@ function App() {
             <Route path="/settings/connection-requests" element={<ProtectedRoute><ConnectionRequestsPage /></ProtectedRoute>} />
             <Route path="/settings/tenant-connections" element={<ProtectedRoute><TenantConnectionsPage /></ProtectedRoute>} />
             <Route path="/settings/api-key" element={<ProtectedRoute><ApiKeyPage /></ProtectedRoute>} />
+            <Route path="/settings/oauth" element={<ProtectedRoute><OAuthProvidersPage /></ProtectedRoute>} />
             <Route path="/settings/audit" element={<ProtectedRoute><AuditPage /></ProtectedRoute>} />
             <Route path="/settings/users" element={<ProtectedRoute><UsersPage /></ProtectedRoute>} />
             <Route path="/settings/usage" element={<ProtectedRoute><UsagePage /></ProtectedRoute>} />

--- a/ui/src/components/Layout/Sidebar.tsx
+++ b/ui/src/components/Layout/Sidebar.tsx
@@ -84,6 +84,16 @@ export default function Sidebar() {
             API Key
           </Link>
           <Link
+            to="/settings/oauth"
+            className={`flex items-center gap-3 px-4 py-2 rounded-lg text-sm transition-all duration-fast ${
+              isActive('/settings/oauth')
+                ? 'bg-primary-100 dark:bg-primary-900/30 text-primary-700 dark:text-primary-300 font-semibold'
+                : 'text-neutral-700 dark:text-neutral-300 hover:bg-neutral-100 dark:hover:bg-neutral-700/50'
+            }`}
+          >
+            OAuth providers
+          </Link>
+          <Link
             to="/settings/audit"
             className={`flex items-center gap-3 px-4 py-2 rounded-lg text-sm transition-all duration-fast ${
               isActive('/settings/audit')

--- a/ui/src/components/Layout/Sidebar.tsx
+++ b/ui/src/components/Layout/Sidebar.tsx
@@ -5,10 +5,15 @@
 
 import { Link, useLocation } from 'react-router-dom'
 import { useConnectionsStore } from '../../store/connectionsStore'
+import { useAuthStore } from '../../store/authStore'
 
 export default function Sidebar() {
   const { pathname } = useLocation()
   const { connections = [] } = useConnectionsStore()
+  // OAuth provider management is owner/admin-only (CRUD is admin-gated
+  // server-side); hide the entry for everyone else.
+  const role = useAuthStore((s) => s.currentTenant?.user_role)
+  const canManageOAuth = role === 'owner' || role === 'admin'
   const runningCount = (connections || []).filter((c) => c.status === 'running').length
   const stoppedCount = (connections || []).filter((c) => c.status === 'stopped').length
   const errorCount = (connections || []).filter((c) => c.status === 'error').length
@@ -83,6 +88,7 @@ export default function Sidebar() {
           >
             API Key
           </Link>
+          {canManageOAuth && (
           <Link
             to="/settings/oauth"
             className={`flex items-center gap-3 px-4 py-2 rounded-lg text-sm transition-all duration-fast ${
@@ -93,6 +99,7 @@ export default function Sidebar() {
           >
             OAuth providers
           </Link>
+          )}
           <Link
             to="/settings/audit"
             className={`flex items-center gap-3 px-4 py-2 rounded-lg text-sm transition-all duration-fast ${

--- a/ui/src/components/Pipeline/OAuthGrantSelector.tsx
+++ b/ui/src/components/Pipeline/OAuthGrantSelector.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
+import { Link } from 'react-router-dom'
 import * as oauthService from '../../services/oauthService'
 import type { OAuthProvider, OAuthGrant } from '../../services/oauthService'
 import OAuthConnect from './OAuthConnect'
@@ -22,24 +23,16 @@ const inputStyle: React.CSSProperties = {
   backgroundColor: '#ffffff',
 }
 
-// Known provider types whose auth/token URLs + scopes the backend fills in
-// automatically (applyProfileDefaults). "custom" requires explicit URLs.
-// Values must match the backend provider registry keys (pkg/oauth DefaultRegistry)
-// so the known types get their auth/token URLs + scopes filled by applyProfileDefaults.
-const PROVIDER_TYPES = ['google', 'microsoft365', 'salesforce', 'hubspot', 'shopify', 'custom']
-
-const defaultRedirectURL = () =>
-  typeof window !== 'undefined' ? `${window.location.origin}/api/v1/oauth/callback` : ''
-
 /**
- * Lets the user pick an existing OAuth grant for a node, or connect a new one.
+ * Lets a pipeline node pick an existing OAuth grant, or connect a new one.
  * Flow: choose a configured provider → either pick one of its existing grants
  * or click "Connect" to run the popup auth flow. Surfaces a "Reconnect
  * required" badge when a grant's refresh has permanently failed, and offers a
- * revoke button (completes acceptance criterion #4: revoke from the UI).
+ * revoke button (acceptance criterion #4).
  *
- * Also includes an inline "Add provider" form so an owner can register an OAuth
- * app (client id/secret) without leaving the editor.
+ * Providers themselves are registered under Settings → OAuth providers
+ * (OAuthProvidersPage); this control only selects/connects, it does not create
+ * providers.
  */
 export default function OAuthGrantSelector({ value, onChange, connectionId }: OAuthGrantSelectorProps) {
   const [providers, setProviders] = useState<OAuthProvider[]>([])
@@ -48,18 +41,6 @@ export default function OAuthGrantSelector({ value, onChange, connectionId }: OA
   const [shop, setShop] = useState<string>('')
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
-
-  // Add-provider form state.
-  const [addOpen, setAddOpen] = useState(false)
-  const [fName, setFName] = useState('')
-  const [fType, setFType] = useState('google')
-  const [fClientId, setFClientId] = useState('')
-  const [fSecret, setFSecret] = useState('')
-  const [fRedirect, setFRedirect] = useState(defaultRedirectURL())
-  const [fAuthURL, setFAuthURL] = useState('')
-  const [fTokenURL, setFTokenURL] = useState('')
-  const [saving, setSaving] = useState(false)
-  const [addError, setAddError] = useState<string | null>(null)
 
   const refresh = useCallback(async () => {
     setLoading(true)
@@ -120,105 +101,17 @@ export default function OAuthGrantSelector({ value, onChange, connectionId }: OA
     }
   }
 
-  const handleCreateProvider = async () => {
-    if (!fName.trim() || !fClientId.trim() || !fSecret.trim() || !fRedirect.trim()) {
-      setAddError('Name, client id, client secret and redirect URL are required')
-      return
-    }
-    if (fType === 'custom' && (!fAuthURL.trim() || !fTokenURL.trim())) {
-      setAddError('Custom providers need an auth URL and a token URL')
-      return
-    }
-    setSaving(true)
-    setAddError(null)
-    try {
-      const created = await oauthService.createProvider({
-        name: fName.trim(),
-        provider_type: fType,
-        client_id: fClientId.trim(),
-        client_secret: fSecret,
-        redirect_url: fRedirect.trim(),
-        ...(fType === 'custom' ? { auth_url: fAuthURL.trim(), token_url: fTokenURL.trim() } : {}),
-      })
-      // Reset the form, select the new provider, reload lists.
-      setAddOpen(false)
-      setFName(''); setFClientId(''); setFSecret(''); setFAuthURL(''); setFTokenURL('')
-      await refresh()
-      if (created?.id) setProviderId(created.id)
-    } catch (e) {
-      setAddError(e instanceof Error ? e.message : 'Failed to create provider')
-    } finally {
-      setSaving(false)
-    }
-  }
-
-  // Inline "Add OAuth provider" form (shared by the empty + populated states).
-  const addProviderForm = (
-    <div style={{ marginTop: '8px' }}>
-      {!addOpen ? (
-        <button
-          type="button"
-          onClick={() => { setAddOpen(true); setFRedirect(defaultRedirectURL()) }}
-          style={{
-            padding: '4px 10px', fontSize: '12px', fontWeight: 600,
-            color: '#2563eb', backgroundColor: '#eff6ff',
-            border: '1px solid #bfdbfe', borderRadius: '4px', cursor: 'pointer',
-          }}
-        >
-          + Add OAuth provider
-        </button>
-      ) : (
-        <div style={{ border: '1px solid #e5e7eb', borderRadius: '6px', padding: '10px', backgroundColor: '#f9fafb' }}>
-          <div style={{ fontSize: '12px', fontWeight: 600, color: '#374151', marginBottom: '8px' }}>New OAuth provider</div>
-          <input style={inputStyle} placeholder="Name (e.g. Google – My Project)" value={fName} onChange={(e) => setFName(e.target.value)} />
-          <select style={inputStyle} value={fType} onChange={(e) => setFType(e.target.value)}>
-            {PROVIDER_TYPES.map((t) => <option key={t} value={t}>{t}</option>)}
-          </select>
-          <input style={inputStyle} placeholder="Client ID" value={fClientId} onChange={(e) => setFClientId(e.target.value)} />
-          <input style={inputStyle} type="password" placeholder="Client secret" value={fSecret} onChange={(e) => setFSecret(e.target.value)} autoComplete="new-password" />
-          <input style={inputStyle} placeholder="Redirect URL" value={fRedirect} onChange={(e) => setFRedirect(e.target.value)} />
-          {fType === 'custom' && (
-            <>
-              <input style={inputStyle} placeholder="Authorize URL" value={fAuthURL} onChange={(e) => setFAuthURL(e.target.value)} />
-              <input style={inputStyle} placeholder="Token URL" value={fTokenURL} onChange={(e) => setFTokenURL(e.target.value)} />
-            </>
-          )}
-          <div style={{ fontSize: '11px', color: '#6b7280', marginBottom: '8px' }}>
-            Register this exact Redirect URL with the provider. For known types the auth/token URLs are filled automatically.
-          </div>
-          {addError && <p style={{ fontSize: '11px', color: '#dc2626', marginBottom: '6px' }}>{addError}</p>}
-          <div style={{ display: 'flex', gap: '6px' }}>
-            <button
-              type="button" disabled={saving} onClick={handleCreateProvider}
-              style={{ padding: '4px 10px', fontSize: '12px', fontWeight: 600, color: '#fff', backgroundColor: '#2563eb', border: 'none', borderRadius: '4px', cursor: 'pointer' }}
-            >
-              {saving ? 'Saving…' : 'Save provider'}
-            </button>
-            <button
-              type="button" disabled={saving} onClick={() => { setAddOpen(false); setAddError(null) }}
-              style={{ padding: '4px 10px', fontSize: '12px', color: '#374151', backgroundColor: '#fff', border: '1px solid #d1d5db', borderRadius: '4px', cursor: 'pointer' }}
-            >
-              Cancel
-            </button>
-          </div>
-        </div>
-      )}
-    </div>
-  )
-
   if (loading && providers.length === 0) {
     return <p style={{ fontSize: '12px', color: '#6b7280' }}>Loading OAuth providers…</p>
   }
 
   if (providers.length === 0) {
     return (
-      <div>
-        <p style={{ fontSize: '12px', color: '#92400e', marginBottom: '4px' }}>
-          No OAuth providers configured yet. Add one to connect an account.
-        </p>
-        {addProviderForm}
-        {error && <p style={{ marginTop: '6px', fontSize: '12px', color: '#dc2626' }}>{error}</p>}
-      </div>
+      <p style={{ fontSize: '12px', color: '#92400e' }}>
+        No OAuth providers configured yet. Add one under{' '}
+        <Link to="/settings/oauth" style={{ color: '#2563eb', fontWeight: 600 }}>Settings → OAuth providers</Link>,
+        then come back to connect an account.
+      </p>
     )
   }
 
@@ -299,7 +192,10 @@ export default function OAuthGrantSelector({ value, onChange, connectionId }: OA
         onConnected={handleConnected}
       />
 
-      {addProviderForm}
+      <p style={{ marginTop: '8px', fontSize: '11px', color: '#6b7280' }}>
+        Manage providers under{' '}
+        <Link to="/settings/oauth" style={{ color: '#2563eb' }}>Settings → OAuth providers</Link>.
+      </p>
 
       {error && <p style={{ marginTop: '6px', fontSize: '12px', color: '#dc2626' }}>{error}</p>}
     </div>

--- a/ui/src/components/Pipeline/PropertyEditor.tsx
+++ b/ui/src/components/Pipeline/PropertyEditor.tsx
@@ -463,6 +463,79 @@ function TenantConsumerConfig({
   )
 }
 
+// Salesforce producer config (#79 PR 2): write records via REST (insert/upsert),
+// auto Bulk API for batches ≥200. Stores config.salesforce = {instance_url,
+// oauth_grant_id, object, operation, external_id_field, api_version}.
+function SalesforceProducerConfig({
+  config,
+  setConfig,
+  deployedConnectionId,
+}: {
+  config: Record<string, unknown>
+  setConfig: (config: Record<string, unknown>) => void
+  deployedConnectionId?: string
+}) {
+  const sf = (config.salesforce as Record<string, unknown>) || {}
+  const update = (patch: Record<string, unknown>) =>
+    setConfig({ ...config, salesforce: { ...sf, ...patch } })
+  const operation = (sf.operation as string) || 'insert'
+  const labelStyle: React.CSSProperties = {
+    fontSize: '12px', fontWeight: 500, color: '#374151', display: 'block', marginBottom: '4px',
+  }
+
+  return (
+    <div className="space-y-3">
+      <StyledInput
+        label="Instance URL"
+        placeholder="https://your-org.my.salesforce.com"
+        value={(sf.instance_url as string) || ''}
+        onChange={(v) => update({ instance_url: v })}
+      />
+      <div>
+        <label style={labelStyle}>Salesforce account (OAuth)</label>
+        <OAuthGrantSelector
+          value={(sf.oauth_grant_id as string) || ''}
+          onChange={(grantId) => update({ oauth_grant_id: grantId || '' })}
+          connectionId={deployedConnectionId}
+        />
+      </div>
+      <StyledInput
+        label="Object (sObject)"
+        placeholder="Account"
+        value={(sf.object as string) || ''}
+        onChange={(v) => update({ object: v })}
+      />
+      <StyledSelect
+        label="Operation"
+        value={operation}
+        onChange={(v) => update({ operation: v })}
+        options={[
+          { value: 'insert', label: 'Insert' },
+          { value: 'upsert', label: 'Upsert (by external id)' },
+        ]}
+      />
+      {operation === 'upsert' && (
+        <StyledInput
+          label="External ID field"
+          placeholder="ExternalId__c"
+          value={(sf.external_id_field as string) || ''}
+          onChange={(v) => update({ external_id_field: v })}
+        />
+      )}
+      <StyledInput
+        label="API version"
+        placeholder="v60.0"
+        value={(sf.api_version as string) || ''}
+        onChange={(v) => update({ api_version: v })}
+      />
+      <div style={{ fontSize: '11px', color: '#6b7280' }}>
+        Records flowing into this node are written to Salesforce. Batches of 200+ records
+        automatically use the Bulk API 2.0.
+      </div>
+    </div>
+  )
+}
+
 // Salesforce consumer config (#79 PR 1): SOQL poll authenticated by an OAuth
 // grant. Stores config.salesforce = {instance_url, oauth_grant_id, soql,
 // poll_interval_seconds, api_version}.
@@ -2319,6 +2392,7 @@ export default function PropertyEditor({
                 { value: 'http', label: 'Webhook (HTTP)' },
                 { value: 'file', label: 'File Output' },
                 { value: 'database', label: 'Database' },
+                { value: 'salesforce', label: 'Salesforce' },
               ]}
             />
 
@@ -2425,6 +2499,14 @@ export default function PropertyEditor({
               <DatabaseProducerConfig
                 config={config}
                 setConfig={setConfig}
+              />
+            )}
+
+            {config.type === 'salesforce' && (
+              <SalesforceProducerConfig
+                config={config}
+                setConfig={setConfig}
+                deployedConnectionId={deployedConnectionId}
               />
             )}
           </div>

--- a/ui/src/components/Pipeline/PropertyEditor.tsx
+++ b/ui/src/components/Pipeline/PropertyEditor.tsx
@@ -2064,18 +2064,19 @@ function ApiConsumerConfig({
                 />
                 <span style={{ fontSize: '10px', color: '#9ca3af', marginTop: '-6px', marginBottom: '6px', display: 'block' }}>Query params (e.g. lat=59.9&amp;lon=10.7)</span>
 
-                <div style={{ display: 'flex', gap: '8px' }}>
+                <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
                   <select
                     value={ep.auth_type}
                     onChange={(e) => updateEndpoint(idx, 'auth_type', e.target.value)}
                     style={{
-                      flex: 1,
+                      width: '100%',
                       padding: '8px 10px',
                       border: '1px solid #d1d5db',
                       borderRadius: '4px',
                       fontSize: '12px',
                       color: '#374151',
                       backgroundColor: '#ffffff',
+                      boxSizing: 'border-box',
                     }}
                   >
                     <option value="none">No Auth</option>
@@ -2085,25 +2086,21 @@ function ApiConsumerConfig({
                   </select>
 
                   {(ep.auth_type === 'bearer' || ep.auth_type === 'api_key') && (
-                    <div style={{ flex: 2 }}>
-                      <SecretInput
-                        label={ep.auth_type === 'bearer' ? 'Bearer token' : 'API key'}
-                        placeholder={ep.auth_type === 'bearer' ? 'Token value' : 'API key value'}
-                        field="auth_value"
-                        config={ep as unknown as Record<string, unknown>}
-                        defaultSecretName={`api-${ep.auth_type}-${idx}`}
-                        onChange={(patch) => patchEndpoint(idx, patch)}
-                      />
-                    </div>
+                    <SecretInput
+                      label={ep.auth_type === 'bearer' ? 'Bearer token' : 'API key'}
+                      placeholder={ep.auth_type === 'bearer' ? 'Token value' : 'API key value'}
+                      field="auth_value"
+                      config={ep as unknown as Record<string, unknown>}
+                      defaultSecretName={`api-${ep.auth_type}-${idx}`}
+                      onChange={(patch) => patchEndpoint(idx, patch)}
+                    />
                   )}
 
                   {ep.auth_type === 'oauth' && (
-                    <div style={{ flex: 2 }}>
-                      <OAuthGrantSelector
-                        value={ep.oauth_grant_id}
-                        onChange={(grantId) => updateEndpoint(idx, 'oauth_grant_id', grantId || '')}
-                      />
-                    </div>
+                    <OAuthGrantSelector
+                      value={ep.oauth_grant_id}
+                      onChange={(grantId) => updateEndpoint(idx, 'oauth_grant_id', grantId || '')}
+                    />
                   )}
                 </div>
               </div>

--- a/ui/src/components/Pipeline/PropertyEditor.tsx
+++ b/ui/src/components/Pipeline/PropertyEditor.tsx
@@ -463,6 +463,81 @@ function TenantConsumerConfig({
   )
 }
 
+// Salesforce consumer config (#79 PR 1): SOQL poll authenticated by an OAuth
+// grant. Stores config.salesforce = {instance_url, oauth_grant_id, soql,
+// poll_interval_seconds, api_version}.
+function SalesforceConsumerConfig({
+  config,
+  setConfig,
+  deployedConnectionId,
+}: {
+  config: Record<string, unknown>
+  setConfig: (config: Record<string, unknown>) => void
+  deployedConnectionId?: string
+}) {
+  const sf = (config.salesforce as Record<string, unknown>) || {}
+  const update = (patch: Record<string, unknown>) =>
+    setConfig({ ...config, salesforce: { ...sf, ...patch } })
+
+  const labelStyle: React.CSSProperties = {
+    fontSize: '12px', fontWeight: 500, color: '#374151', display: 'block', marginBottom: '4px',
+  }
+
+  return (
+    <div className="space-y-3">
+      <StyledInput
+        label="Instance URL"
+        placeholder="https://your-org.my.salesforce.com"
+        value={(sf.instance_url as string) || ''}
+        onChange={(v) => update({ instance_url: v })}
+      />
+
+      <div>
+        <label style={labelStyle}>Salesforce account (OAuth)</label>
+        <OAuthGrantSelector
+          value={(sf.oauth_grant_id as string) || ''}
+          onChange={(grantId) => update({ oauth_grant_id: grantId || '' })}
+          connectionId={deployedConnectionId}
+        />
+      </div>
+
+      <div>
+        <label style={labelStyle}>SOQL query</label>
+        <textarea
+          style={{
+            width: '100%', minHeight: '70px', padding: '8px 10px',
+            border: '1px solid #d1d5db', borderRadius: '4px', fontSize: '12px',
+            fontFamily: 'monospace', color: '#111827', boxSizing: 'border-box',
+          }}
+          placeholder="SELECT Id, Name FROM Account ORDER BY LastModifiedDate DESC"
+          value={(sf.soql as string) || ''}
+          onChange={(e) => update({ soql: e.target.value })}
+        />
+      </div>
+
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '8px' }}>
+        <StyledInput
+          label="Poll interval (s, 0 = once)"
+          placeholder="0"
+          type="number"
+          value={String((sf.poll_interval_seconds as number) ?? 0)}
+          onChange={(v) => update({ poll_interval_seconds: parseInt(v) || 0 })}
+        />
+        <StyledInput
+          label="API version"
+          placeholder="v60.0"
+          value={(sf.api_version as string) || ''}
+          onChange={(v) => update({ api_version: v })}
+        />
+      </div>
+      <div style={{ fontSize: '11px', color: '#6b7280' }}>
+        Connect a Salesforce account (OAuth) above, then enter a SOQL query. For a
+        sandbox, register a Salesforce provider with the test.salesforce.com URLs.
+      </div>
+    </div>
+  )
+}
+
 // API Consumer configuration component
 // Minimal by default - just Base URL
 // Advanced options (poll interval, endpoints) expandable
@@ -2066,6 +2141,7 @@ export default function PropertyEditor({
                 { value: 'file', label: 'File Watcher' },
                 { value: 'database', label: 'Database CDC' },
                 { value: 'tenant', label: 'Tenant Input' },
+                { value: 'salesforce', label: 'Salesforce' },
               ]}
             />
 
@@ -2218,6 +2294,14 @@ export default function PropertyEditor({
               <TenantConsumerConfig
                 config={config}
                 setConfig={setConfig}
+              />
+            )}
+
+            {config.type === 'salesforce' && (
+              <SalesforceConsumerConfig
+                config={config}
+                setConfig={setConfig}
+                deployedConnectionId={deployedConnectionId}
               />
             )}
           </div>

--- a/ui/src/components/Pipeline/PropertyEditor.tsx
+++ b/ui/src/components/Pipeline/PropertyEditor.tsx
@@ -2378,6 +2378,32 @@ export default function PropertyEditor({
                 <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-1">
                   Pipeline data will be POSTed to this URL. Paste a webhook URL from any external service (e.g. webhook.site, Slack, Discord).
                 </p>
+
+                <StyledSelect
+                  label="Authentication"
+                  value={((config.http as any)?.auth_type as string) || 'none'}
+                  onChange={(value) =>
+                    setConfig({ ...config, http: { ...(config.http as any), auth_type: value } })
+                  }
+                  options={[
+                    { value: 'none', label: 'None' },
+                    { value: 'oauth', label: 'OAuth 2.0' },
+                  ]}
+                />
+                {(config.http as any)?.auth_type === 'oauth' && (
+                  <div style={{ marginTop: '4px' }}>
+                    <OAuthGrantSelector
+                      value={(config.http as any)?.oauth_grant_id || ''}
+                      onChange={(grantId) =>
+                        setConfig({
+                          ...config,
+                          http: { ...(config.http as any), oauth_grant_id: grantId || '' },
+                        })
+                      }
+                      connectionId={deployedConnectionId}
+                    />
+                  </div>
+                )}
               </>
             )}
 

--- a/ui/src/pages/OAuthProvidersPage.tsx
+++ b/ui/src/pages/OAuthProvidersPage.tsx
@@ -1,0 +1,192 @@
+import { useState, useEffect, useCallback } from 'react'
+import { useUIStore } from '@/store/uiStore'
+import * as oauthService from '@/services/oauthService'
+import type { OAuthProvider } from '@/services/oauthService'
+
+// Values must match the backend provider registry keys (pkg/oauth DefaultRegistry)
+// so known types get their auth/token URLs + scopes filled by applyProfileDefaults.
+const PROVIDER_TYPES = ['google', 'microsoft365', 'salesforce', 'hubspot', 'shopify', 'custom']
+
+const defaultRedirectURL = () =>
+  typeof window !== 'undefined' ? `${window.location.origin}/api/v1/oauth/callback` : ''
+
+const inputClass =
+  'w-full px-3 py-2 border border-neutral-300 rounded-md text-sm text-neutral-900 bg-white focus:outline-none focus:ring-2 focus:ring-blue-500'
+const labelClass = 'block text-xs font-medium text-neutral-600 mb-1'
+
+/**
+ * Settings → OAuth providers. Owner-managed registration of OAuth apps
+ * (client id/secret + URLs). Provider CRUD endpoints are admin-gated server-side.
+ * Pipeline nodes only *select* a provider/grant (see OAuthGrantSelector).
+ */
+export default function OAuthProvidersPage() {
+  const { addNotification, showConfirmDialog, hideConfirmDialog } = useUIStore()
+
+  const [providers, setProviders] = useState<OAuthProvider[]>([])
+  const [loading, setLoading] = useState(true)
+
+  const [name, setName] = useState('')
+  const [type, setType] = useState('google')
+  const [clientId, setClientId] = useState('')
+  const [secret, setSecret] = useState('')
+  const [redirect, setRedirect] = useState(defaultRedirectURL())
+  const [authURL, setAuthURL] = useState('')
+  const [tokenURL, setTokenURL] = useState('')
+  const [saving, setSaving] = useState(false)
+
+  const refresh = useCallback(async () => {
+    setLoading(true)
+    try {
+      setProviders(await oauthService.listProviders())
+    } catch (e) {
+      addNotification({ type: 'error', title: 'Error', message: e instanceof Error ? e.message : 'Failed to load providers' })
+    } finally {
+      setLoading(false)
+    }
+  }, [addNotification])
+
+  useEffect(() => {
+    void refresh()
+  }, [refresh])
+
+  const resetForm = () => {
+    setName(''); setClientId(''); setSecret(''); setAuthURL(''); setTokenURL('')
+    setRedirect(defaultRedirectURL())
+  }
+
+  const handleCreate = async () => {
+    if (!name.trim() || !clientId.trim() || !secret.trim() || !redirect.trim()) {
+      addNotification({ type: 'error', title: 'Missing fields', message: 'Name, client id, client secret and redirect URL are required.' })
+      return
+    }
+    if (type === 'custom' && (!authURL.trim() || !tokenURL.trim())) {
+      addNotification({ type: 'error', title: 'Missing URLs', message: 'Custom providers need an authorize URL and a token URL.' })
+      return
+    }
+    setSaving(true)
+    try {
+      await oauthService.createProvider({
+        name: name.trim(),
+        provider_type: type,
+        client_id: clientId.trim(),
+        client_secret: secret,
+        redirect_url: redirect.trim(),
+        ...(type === 'custom' ? { auth_url: authURL.trim(), token_url: tokenURL.trim() } : {}),
+      })
+      addNotification({ type: 'success', title: 'Provider added', message: `${name.trim()} is ready to connect.` })
+      resetForm()
+      await refresh()
+    } catch (e) {
+      addNotification({ type: 'error', title: 'Error', message: e instanceof Error ? e.message : 'Failed to create provider' })
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const handleDelete = (p: OAuthProvider) => {
+    showConfirmDialog({
+      title: 'Delete provider',
+      message: `Delete "${p.name}"? Existing grants for this provider will stop working.`,
+      confirmLabel: 'Delete',
+      destructive: true,
+      onConfirm: async () => {
+        hideConfirmDialog()
+        try {
+          await oauthService.deleteProvider(p.id)
+          addNotification({ type: 'success', title: 'Deleted', message: `${p.name} removed.` })
+          await refresh()
+        } catch (e) {
+          addNotification({ type: 'error', title: 'Error', message: e instanceof Error ? e.message : 'Failed to delete provider' })
+        }
+      },
+    })
+  }
+
+  return (
+    <div className="p-6 max-w-3xl mx-auto">
+      <h1 className="text-2xl font-bold text-neutral-900 mb-2">OAuth Providers</h1>
+      <p className="text-sm text-neutral-600 mb-6">
+        Register OAuth apps (client id/secret) once here; pipeline nodes then connect accounts and
+        pick a provider. Register the redirect URL below with the provider exactly as shown.
+      </p>
+
+      {/* Add provider */}
+      <div className="bg-white border border-neutral-200 rounded-lg p-5 mb-6">
+        <h2 className="text-sm font-semibold text-neutral-800 mb-3">Add a provider</h2>
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <label className={labelClass}>Name</label>
+            <input className={inputClass} placeholder="Google – My Project" value={name} onChange={(e) => setName(e.target.value)} />
+          </div>
+          <div>
+            <label className={labelClass}>Type</label>
+            <select className={inputClass} value={type} onChange={(e) => setType(e.target.value)}>
+              {PROVIDER_TYPES.map((t) => <option key={t} value={t}>{t}</option>)}
+            </select>
+          </div>
+          <div>
+            <label className={labelClass}>Client ID</label>
+            <input className={inputClass} value={clientId} onChange={(e) => setClientId(e.target.value)} />
+          </div>
+          <div>
+            <label className={labelClass}>Client secret</label>
+            <input className={inputClass} type="password" autoComplete="new-password" value={secret} onChange={(e) => setSecret(e.target.value)} />
+          </div>
+          <div className="col-span-2">
+            <label className={labelClass}>Redirect URL</label>
+            <input className={inputClass} value={redirect} onChange={(e) => setRedirect(e.target.value)} />
+          </div>
+          {type === 'custom' && (
+            <>
+              <div>
+                <label className={labelClass}>Authorize URL</label>
+                <input className={inputClass} value={authURL} onChange={(e) => setAuthURL(e.target.value)} />
+              </div>
+              <div>
+                <label className={labelClass}>Token URL</label>
+                <input className={inputClass} value={tokenURL} onChange={(e) => setTokenURL(e.target.value)} />
+              </div>
+            </>
+          )}
+        </div>
+        <p className="text-xs text-neutral-500 mt-2">
+          For known types the authorize/token URLs are filled automatically. Register the redirect URL
+          with the provider character-for-character.
+        </p>
+        <button
+          disabled={saving}
+          onClick={handleCreate}
+          className="mt-3 px-4 py-2 bg-blue-600 hover:bg-blue-700 disabled:opacity-50 text-white text-sm font-semibold rounded-md"
+        >
+          {saving ? 'Saving…' : 'Add provider'}
+        </button>
+      </div>
+
+      {/* List */}
+      <h2 className="text-sm font-semibold text-neutral-800 mb-2">Configured providers</h2>
+      {loading ? (
+        <p className="text-neutral-500">Loading…</p>
+      ) : providers.length === 0 ? (
+        <p className="text-sm text-neutral-500">No providers configured yet.</p>
+      ) : (
+        <div className="space-y-2">
+          {providers.map((p) => (
+            <div key={p.id} className="bg-white border border-neutral-200 rounded-lg p-4 flex items-center justify-between">
+              <div className="min-w-0">
+                <p className="font-medium text-neutral-900 truncate">{p.name} <span className="text-xs text-neutral-500">({p.provider_type})</span></p>
+                <p className="text-xs text-neutral-500 truncate">client: {p.client_id}</p>
+                <p className="text-xs text-neutral-500 truncate">redirect: {p.redirect_url}</p>
+              </div>
+              <button
+                onClick={() => handleDelete(p)}
+                className="ml-4 shrink-0 px-3 py-1.5 text-xs font-medium text-red-600 bg-red-50 border border-red-200 rounded-md hover:bg-red-100"
+              >
+                Delete
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/ui/src/pages/OAuthProvidersPage.tsx
+++ b/ui/src/pages/OAuthProvidersPage.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from 'react'
 import { useUIStore } from '@/store/uiStore'
+import { useAuthStore } from '@/store/authStore'
 import * as oauthService from '@/services/oauthService'
 import type { OAuthProvider } from '@/services/oauthService'
 
@@ -21,6 +22,11 @@ const labelClass = 'block text-xs font-medium text-neutral-600 mb-1'
  */
 export default function OAuthProvidersPage() {
   const { addNotification, showConfirmDialog, hideConfirmDialog } = useUIStore()
+
+  // Provider CRUD endpoints are admin-gated server-side; mirror that in the UI
+  // so non-admins see a read-only view instead of controls that 403.
+  const role = useAuthStore((s) => s.currentTenant?.user_role)
+  const canManage = role === 'owner' || role === 'admin'
 
   const [providers, setProviders] = useState<OAuthProvider[]>([])
   const [loading, setLoading] = useState(true)
@@ -69,7 +75,7 @@ export default function OAuthProvidersPage() {
         name: name.trim(),
         provider_type: type,
         client_id: clientId.trim(),
-        client_secret: secret,
+        client_secret: secret.trim(),
         redirect_url: redirect.trim(),
         ...(type === 'custom' ? { auth_url: authURL.trim(), token_url: tokenURL.trim() } : {}),
       })
@@ -110,7 +116,15 @@ export default function OAuthProvidersPage() {
         pick a provider. Register the redirect URL below with the provider exactly as shown.
       </p>
 
-      {/* Add provider */}
+      {!canManage && (
+        <div className="bg-amber-50 border border-amber-200 text-amber-800 rounded-lg p-4 mb-6 text-sm">
+          Only workspace <strong>owners</strong> and <strong>admins</strong> can register or delete OAuth providers.
+          You can view the configured providers below.
+        </div>
+      )}
+
+      {/* Add provider — owners/admins only */}
+      {canManage && (
       <div className="bg-white border border-neutral-200 rounded-lg p-5 mb-6">
         <h2 className="text-sm font-semibold text-neutral-800 mb-3">Add a provider</h2>
         <div className="grid grid-cols-2 gap-3">
@@ -161,6 +175,7 @@ export default function OAuthProvidersPage() {
           {saving ? 'Saving…' : 'Add provider'}
         </button>
       </div>
+      )}
 
       {/* List */}
       <h2 className="text-sm font-semibold text-neutral-800 mb-2">Configured providers</h2>
@@ -177,12 +192,14 @@ export default function OAuthProvidersPage() {
                 <p className="text-xs text-neutral-500 truncate">client: {p.client_id}</p>
                 <p className="text-xs text-neutral-500 truncate">redirect: {p.redirect_url}</p>
               </div>
-              <button
-                onClick={() => handleDelete(p)}
-                className="ml-4 shrink-0 px-3 py-1.5 text-xs font-medium text-red-600 bg-red-50 border border-red-200 rounded-md hover:bg-red-100"
-              >
-                Delete
-              </button>
+              {canManage && (
+                <button
+                  onClick={() => handleDelete(p)}
+                  className="ml-4 shrink-0 px-3 py-1.5 text-xs font-medium text-red-600 bg-red-50 border border-red-200 rounded-md hover:bg-red-100"
+                >
+                  Delete
+                </button>
+              )}
             </div>
           ))}
         </div>


### PR DESCRIPTION
## Summary

Phase 2 (Connector Ecosystem) follow-on to the merged OAuth framework (#75) and Connector SDK (#83). Three cohesive, OAuth-themed pieces:

- **#79 Salesforce connector (PRs 1 & 2 of 3)** — a SOQL-poll **consumer** and a REST/Bulk **producer**, both on the SDK and authenticated via an OAuth grant.
- **#97 http-producer OAuth output** — deliver to OAuth-protected HTTP endpoints.
- **#100 OAuth provider management** — moved from an inline node form to a proper Settings page.

17 files, +1735/−136. All commits build on the SDK + OAuth that already landed on `main`.

## What's included

### #79 Salesforce connector
- **`cmd/salesforce-consumer`** (PR 1/3) — SDK `Consumer`, command-driven. Resolves the grant's access token via `pkg/oauthtoken`, runs a **SOQL** query against the org's `instance_url` REST API with pagination (`nextRecordsUrl`) + retry-once-on-401, and publishes each page's records. Node config `type:"salesforce"` → `{instance_url, oauth_grant_id, soql, poll_interval_seconds, api_version}`. → satisfies criterion **#1** (connect via OAuth + pull data).
- **`cmd/salesforce-producer`** (PR 2/3) — SDK `Producer` with predecessor routing. Parses the envelope into records, then **REST sObject** insert/upsert for < 200, **Bulk API 2.0** (create job → upload CSV → UploadComplete) for ≥ 200. OAuth token + 401 retry; non-JSON → Permanent, transient → Retriable. → satisfies criterion **#3** (auto Bulk ≥200).
- **UI**: "Salesforce" as both a source and a destination type, with config editors.
- **Deferred to PR 3/3** (blocked on **#81 schema discovery**): CDC/platform events + `describe`-driven field-mapping UI (criterion #2).

### #97 http-producer OAuth output
- `HTTPConfig` gains `auth_type` + `oauth_grant_id`; `sendHTTPRequest` attaches `Authorization: Bearer <token>` for `auth_type=oauth` and force-refreshes + retries once on 401 (mirrors api-consumer). UI: an Authentication selector (None / OAuth 2.0) on the HTTP destination.

### #100 OAuth provider management → Settings
- New **Settings → OAuth providers** page (list / create / delete; admin-gated endpoints). Route + sidebar link. `OAuthGrantSelector` reduced to *selecting* a provider/grant (no inline create form); empty state links to the Settings page.

## Reused infra (no new backend foundations)
`pkg/oauthtoken` (worker token client), the service-token-gated `GET /oauth/grants/{id}/token`, the SDK runner/harness, and the already-registered Salesforce OAuth profile.

## Testing
- **Go**: Docker-less harness tests for all new workers — salesforce-consumer (SOQL round-trip), salesforce-producer (REST insert + Bulk ≥threshold), http-producer (401 → refresh → 200). `go build/vet`, `gofmt`, `make lint-tenant` clean.
- **UI**: `tsc --noEmit` + `vite build` clean.
- **Live**: salesforce-consumer, salesforce-producer, and the rebuilt http-producer all boot **healthy** and subscribe/serve as expected on the docker-compose stack.

## Reviewer notes
- New compose services `salesforce-consumer` / `salesforce-producer` carry `MGMT_API_URL` + `OAUTH_TOKEN_SERVICE_SECRET` for token resolution; http-producer gains the same.
- Salesforce `instance_url` is taken from node config (the grant doesn't capture Salesforce's per-org URL).
- Full Salesforce data-flow requires a real org/sandbox; the worker logic is covered by harness tests. #97 is verifiable end-to-end against `httpbin` (it echoes the injected Bearer header).
- `#79` is intentionally split — PR 3/3 (CDC + describe field mapping) is gated on #81 and not in this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)