### PR TITLE
Schema discovery + visual field mapping — #81

### DIFF
--- a/src/cmd/db-consumer/server.go
+++ b/src/cmd/db-consumer/server.go
@@ -281,7 +281,10 @@ func handleSchema() http.HandlerFunc {
 			Table    string `json:"table"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			http.Error(w, "Invalid JSON", http.StatusBadRequest)
+			// Return JSON (not plain text) so the UI's resp.json() gets a usable message.
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"ok": false, "error": "invalid JSON request body"})
 			return
 		}
 		if req.Table == "" {
@@ -320,9 +323,14 @@ func handleSchema() http.HandlerFunc {
 		for rows.Next() {
 			var name, dataType, isNullable string
 			if err := rows.Scan(&name, &dataType, &isNullable); err != nil {
-				continue
+				writeErr("scan column: " + err.Error())
+				return
 			}
 			fields = append(fields, schemaField{Name: name, Type: dataType, Nullable: isNullable == "YES"})
+		}
+		if err := rows.Err(); err != nil {
+			writeErr("read columns: " + err.Error())
+			return
 		}
 
 		w.Header().Set("Content-Type", "application/json")

--- a/src/cmd/db-consumer/server.go
+++ b/src/cmd/db-consumer/server.go
@@ -238,3 +238,95 @@ func handleSampleData() http.HandlerFunc {
 		_, _ = w.Write(resp)
 	}
 }
+
+// schemaField is one column of the source table, for the UI's schema tree.
+type schemaField struct {
+	Name     string `json:"name"`
+	Type     string `json:"type"`
+	Nullable bool   `json:"nullable"`
+}
+
+// handleSchema returns the column schema (name + SQL type + nullability) of a
+// source table via information_schema. Unlike sample-data it works on empty
+// tables and gives authoritative types. Queries the external source DB only.
+// lint:tenant-ok — connects to the user's source DB, not the management DB.
+func handleSchema() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
+		w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		if r.Method != http.MethodPost {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		writeErr := func(msg string) {
+			w.Header().Set("Content-Type", "application/json")
+			resp, _ := json.Marshal(map[string]interface{}{"ok": false, "error": msg})
+			_, _ = w.Write(resp)
+		}
+
+		var req struct {
+			Host     string `json:"host"`
+			Port     int    `json:"port"`
+			User     string `json:"user"`
+			Password string `json:"password"`
+			Database string `json:"database"`
+			SSLMode  string `json:"sslmode"`
+			Table    string `json:"table"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "Invalid JSON", http.StatusBadRequest)
+			return
+		}
+		if req.Table == "" {
+			writeErr("No table specified")
+			return
+		}
+		if req.Port == 0 {
+			req.Port = 5432
+		}
+		if req.SSLMode == "" {
+			req.SSLMode = "disable"
+		}
+
+		connStr := fmt.Sprintf("host=%s port=%d user=%s password=%s dbname=%s sslmode=%s connect_timeout=5",
+			req.Host, req.Port, req.User, req.Password, req.Database, req.SSLMode)
+
+		db, err := sql.Open("postgres", connStr)
+		if err != nil {
+			writeErr(err.Error())
+			return
+		}
+		defer db.Close()
+
+		rows, err := db.Query(`
+			SELECT column_name, data_type, is_nullable
+			FROM information_schema.columns
+			WHERE table_schema = 'public' AND table_name = $1
+			ORDER BY ordinal_position`, req.Table)
+		if err != nil {
+			writeErr(err.Error())
+			return
+		}
+		defer rows.Close()
+
+		fields := []schemaField{}
+		for rows.Next() {
+			var name, dataType, isNullable string
+			if err := rows.Scan(&name, &dataType, &isNullable); err != nil {
+				continue
+			}
+			fields = append(fields, schemaField{Name: name, Type: dataType, Nullable: isNullable == "YES"})
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		resp, _ := json.Marshal(map[string]interface{}{"ok": true, "fields": fields})
+		_, _ = w.Write(resp)
+	}
+}

--- a/src/cmd/db-consumer/service.go
+++ b/src/cmd/db-consumer/service.go
@@ -64,6 +64,7 @@ func (s *dbConsumer) Configure(ctx context.Context, res *sdk.Resources) error {
 	s.RegisterHTTPHandler("/events/", s.handleEvents())
 	s.RegisterHTTPHandler("/test-connection/", handleTestConnection())
 	s.RegisterHTTPHandler("/sample-data/", handleSampleData())
+	s.RegisterHTTPHandler("/schema/", handleSchema())
 
 	res.Health.SetReady(true)
 	return nil

--- a/src/cmd/file-consumer/schema_csv_test.go
+++ b/src/cmd/file-consumer/schema_csv_test.go
@@ -30,3 +30,21 @@ func TestParseDelimitedSample_Empty(t *testing.T) {
 		t.Errorf("empty input should yield nil headers, got %v", h)
 	}
 }
+
+func TestParseDelimitedSample_DupAndBlankHeaders(t *testing.T) {
+	csv := []byte("id,,id,name\n1,x,2,Acme\n")
+	headers, row := parseDelimitedSample(csv, ',')
+	want := []string{"id", "column_2", "id_2", "name"}
+	if len(headers) != len(want) {
+		t.Fatalf("headers = %v, want %v", headers, want)
+	}
+	for i := range want {
+		if headers[i] != want[i] {
+			t.Errorf("headers[%d] = %q, want %q", i, headers[i], want[i])
+		}
+	}
+	// Values map onto the de-duplicated keys.
+	if row["id"] != "1" || row["id_2"] != "2" || row["column_2"] != "x" || row["name"] != "Acme" {
+		t.Errorf("row = %v", row)
+	}
+}

--- a/src/cmd/file-consumer/schema_csv_test.go
+++ b/src/cmd/file-consumer/schema_csv_test.go
@@ -1,0 +1,32 @@
+package main
+
+import "testing"
+
+func TestParseDelimitedSample_CSV(t *testing.T) {
+	csv := []byte("id,name,city\n1,Acme,Bicester\n2,Globex,Oslo\n")
+	headers, row := parseDelimitedSample(csv, ',')
+	if len(headers) != 3 || headers[0] != "id" || headers[2] != "city" {
+		t.Fatalf("headers = %v, want [id name city]", headers)
+	}
+	if row["name"] != "Acme" || row["city"] != "Bicester" {
+		t.Errorf("first row = %v, want Acme/Bicester", row)
+	}
+}
+
+func TestParseDelimitedSample_TSV_HeaderOnly(t *testing.T) {
+	tsv := []byte("col_a\tcol_b\n")
+	headers, row := parseDelimitedSample(tsv, '\t')
+	if len(headers) != 2 || headers[1] != "col_b" {
+		t.Fatalf("headers = %v, want [col_a col_b]", headers)
+	}
+	// No data rows -> empty-string values, keys present.
+	if v, ok := row["col_a"]; !ok || v != "" {
+		t.Errorf("row[col_a] = %q (ok=%v), want empty present", v, ok)
+	}
+}
+
+func TestParseDelimitedSample_Empty(t *testing.T) {
+	if h, _ := parseDelimitedSample([]byte(""), ','); h != nil {
+		t.Errorf("empty input should yield nil headers, got %v", h)
+	}
+}

--- a/src/cmd/file-consumer/server.go
+++ b/src/cmd/file-consumer/server.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"bytes"
+	"encoding/csv"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -14,6 +16,52 @@ import (
 	"github.com/ValueRetail/vrsky/pkg/envelope"
 	"github.com/google/uuid"
 )
+
+// isDelimited reports whether the file is a delimited table (CSV/TSV) we can
+// derive a column schema from.
+func isDelimited(filename string) bool {
+	ext := strings.ToLower(filepath.Ext(filename))
+	return ext == ".csv" || ext == ".tsv"
+}
+
+func delimiterFor(filename string) rune {
+	if strings.EqualFold(filepath.Ext(filename), ".tsv") {
+		return '\t'
+	}
+	return ','
+}
+
+// parseDelimitedSample reads the header row (column names) and the first data
+// row (values) from CSV/TSV bytes. Returns the headers and a header→value map
+// for the first row (empty-string values when there are no data rows), so the
+// UI renders fields with sensible string previews.
+func parseDelimitedSample(payload []byte, delim rune) ([]string, map[string]string) {
+	rd := csv.NewReader(bytes.NewReader(payload))
+	rd.Comma = delim
+	rd.FieldsPerRecord = -1 // tolerate ragged rows
+	rd.LazyQuotes = true
+
+	header, err := rd.Read()
+	if err != nil || len(header) == 0 {
+		return nil, nil
+	}
+	for i := range header {
+		header[i] = strings.TrimSpace(header[i])
+	}
+
+	row := make(map[string]string, len(header))
+	for _, h := range header {
+		row[h] = ""
+	}
+	if rec, err := rd.Read(); err == nil {
+		for i, h := range header {
+			if i < len(rec) {
+				row[h] = rec[i]
+			}
+		}
+	}
+	return header, row
+}
 
 // HTTP handlers served on the SDK auxiliary HTTP port (WORKER_HTTP_PORT, 9200 in
 // compose). Registered in Configure via RegisterHTTPHandler. /health is served
@@ -244,17 +292,27 @@ func (s *fileConsumer) handleSampleData() http.HandlerFunc {
 		}
 
 		resp := map[string]interface{}{"ok": true, "filename": filename}
-		// Prefer parsed JSON when the content looks like JSON; fall back to a
-		// plain text envelope so CSV/XML/log files still render in the preview.
+		// Prefer parsed JSON when the content looks like JSON; for CSV/TSV parse
+		// the header row into fields (so schema discovery shows columns); fall
+		// back to a plain text envelope for everything else.
 		ct := detectContentType(filename, payload)
-		if ct == "application/json" {
+		switch {
+		case ct == "application/json":
 			var parsed interface{}
 			if err := json.Unmarshal(payload, &parsed); err == nil {
 				resp["data"] = parsed
 			} else {
 				resp["data"] = map[string]string{"text": string(payload)}
 			}
-		} else {
+		case isDelimited(filename):
+			headers, firstRow := parseDelimitedSample(payload, delimiterFor(filename))
+			if len(headers) > 0 {
+				resp["columns"] = headers
+				resp["data"] = firstRow // first data row keyed by header (empty strings if no rows)
+			} else {
+				resp["data"] = map[string]string{"text": string(payload), "content_type": ct}
+			}
+		default:
 			resp["data"] = map[string]string{"text": string(payload), "content_type": ct}
 		}
 		w.Header().Set("Content-Type", "application/json")

--- a/src/cmd/file-consumer/server.go
+++ b/src/cmd/file-consumer/server.go
@@ -45,8 +45,21 @@ func parseDelimitedSample(payload []byte, delim rune) ([]string, map[string]stri
 	if err != nil || len(header) == 0 {
 		return nil, nil
 	}
+	// Normalise headers to unique, non-empty names so duplicate/blank columns
+	// don't collide into one schema field (or React key) or overwrite row values.
+	seen := make(map[string]int, len(header))
 	for i := range header {
-		header[i] = strings.TrimSpace(header[i])
+		name := strings.TrimSpace(header[i])
+		if name == "" {
+			name = fmt.Sprintf("column_%d", i+1)
+		}
+		if n := seen[name]; n > 0 {
+			seen[name] = n + 1
+			name = fmt.Sprintf("%s_%d", name, n+1)
+		} else {
+			seen[name] = 1
+		}
+		header[i] = name
 	}
 
 	row := make(map[string]string, len(header))

--- a/ui/node_modules/.package-lock.json
+++ b/ui/node_modules/.package-lock.json
@@ -536,45 +536,6 @@
         "node": ">=20.19.0"
       }
     },
-    "node_modules/@dnd-kit/accessibility": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
-      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0"
-      }
-    },
-    "node_modules/@dnd-kit/core": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
-      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@dnd-kit/accessibility": "^3.1.1",
-        "@dnd-kit/utilities": "^3.2.2",
-        "tslib": "^2.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
-      }
-    },
-    "node_modules/@dnd-kit/utilities": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
-      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0"
-      }
-    },
     "node_modules/@esbuild/darwin-arm64": {
       "version": "0.27.3",
       "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
@@ -6175,12 +6136,6 @@
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "dev": true,
       "license": "Apache-2.0"
-    },
-    "node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/ui/node_modules/.package-lock.json
+++ b/ui/node_modules/.package-lock.json
@@ -536,6 +536,45 @@
         "node": ">=20.19.0"
       }
     },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
     "node_modules/@esbuild/darwin-arm64": {
       "version": "0.27.3",
       "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
@@ -6136,6 +6175,12 @@
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -8,6 +8,7 @@
       "name": "ui",
       "version": "0.0.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
         "cytoscape": "^3.33.1",
         "konva": "^10.2.0",
         "react": "^18.3.1",
@@ -574,6 +575,45 @@
       "license": "MIT",
       "engines": {
         "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -6937,6 +6977,12 @@
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -14,6 +14,7 @@
     "test:ui": "vitest --ui"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
     "cytoscape": "^3.33.1",
     "konva": "^10.2.0",
     "react": "^18.3.1",

--- a/ui/src/components/Pipeline/PropertyEditor.tsx
+++ b/ui/src/components/Pipeline/PropertyEditor.tsx
@@ -6,6 +6,8 @@ import OAuthGrantSelector from './OAuthGrantSelector'
 import { useAuthStore } from '../../store/authStore'
 import * as tenantDataService from '../../services/tenantDataService'
 import type { TenantDataConnection, DataConnectionRequest } from '../../types/models'
+import { SchemaTree } from './SchemaTree'
+import { discoverSchema, type SchemaField } from './schemaDiscovery'
 
 // Walk upstream from a node via edges, returning the first ancestor that's
 // an 'input' (consumer). Returns undefined if none reachable.
@@ -2248,12 +2250,14 @@ function ConverterConfig({
   allNodes,
   allEdges,
   currentNodeId,
+  deployedConnectionId,
 }: {
   config: Record<string, unknown>
   setConfig: (config: Record<string, unknown>) => void
   allNodes?: Node[]
   allEdges?: Edge[]
   currentNodeId?: string
+  deployedConnectionId?: string
 }) {
   const outputFormat = (config.output_format as string) || ''
   const csvDelimiter = (config.csv_delimiter as string) || ','
@@ -2267,6 +2271,9 @@ function ConverterConfig({
   const [previewOutput, setPreviewOutput] = useState('')
   const [previewing, setPreviewing] = useState(false)
   const [fetchingSample, setFetchingSample] = useState(false)
+  const [schemaFields, setSchemaFields] = useState<SchemaField[]>([])
+  const [discovering, setDiscovering] = useState(false)
+  const [schemaError, setSchemaError] = useState('')
 
   // Get the consumer that actually feeds this converter (walk edges upstream)
   const consumerNode = (currentNodeId && allNodes && allEdges)
@@ -2333,6 +2340,28 @@ function ConverterConfig({
     setConfig({
       ...config,
       mappings: [...mappings, { source: '', target: '', type: 'rename' }],
+    })
+  }
+
+  const runDiscoverSchema = async () => {
+    setDiscovering(true)
+    setSchemaError('')
+    try {
+      const fields = await discoverSchema(consumerType, consumerConfig, { deployedConnectionId })
+      setSchemaFields(fields)
+      if (fields.length === 0) setSchemaError('No fields found in the sample.')
+    } catch (err) {
+      setSchemaFields([])
+      setSchemaError(err instanceof Error ? err.message : 'Schema discovery failed')
+    }
+    setDiscovering(false)
+  }
+
+  // Append a mapping from a picked source field (rename source → its own name).
+  const addMappingFromField = (field: SchemaField) => {
+    setConfig({
+      ...config,
+      mappings: [...mappings, { source: field.path, target: field.name, type: 'rename' }],
     })
   }
 
@@ -2417,6 +2446,29 @@ function ConverterConfig({
           <p className="text-xs text-neutral-500">Use <code className="bg-neutral-100 px-1 rounded">{'{field_name}'}</code> to insert field values. One line per row.</p>
         </>
       )}
+
+      {/* Source schema discovery (#81) — discover the upstream fields + types, click to map */}
+      <div style={{ borderTop: '1px solid #e5e7eb', paddingTop: '8px', marginTop: '8px' }}>
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '4px' }}>
+          <div style={{ fontSize: '12px', fontWeight: 600, color: '#374151' }}>Source schema</div>
+          <button
+            onClick={runDiscoverSchema}
+            disabled={discovering}
+            style={{ fontSize: '11px', padding: '2px 8px', backgroundColor: '#eef2ff', border: '1px solid #c7d2fe', borderRadius: '4px', cursor: discovering ? 'not-allowed' : 'pointer', color: '#3730a3', fontWeight: 600 }}
+          >
+            {discovering ? 'Discovering…' : 'Discover schema'}
+          </button>
+        </div>
+        {schemaError && <div style={{ fontSize: '11px', color: '#b45309', marginBottom: '4px' }}>{schemaError}</div>}
+        {schemaFields.length > 0 && (
+          <>
+            <SchemaTree fields={schemaFields} onPick={addMappingFromField} />
+            <div style={{ fontSize: '11px', color: '#6b7280', marginTop: '4px' }}>
+              Click <strong>+</strong> on a field to add it as a mapping.
+            </div>
+          </>
+        )}
+      </div>
 
       {/* Field Mappings - optional, applied before format conversion */}
       <div style={{ borderTop: '1px solid #e5e7eb', paddingTop: '8px', marginTop: '8px' }}>
@@ -3259,7 +3311,7 @@ export default function PropertyEditor({
 
       case 'converter':
         return (
-          <ConverterConfig config={config} setConfig={setConfig} allNodes={allNodes} allEdges={allEdges} currentNodeId={node.id} />
+          <ConverterConfig config={config} setConfig={setConfig} allNodes={allNodes} allEdges={allEdges} currentNodeId={node.id} deployedConnectionId={deployedConnectionId} />
         )
 
       case 'filter':

--- a/ui/src/components/Pipeline/PropertyEditor.tsx
+++ b/ui/src/components/Pipeline/PropertyEditor.tsx
@@ -1,4 +1,15 @@
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect, useRef, type ReactNode } from 'react'
+import {
+  DndContext,
+  DragOverlay,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  useDraggable,
+  useDroppable,
+  type DragEndEvent,
+  type DragStartEvent,
+} from '@dnd-kit/core'
 import type { Node, Edge } from '../../types/pipeline'
 import SecretInput from './SecretInput'
 import WebhookSignatureConfig from './WebhookSignatureConfig'
@@ -2244,6 +2255,41 @@ function FilterConfig({
   )
 }
 
+// --- Drag-and-drop field mapping (#81 PR2) ---
+// A draggable wrapper around a SchemaTree field row. PointerSensor uses an
+// activation distance so the row's expand/pick buttons still receive clicks.
+function DraggableField({ field, children }: { field: SchemaField; children: ReactNode }) {
+  const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
+    id: `field:${field.path}`,
+    data: { field },
+  })
+  return (
+    <div ref={setNodeRef} {...attributes} {...listeners} style={{ cursor: 'grab', opacity: isDragging ? 0.4 : 1 }}>
+      {children}
+    </div>
+  )
+}
+
+// A mapping row as a drop target — dropping a field sets that row's source.
+function DroppableMapping({ index, children }: { index: number; children: ReactNode }) {
+  const { setNodeRef, isOver } = useDroppable({ id: `mapping:${index}` })
+  return (
+    <div ref={setNodeRef} style={{ outline: isOver ? '2px solid #7c3aed' : 'none', outlineOffset: '2px', borderRadius: '6px' }}>
+      {children}
+    </div>
+  )
+}
+
+// Drop zone that appends a new mapping from the dropped field.
+function DropToAddMapping({ children }: { children: ReactNode }) {
+  const { setNodeRef, isOver } = useDroppable({ id: 'mapping-new' })
+  return (
+    <div ref={setNodeRef} style={{ outline: isOver ? '2px dashed #7c3aed' : 'none', outlineOffset: '2px', borderRadius: '6px' }}>
+      {children}
+    </div>
+  )
+}
+
 function ConverterConfig({
   config,
   setConfig,
@@ -2274,6 +2320,9 @@ function ConverterConfig({
   const [schemaFields, setSchemaFields] = useState<SchemaField[]>([])
   const [discovering, setDiscovering] = useState(false)
   const [schemaError, setSchemaError] = useState('')
+  const [activeField, setActiveField] = useState<SchemaField | null>(null)
+  // Activation distance so clicks on the tree's expand/pick buttons still work.
+  const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 6 } }))
 
   // Get the consumer that actually feeds this converter (walk edges upstream)
   const consumerNode = (currentNodeId && allNodes && allEdges)
@@ -2402,6 +2451,25 @@ function ConverterConfig({
     })
   }
 
+  const onDragStart = (e: DragStartEvent) => {
+    setActiveField((e.active.data.current?.field as SchemaField | undefined) || null)
+  }
+
+  const onDragEnd = (e: DragEndEvent) => {
+    setActiveField(null)
+    const field = e.active.data.current?.field as SchemaField | undefined
+    const overId = e.over?.id
+    if (!field || !overId) return
+    if (overId === 'mapping-new') {
+      addMappingFromField(field)
+    } else if (typeof overId === 'string' && overId.startsWith('mapping:')) {
+      const idx = parseInt(overId.slice('mapping:'.length), 10)
+      if (!Number.isNaN(idx)) {
+        updateMapping(idx, { source: field.path, target: mappings[idx]?.target || field.name })
+      }
+    }
+  }
+
   const removeMapping = (index: number) => {
     setConfig({
       ...config,
@@ -2433,6 +2501,7 @@ function ConverterConfig({
   }
 
   return (
+    <DndContext sensors={sensors} onDragStart={onDragStart} onDragEnd={onDragEnd}>
     <div className="space-y-3">
       {/* Output Format */}
       <StyledSelect
@@ -2499,9 +2568,13 @@ function ConverterConfig({
         {schemaError && <div style={{ fontSize: '11px', color: '#b45309', marginBottom: '4px' }}>{schemaError}</div>}
         {schemaFields.length > 0 && (
           <>
-            <SchemaTree fields={schemaFields} onPick={addMappingFromField} />
+            <SchemaTree
+              fields={schemaFields}
+              onPick={addMappingFromField}
+              renderField={(field, row) => <DraggableField field={field}>{row}</DraggableField>}
+            />
             <div style={{ fontSize: '11px', color: '#6b7280', marginTop: '4px' }}>
-              Click <strong>+</strong> on a field to add it as a mapping.
+              <strong>Drag</strong> a field onto a mapping (or the add zone), or click <strong>+</strong> to map it.
             </div>
           </>
         )}
@@ -2514,7 +2587,8 @@ function ConverterConfig({
         </div>
 
         {mappings.map((m, i) => (
-          <div key={i} style={{ backgroundColor: '#f9fafb', border: '1px solid #e5e7eb', borderRadius: '6px', padding: '8px', marginBottom: '6px' }}>
+          <DroppableMapping key={i} index={i}>
+          <div style={{ backgroundColor: '#f9fafb', border: '1px solid #e5e7eb', borderRadius: '6px', padding: '8px', marginBottom: '6px' }}>
             <div style={{ display: 'flex', alignItems: 'center', gap: '4px', marginBottom: '6px' }}>
               <select
                 value={m.type || 'rename'}
@@ -2545,14 +2619,17 @@ function ConverterConfig({
               <StyledInput label="Template" placeholder="e.g. {first_name} {last_name}" value={m.expression || ''} onChange={(v) => updateMapping(i, { expression: v })} />
             )}
           </div>
+          </DroppableMapping>
         ))}
 
-        <button
-          onClick={addMapping}
-          style={{ width: '100%', padding: '6px 12px', fontSize: '12px', fontWeight: 600, backgroundColor: '#f3f4f6', color: '#374151', border: '1px dashed #d1d5db', borderRadius: '6px', cursor: 'pointer' }}
-        >
-          + Add Mapping
-        </button>
+        <DropToAddMapping>
+          <button
+            onClick={addMapping}
+            style={{ width: '100%', padding: '6px 12px', fontSize: '12px', fontWeight: 600, backgroundColor: '#f3f4f6', color: '#374151', border: '1px dashed #d1d5db', borderRadius: '6px', cursor: 'pointer' }}
+          >
+            + Add Mapping
+          </button>
+        </DropToAddMapping>
 
         <label style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '12px', color: '#374151', marginTop: '8px' }}>
           <input type="checkbox" checked={dropUnmapped} onChange={(e) => setConfig({ ...config, drop_unmapped: e.target.checked })} />
@@ -2592,6 +2669,14 @@ function ConverterConfig({
         )}
       </div>
     </div>
+    <DragOverlay>
+      {activeField ? (
+        <div style={{ fontFamily: 'monospace', fontSize: '12px', background: '#7c3aed', color: '#fff', borderRadius: '4px', padding: '2px 8px', boxShadow: '0 2px 6px rgba(0,0,0,0.2)' }}>
+          {activeField.path}
+        </div>
+      ) : null}
+    </DragOverlay>
+    </DndContext>
   )
 }
 

--- a/ui/src/components/Pipeline/PropertyEditor.tsx
+++ b/ui/src/components/Pipeline/PropertyEditor.tsx
@@ -2464,7 +2464,7 @@ function ConverterConfig({
       addMappingFromField(field)
     } else if (typeof overId === 'string' && overId.startsWith('mapping:')) {
       const idx = parseInt(overId.slice('mapping:'.length), 10)
-      if (!Number.isNaN(idx)) {
+      if (!Number.isNaN(idx) && idx >= 0 && idx < mappings.length) {
         updateMapping(idx, { source: field.path, target: mappings[idx]?.target || field.name })
       }
     }

--- a/ui/src/components/Pipeline/PropertyEditor.tsx
+++ b/ui/src/components/Pipeline/PropertyEditor.tsx
@@ -2323,6 +2323,43 @@ function ConverterConfig({
         } else {
           setPreviewInput('// Error: ' + (data.error || 'No files in watch directory'))
         }
+      } else if (consumerType === 'api') {
+        const api = (consumerConfig.api as { base_url?: string; endpoints?: Array<Record<string, unknown>> }) || {}
+        const ep = api.endpoints?.[0]
+        if (!api.base_url || !ep) {
+          setPreviewInput('// Set the API base URL and an endpoint on the input first')
+          return
+        }
+        const resp = await fetch('http://localhost:9800/sample-data/', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            base_url: api.base_url, path: (ep.path as string) || '/', params: (ep.params as string) || '',
+            auth_type: (ep.auth_type as string) || 'none', auth_value: (ep.auth_value as string) || '',
+          }),
+        })
+        const data = await resp.json()
+        setPreviewInput(data.ok ? JSON.stringify(data.data, null, 2) : '// Error: ' + (data.error || 'No data'))
+      } else if (consumerType === 'tenant') {
+        const t = (consumerConfig.tenant as { source_tenant_id?: string; source_connection_id?: string }) || {}
+        if (!t.source_tenant_id) {
+          setPreviewInput('// Configure the tenant data source first')
+          return
+        }
+        const { default: apiClient } = await import('../../services/api')
+        const params = new URLSearchParams({ source_tenant_id: t.source_tenant_id })
+        if (t.source_connection_id) params.set('source_connection_id', t.source_connection_id)
+        const resp = await apiClient.get(`/api/v1/sample-data/source?${params.toString()}`)
+        setPreviewInput(resp.data?.ok ? JSON.stringify(resp.data.data, null, 2) : '// Error: ' + (resp.data?.error || 'No data'))
+      } else {
+        // http / webhook and others: only a deployed connection has a sample.
+        if (!deployedConnectionId) {
+          setPreviewInput('// Deploy the pipeline and send data once, then fetch the sample')
+          return
+        }
+        const { default: apiClient } = await import('../../services/api')
+        const resp = await apiClient.get(`/api/v1/connections/${deployedConnectionId}/sample-data`)
+        setPreviewInput(resp.data?.ok ? JSON.stringify(resp.data.data, null, 2) : '// Error: ' + (resp.data?.error || 'No sample yet'))
       }
     } catch (err) {
       setPreviewInput('// Error fetching sample: ' + (err instanceof Error ? err.message : 'unknown'))
@@ -2527,7 +2564,7 @@ function ConverterConfig({
       <div style={{ borderTop: '1px solid #e5e7eb', paddingTop: '8px', marginTop: '8px' }}>
         <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '4px' }}>
           <div style={{ fontSize: '12px', fontWeight: 600, color: '#374151' }}>Preview</div>
-          {consumerType === 'database' && (
+          {consumerNode && (
             <button
               onClick={fetchSampleData}
               disabled={fetchingSample}
@@ -2541,7 +2578,7 @@ function ConverterConfig({
           value={previewInput}
           onChange={(e) => setPreviewInput(e.target.value)}
           style={{ width: '100%', height: '80px', padding: '6px 8px', fontSize: '11px', fontFamily: 'monospace', border: '1px solid #d1d5db', borderRadius: '4px', resize: 'vertical', boxSizing: 'border-box' }}
-          placeholder={consumerType === 'database' ? 'Click "Fetch from Input" to load real data, or paste JSON here' : '[{"field": "value"}]'}
+          placeholder={consumerNode ? 'Click "Fetch from Input" to load real data, or paste JSON here' : '[{"field": "value"}]'}
         />
         <button
           onClick={runPreview}

--- a/ui/src/components/Pipeline/SchemaTree.tsx
+++ b/ui/src/components/Pipeline/SchemaTree.tsx
@@ -3,8 +3,23 @@
 // — it consumes SchemaField[] produced by inferSchema (JSON sources) or the DB
 // information_schema endpoint. PR2 layers drag-and-drop via the renderField slot
 // without touching this component.
-import { useMemo, useState, type ReactNode } from 'react'
+import { useEffect, useMemo, useState, type ReactNode } from 'react'
 import type { SchemaField, SchemaFieldType } from './schema'
+
+// seedExpanded returns the set of paths to expand by default (top two levels).
+function seedExpanded(fields: SchemaField[]): Set<string> {
+  const s = new Set<string>()
+  const walk = (fs: SchemaField[], depth: number) => {
+    for (const f of fs) {
+      if (f.children && depth < 1) {
+        s.add(f.path)
+        walk(f.children, depth + 1)
+      }
+    }
+  }
+  walk(fields, 0)
+  return s
+}
 
 const BADGE: Record<SchemaFieldType, { bg: string; fg: string }> = {
   string: { bg: '#e0e7ff', fg: '#3730a3' },
@@ -46,20 +61,12 @@ export function SchemaTree({
   emptyHint?: string
 }) {
   const [search, setSearch] = useState('')
-  // Default-expand the top two levels so the tree is immediately useful.
-  const [expanded, setExpanded] = useState<Set<string>>(() => {
-    const s = new Set<string>()
-    const seed = (fs: SchemaField[], depth: number) => {
-      for (const f of fs) {
-        if (f.children && depth < 1) {
-          s.add(f.path)
-          seed(f.children, depth + 1)
-        }
-      }
-    }
-    seed(fields, 0)
-    return s
-  })
+  // Default-expand the top two levels so the tree is immediately useful, and
+  // re-seed whenever a fresh schema is discovered (the fields prop changes).
+  const [expanded, setExpanded] = useState<Set<string>>(() => seedExpanded(fields))
+  useEffect(() => {
+    setExpanded(seedExpanded(fields))
+  }, [fields])
   const q = search.trim().toLowerCase()
 
   const toggle = (path: string) =>

--- a/ui/src/components/Pipeline/SchemaTree.tsx
+++ b/ui/src/components/Pipeline/SchemaTree.tsx
@@ -1,0 +1,137 @@
+// SchemaTree renders a source field tree (#81): types as colored badges,
+// expand/collapse, search, and a per-field "pick" action. It's source-agnostic
+// — it consumes SchemaField[] produced by inferSchema (JSON sources) or the DB
+// information_schema endpoint. PR2 layers drag-and-drop via the renderField slot
+// without touching this component.
+import { useMemo, useState, type ReactNode } from 'react'
+import type { SchemaField, SchemaFieldType } from './schema'
+
+const BADGE: Record<SchemaFieldType, { bg: string; fg: string }> = {
+  string: { bg: '#e0e7ff', fg: '#3730a3' },
+  number: { bg: '#dcfce7', fg: '#166534' },
+  boolean: { bg: '#f3e8ff', fg: '#6b21a8' },
+  object: { bg: '#fef3c7', fg: '#92400e' },
+  array: { bg: '#fed7aa', fg: '#9a3412' },
+  null: { bg: '#f1f5f9', fg: '#64748b' },
+  unknown: { bg: '#f1f5f9', fg: '#64748b' },
+}
+
+function TypeBadge({ type }: { type: SchemaFieldType }) {
+  const c = BADGE[type]
+  return (
+    <span style={{ fontSize: '10px', fontWeight: 600, color: c.fg, background: c.bg, borderRadius: '3px', padding: '1px 5px', fontFamily: 'monospace' }}>
+      {type}
+    </span>
+  )
+}
+
+// matches returns true if the field or any descendant path/name contains q.
+function matches(f: SchemaField, q: string): boolean {
+  if (!q) return true
+  if (f.path.toLowerCase().includes(q) || f.name.toLowerCase().includes(q)) return true
+  return (f.children || []).some((c) => matches(c, q))
+}
+
+export function SchemaTree({
+  fields,
+  onPick,
+  renderField,
+  emptyHint,
+}: {
+  fields: SchemaField[]
+  /** Called when the user clicks the pick (+) action on a field. */
+  onPick?: (field: SchemaField) => void
+  /** Optional wrapper around a field's row (e.g. to make it draggable in PR2). */
+  renderField?: (field: SchemaField, defaultRow: ReactNode) => ReactNode
+  emptyHint?: string
+}) {
+  const [search, setSearch] = useState('')
+  // Default-expand the top two levels so the tree is immediately useful.
+  const [expanded, setExpanded] = useState<Set<string>>(() => {
+    const s = new Set<string>()
+    const seed = (fs: SchemaField[], depth: number) => {
+      for (const f of fs) {
+        if (f.children && depth < 1) {
+          s.add(f.path)
+          seed(f.children, depth + 1)
+        }
+      }
+    }
+    seed(fields, 0)
+    return s
+  })
+  const q = search.trim().toLowerCase()
+
+  const toggle = (path: string) =>
+    setExpanded((prev) => {
+      const next = new Set(prev)
+      if (next.has(path)) next.delete(path)
+      else next.add(path)
+      return next
+    })
+
+  const visible = useMemo(() => fields.filter((f) => matches(f, q)), [fields, q])
+
+  const renderNode = (field: SchemaField, depth: number): ReactNode => {
+    if (q && !matches(field, q)) return null
+    const hasChildren = !!field.children && field.children.length > 0
+    const isOpen = q ? true : expanded.has(field.path)
+
+    const row = (
+      <div style={{ display: 'flex', alignItems: 'center', gap: '6px', padding: '2px 0', paddingLeft: `${depth * 14}px` }}>
+        {hasChildren ? (
+          <button
+            onClick={() => toggle(field.path)}
+            style={{ border: 'none', background: 'none', cursor: 'pointer', color: '#64748b', width: '12px', padding: 0 }}
+          >
+            {isOpen ? '▾' : '▸'}
+          </button>
+        ) : (
+          <span style={{ width: '12px' }} />
+        )}
+        <span style={{ fontFamily: 'monospace', fontSize: '12px', color: '#111827' }}>{field.name}</span>
+        <TypeBadge type={field.type} />
+        {field.nullable && <span style={{ fontSize: '10px', color: '#94a3b8' }}>nullable</span>}
+        {onPick && (
+          <button
+            title="Add as mapping"
+            onClick={() => onPick(field)}
+            style={{ marginLeft: 'auto', border: '1px solid #cbd5e1', background: '#f8fafc', borderRadius: '3px', cursor: 'pointer', fontSize: '11px', color: '#334155', padding: '0 6px' }}
+          >
+            +
+          </button>
+        )}
+      </div>
+    )
+
+    return (
+      <div key={field.path}>
+        {renderField ? renderField(field, row) : row}
+        {hasChildren && isOpen && (
+          <div style={{ borderLeft: '1px solid #e2e8f0', marginLeft: `${depth * 14 + 5}px` }}>
+            {field.children!.map((c) => renderNode(c, depth + 1))}
+          </div>
+        )}
+      </div>
+    )
+  }
+
+  if (fields.length === 0) {
+    return <div style={{ fontSize: '12px', color: '#94a3b8', padding: '6px' }}>{emptyHint || 'No fields discovered.'}</div>
+  }
+
+  return (
+    <div>
+      <input
+        type="text"
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+        placeholder="Search fields…"
+        style={{ width: '100%', padding: '4px 8px', border: '1px solid #d1d5db', borderRadius: '4px', fontSize: '12px', marginBottom: '6px', boxSizing: 'border-box' }}
+      />
+      <div style={{ maxHeight: '260px', overflowY: 'auto', border: '1px solid #e2e8f0', borderRadius: '4px', padding: '4px 6px', background: '#fff' }}>
+        {visible.map((f) => renderNode(f, 0))}
+      </div>
+    </div>
+  )
+}

--- a/ui/src/components/Pipeline/schema.ts
+++ b/ui/src/components/Pipeline/schema.ts
@@ -1,0 +1,85 @@
+// Schema model + discovery helpers for the visual field-mapping UI (#81).
+//
+// A SchemaField is one node in the source field tree. Types come from the DB
+// information_schema (authoritative) or are inferred client-side from a fetched
+// JSON sample for the other source types.
+
+export type SchemaFieldType =
+  | 'string'
+  | 'number'
+  | 'boolean'
+  | 'object'
+  | 'array'
+  | 'null'
+  | 'unknown'
+
+export interface SchemaField {
+  /** Dot-path from the record root, e.g. "customer.email" (matches the converter's getNestedField). */
+  path: string
+  /** Leaf label (last path segment). */
+  name: string
+  type: SchemaFieldType
+  nullable?: boolean
+  /** Present for object fields. */
+  children?: SchemaField[]
+}
+
+export function jsTypeOf(v: unknown): SchemaFieldType {
+  if (v === null) return 'null'
+  if (Array.isArray(v)) return 'array'
+  switch (typeof v) {
+    case 'string':
+      return 'string'
+    case 'number':
+      return 'number'
+    case 'boolean':
+      return 'boolean'
+    case 'object':
+      return 'object'
+    default:
+      return 'unknown'
+  }
+}
+
+// Coarse bucket for a SQL data_type (information_schema) → drives the badge.
+export function sqlTypeToBadge(sqlType: string): SchemaFieldType {
+  const t = sqlType.toLowerCase()
+  if (/(int|serial|numeric|decimal|real|double|float|money)/.test(t)) return 'number'
+  if (/bool/.test(t)) return 'boolean'
+  if (/(json|jsonb)/.test(t)) return 'object'
+  if (/array/.test(t)) return 'array'
+  return 'string' // text, varchar, char, timestamp, date, uuid, … render as string-ish
+}
+
+// inferSchema builds a field tree from a fetched sample. Arrays (e.g. DB rows)
+// are represented by their first element, since the converter operates per
+// record. Nested objects recurse (dot-path); arrays are leaves (the converter
+// can't index into arrays — the filter's "split into rows" handles those).
+export function inferSchema(sample: unknown): SchemaField[] {
+  let root = sample
+  if (Array.isArray(root)) root = root[0]
+  if (root === null || root === undefined || typeof root !== 'object' || Array.isArray(root)) {
+    return []
+  }
+  return fieldsOf(root as Record<string, unknown>, '')
+}
+
+function fieldsOf(obj: Record<string, unknown>, prefix: string): SchemaField[] {
+  return Object.entries(obj).map(([key, val]) => {
+    const path = prefix ? `${prefix}.${key}` : key
+    const type = jsTypeOf(val)
+    const field: SchemaField = { path, name: key, type }
+    if (type === 'object' && val) {
+      field.children = fieldsOf(val as Record<string, unknown>, path)
+    }
+    return field
+  })
+}
+
+// fieldsFromColumns builds a flat schema from a list of column descriptors
+// (DB information_schema, or CSV headers).
+export function fieldsFromColumns(
+  columns: Array<{ name: string; type?: SchemaFieldType; nullable?: boolean }>,
+): SchemaField[] {
+  return columns.map((c) => ({ path: c.name, name: c.name, type: c.type ?? 'string', nullable: c.nullable }))
+}

--- a/ui/src/components/Pipeline/schemaDiscovery.ts
+++ b/ui/src/components/Pipeline/schemaDiscovery.ts
@@ -1,0 +1,100 @@
+// discoverSchema (#81): fetch a source's field schema for the mapping UI.
+// DB uses the authoritative information_schema endpoint; the other sources reuse
+// the existing /sample-data/ endpoints and infer types client-side.
+import apiClient from '../../services/api'
+import { inferSchema, fieldsFromColumns, sqlTypeToBadge, type SchemaField } from './schema'
+
+export type { SchemaField } from './schema'
+
+interface DBColumn {
+  name: string
+  type?: string
+  nullable?: boolean
+}
+
+// discoverSchema returns the source field tree for the upstream consumer feeding
+// a converter/filter node. Throws with a user-facing message when the source
+// isn't configured or the worker can't be reached.
+export async function discoverSchema(
+  consumerType: string | undefined,
+  consumerConfig: Record<string, unknown> | undefined,
+  opts?: { deployedConnectionId?: string },
+): Promise<SchemaField[]> {
+  if (!consumerType || !consumerConfig) {
+    throw new Error('No upstream source is connected to this node')
+  }
+
+  switch (consumerType) {
+    case 'database': {
+      const dc = (consumerConfig.database as Record<string, unknown>) || {}
+      if (!dc.host || !dc.table) throw new Error('Set the database host and table on the input first')
+      const resp = await fetch('http://localhost:9300/schema/', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          host: dc.host, port: dc.port || 5432, user: dc.user, password: dc.password,
+          database: dc.database, sslmode: dc.sslmode, table: dc.table,
+        }),
+      })
+      const data = await resp.json()
+      if (!data.ok) throw new Error(data.error || 'Schema query failed')
+      const cols = (data.fields as DBColumn[] | undefined) || []
+      return fieldsFromColumns(cols.map((f) => ({ name: f.name, type: sqlTypeToBadge(f.type || ''), nullable: f.nullable })))
+    }
+
+    case 'file': {
+      const fc = (consumerConfig.file as Record<string, unknown>) || {}
+      if (!fc.path) throw new Error('Set a watch directory on the file input first')
+      const resp = await fetch('http://localhost:9200/sample-data/', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ path: fc.path }),
+      })
+      const data = await resp.json()
+      if (!data.ok) throw new Error(data.error || 'No files in the watch directory')
+      const columns = data.columns as string[] | undefined
+      if (Array.isArray(columns) && columns.length > 0) {
+        return fieldsFromColumns(columns.map((c) => ({ name: c, type: 'string' as const })))
+      }
+      return inferSchema(data.data)
+    }
+
+    case 'api': {
+      const api = (consumerConfig.api as { base_url?: string; endpoints?: Array<Record<string, unknown>> }) || {}
+      const ep = api.endpoints?.[0]
+      if (!api.base_url || !ep) throw new Error('Set the API base URL and an endpoint first')
+      const resp = await fetch('http://localhost:9800/sample-data/', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          base_url: api.base_url, path: (ep.path as string) || '/', params: (ep.params as string) || '',
+          auth_type: (ep.auth_type as string) || 'none', auth_value: (ep.auth_value as string) || '',
+        }),
+      })
+      const data = await resp.json()
+      if (!data.ok) throw new Error(data.error || 'Sample request failed')
+      return inferSchema(data.data)
+    }
+
+    case 'tenant': {
+      const t = (consumerConfig.tenant as { source_tenant_id?: string; source_connection_id?: string }) || {}
+      if (!t.source_tenant_id) throw new Error('Configure the tenant data source first')
+      const params = new URLSearchParams({ source_tenant_id: t.source_tenant_id })
+      if (t.source_connection_id) params.set('source_connection_id', t.source_connection_id)
+      const resp = await apiClient.get(`/api/v1/sample-data/source?${params.toString()}`)
+      if (!resp.data?.ok) throw new Error(resp.data?.error || 'Sample request failed')
+      return inferSchema(resp.data.data)
+    }
+
+    default: {
+      // http / webhook (and anything else): the only sample is a deployed
+      // connection's last payload.
+      if (!opts?.deployedConnectionId) {
+        throw new Error('Deploy the pipeline and send data once, then discover the schema')
+      }
+      const resp = await apiClient.get(`/api/v1/connections/${opts.deployedConnectionId}/sample-data`)
+      if (!resp.data?.ok) throw new Error(resp.data?.error || 'No sample payload yet')
+      return inferSchema(resp.data.data)
+    }
+  }
+}

--- a/ui/src/components/Pipeline/schemaDiscovery.ts
+++ b/ui/src/components/Pipeline/schemaDiscovery.ts
@@ -12,6 +12,30 @@ interface DBColumn {
   nullable?: boolean
 }
 
+// postJSON POSTs to a worker aux endpoint and parses JSON, surfacing a readable
+// error for non-2xx / non-JSON responses (e.g. a proxy HTML error page) instead
+// of an opaque SyntaxError.
+async function postJSON(url: string, body: unknown): Promise<Record<string, unknown>> {
+  let resp: Response
+  try {
+    resp = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    })
+  } catch {
+    throw new Error('Could not reach the connector — is the worker running?')
+  }
+  if (!resp.ok) {
+    throw new Error(`Connector responded ${resp.status}`)
+  }
+  try {
+    return await resp.json()
+  } catch {
+    throw new Error('Connector returned a non-JSON response')
+  }
+}
+
 // discoverSchema returns the source field tree for the upstream consumer feeding
 // a converter/filter node. Throws with a user-facing message when the source
 // isn't configured or the worker can't be reached.
@@ -28,16 +52,11 @@ export async function discoverSchema(
     case 'database': {
       const dc = (consumerConfig.database as Record<string, unknown>) || {}
       if (!dc.host || !dc.table) throw new Error('Set the database host and table on the input first')
-      const resp = await fetch('http://localhost:9300/schema/', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          host: dc.host, port: dc.port || 5432, user: dc.user, password: dc.password,
-          database: dc.database, sslmode: dc.sslmode, table: dc.table,
-        }),
+      const data = await postJSON('http://localhost:9300/schema/', {
+        host: dc.host, port: dc.port || 5432, user: dc.user, password: dc.password,
+        database: dc.database, sslmode: dc.sslmode, table: dc.table,
       })
-      const data = await resp.json()
-      if (!data.ok) throw new Error(data.error || 'Schema query failed')
+      if (!data.ok) throw new Error((data.error as string) || 'Schema query failed')
       const cols = (data.fields as DBColumn[] | undefined) || []
       return fieldsFromColumns(cols.map((f) => ({ name: f.name, type: sqlTypeToBadge(f.type || ''), nullable: f.nullable })))
     }
@@ -45,13 +64,8 @@ export async function discoverSchema(
     case 'file': {
       const fc = (consumerConfig.file as Record<string, unknown>) || {}
       if (!fc.path) throw new Error('Set a watch directory on the file input first')
-      const resp = await fetch('http://localhost:9200/sample-data/', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ path: fc.path }),
-      })
-      const data = await resp.json()
-      if (!data.ok) throw new Error(data.error || 'No files in the watch directory')
+      const data = await postJSON('http://localhost:9200/sample-data/', { path: fc.path })
+      if (!data.ok) throw new Error((data.error as string) || 'No files in the watch directory')
       const columns = data.columns as string[] | undefined
       if (Array.isArray(columns) && columns.length > 0) {
         return fieldsFromColumns(columns.map((c) => ({ name: c, type: 'string' as const })))
@@ -63,16 +77,11 @@ export async function discoverSchema(
       const api = (consumerConfig.api as { base_url?: string; endpoints?: Array<Record<string, unknown>> }) || {}
       const ep = api.endpoints?.[0]
       if (!api.base_url || !ep) throw new Error('Set the API base URL and an endpoint first')
-      const resp = await fetch('http://localhost:9800/sample-data/', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          base_url: api.base_url, path: (ep.path as string) || '/', params: (ep.params as string) || '',
-          auth_type: (ep.auth_type as string) || 'none', auth_value: (ep.auth_value as string) || '',
-        }),
+      const data = await postJSON('http://localhost:9800/sample-data/', {
+        base_url: api.base_url, path: (ep.path as string) || '/', params: (ep.params as string) || '',
+        auth_type: (ep.auth_type as string) || 'none', auth_value: (ep.auth_value as string) || '',
       })
-      const data = await resp.json()
-      if (!data.ok) throw new Error(data.error || 'Sample request failed')
+      if (!data.ok) throw new Error((data.error as string) || 'Sample request failed')
       return inferSchema(data.data)
     }
 


### PR DESCRIPTION
Closes #81. Point-and-click field handling: **Discover schema** on any source → a typed field tree, then **drag** (or click) source fields onto converter targets to build a mapping — no hand-typing JSON paths. Also **unblocks #79** (Salesforce field mapping from live schema).

Much of the plumbing already existed (per-source `/sample-data/` endpoints, a JSON tree in the Filter editor, the converter `mappings[]` + preview). This PR adds the typed schema layer + the drag-and-drop mapping on top.

### Backend (`c215b5e`)
- **db-consumer** `/schema/`: column name + SQL `data_type` + nullability via `information_schema.columns` (authoritative types, works on empty tables). Queries the external source DB only (`lint:tenant-ok`), mirroring the existing `/test-connection/` + `/sample-data/` handlers.
- **file-consumer**: `/sample-data/` now parses CSV/TSV headers into `columns` + a first-row preview (JSON behaviour unchanged). Pure parser unit-tested.

### UI — schema discovery (`8bde8e8`, `815cd37`)
- `schema.ts`: `SchemaField` model + `inferSchema` (client-side type inference for JSON sources) + `sqlTypeToBadge`.
- `schemaDiscovery.ts`: `discoverSchema(consumerType, config)` — DB via `/schema/`, CSV via file columns, api/file/tenant/http-webhook via the existing sample endpoints + inference.
- `SchemaTree.tsx`: recursive tree with colored **type badges**, search, expand/collapse, a per-field pick (+) action, and a `renderField` slot.
- `ConverterConfig`: **"Discover schema"** → typed tree of the upstream source; click **+** to map. Also fixed: the **"Fetch from Input"** preview now works for *all* source types (was DB-only).

### UI — drag-and-drop (`bca9e37`)
- `@dnd-kit/core`: drag a field from the tree onto a mapping row (sets its source) or the "Add Mapping" drop zone (appends a mapping); `DragOverlay` chip; `PointerSensor` activation distance so the tree's buttons still click. Generated config is unchanged, so it round-trips through the existing preview + `data-converter`.

## Acceptance criteria (#81)
- [x] Click "Discover schema" → tree shows fields **with types** (DB / CSV / JSON), well within 3s.
- [x] Drag-mapping produces a valid converter config that round-trips through the platform.

## Verification
- **Go:** build/vet, `go test ./cmd/db-consumer/... ./cmd/file-consumer/...`, tenant-filter lint — all green.
- **UI:** `npm run build` (tsc) + lint on the new files — clean.
- **Live (all confirmed through the UI):** Database→Converter — Discover schema shows the 5 `customers` columns with types; click + and **drag** both create mappings; Test Transform round-trips real rows. CSV file source shows its header columns; API/webhook sources show inferred types.

## Notes
- Unblocks the deferred #79 criterion: a Salesforce `/schema/` (describe) endpoint can later reuse the same `SchemaTree` + DnD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)