### PR TITLE
Salesforce field mapping from live describe — #79

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -554,6 +554,10 @@ services:
       # OAuth token resolution (#75): fetch access tokens for the configured grant.
       MGMT_API_URL: "http://management-api:3000"
       OAUTH_TOKEN_SERVICE_SECRET: "${OAUTH_TOKEN_SERVICE_SECRET:-dev-oauth-service-secret-change-me}"
+      # Aux HTTP port serving /schema (describe) + /sample-data for the UI's field mapping (#79).
+      WORKER_HTTP_PORT: "9700"
+    ports:
+      - "127.0.0.1:9700:9700"
     depends_on:
       nats:
         condition: service_healthy

--- a/src/cmd/salesforce-consumer/schema_test.go
+++ b/src/cmd/salesforce-consumer/schema_test.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestObjectFromSOQL(t *testing.T) {
+	cases := map[string]string{
+		"SELECT Id, Name FROM Account":                         "Account",
+		"select id from contact where x=1":                     "contact",
+		"SELECT Id FROM My_Custom__c ORDER BY CreatedDate":     "My_Custom__c",
+		"SELECT count() FROM Opportunity LIMIT 10":             "Opportunity",
+		"not a query":                                          "",
+		"":                                                     "",
+	}
+	for soql, want := range cases {
+		if got := objectFromSOQL(soql); got != want {
+			t.Errorf("objectFromSOQL(%q) = %q, want %q", soql, got, want)
+		}
+	}
+}
+
+// TestHandleSchema drives the /schema/ handler against a fake Salesforce describe
+// endpoint (token resolution stubbed) and checks the fields are mapped.
+func TestHandleSchema(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/sobjects/Account/describe") {
+			http.Error(w, "unexpected path "+r.URL.Path, http.StatusNotFound)
+			return
+		}
+		if r.Header.Get("Authorization") != "Bearer fake-token" {
+			http.Error(w, "bad auth", http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"name":"Account","fields":[
+			{"name":"Id","type":"id","nillable":false},
+			{"name":"Name","type":"string","nillable":false},
+			{"name":"AnnualRevenue","type":"currency","nillable":true},
+			{"name":"IsDeleted","type":"boolean","nillable":false}
+		]}`))
+	}))
+	defer srv.Close()
+
+	c := &salesforceConsumer{
+		httpClient:   srv.Client(),
+		logger:       slog.Default(),
+		resolveToken: func(context.Context, string, string, bool) (string, error) { return "fake-token", nil },
+	}
+
+	body, _ := json.Marshal(map[string]string{
+		"tenant_id": "tenant-x", "instance_url": srv.URL, "oauth_grant_id": "g1",
+		"soql": "SELECT Id, Name FROM Account",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/schema/", strings.NewReader(string(body)))
+	rec := httptest.NewRecorder()
+	c.handleSchema()(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		OK     bool   `json:"ok"`
+		Object string `json:"object"`
+		Fields []struct {
+			Name     string `json:"name"`
+			Type     string `json:"type"`
+			Nullable bool   `json:"nullable"`
+		} `json:"fields"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !resp.OK || resp.Object != "Account" || len(resp.Fields) != 4 {
+		t.Fatalf("resp = %+v", resp)
+	}
+	if resp.Fields[2].Name != "AnnualRevenue" || resp.Fields[2].Type != "currency" || !resp.Fields[2].Nullable {
+		t.Errorf("AnnualRevenue field = %+v", resp.Fields[2])
+	}
+}
+
+func TestHandleSchema_MissingObject(t *testing.T) {
+	c := &salesforceConsumer{logger: slog.Default()}
+	body, _ := json.Marshal(map[string]string{
+		"tenant_id": "t", "instance_url": "https://x", "oauth_grant_id": "g1", "soql": "not a query",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/schema/", strings.NewReader(string(body)))
+	rec := httptest.NewRecorder()
+	c.handleSchema()(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+}

--- a/src/cmd/salesforce-consumer/schema_test.go
+++ b/src/cmd/salesforce-consumer/schema_test.go
@@ -18,6 +18,10 @@ func TestObjectFromSOQL(t *testing.T) {
 		"SELECT count() FROM Opportunity LIMIT 10":             "Opportunity",
 		"not a query":                                          "",
 		"":                                                     "",
+		// Child-relationship subquery in SELECT — outer object is Account.
+		"SELECT Name, (SELECT LastName FROM Contacts) FROM Account": "Account",
+		// Semi-join subquery in WHERE — outer object is Account.
+		"SELECT Id FROM Account WHERE Id IN (SELECT AccountId FROM Contact)": "Account",
 	}
 	for soql, want := range cases {
 		if got := objectFromSOQL(soql); got != want {

--- a/src/cmd/salesforce-consumer/server.go
+++ b/src/cmd/salesforce-consumer/server.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/url"
 	"regexp"
+	"strconv"
 	"strings"
 )
 
@@ -15,16 +16,52 @@ import (
 // sample (SOQL) for the visual field-mapping UI (#79 / #81). /health is served
 // separately by the SDK on HEALTH_PORT.
 
-// fromClause extracts the SObject from a SOQL query's FROM clause.
-var fromClause = regexp.MustCompile(`(?i)\bfrom\s+([a-zA-Z0-9_]+)`)
+// limitClause matches a SOQL LIMIT and captures its count.
+var limitClause = regexp.MustCompile(`(?i)\blimit\s+(\d+)`)
 
-// objectFromSOQL returns the SObject named in a SOQL query's FROM clause, or "".
+func isIdentByte(b byte) bool {
+	return b == '_' || (b >= '0' && b <= '9') || (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z')
+}
+
+// objectFromSOQL returns the SObject named in a SOQL query's top-level FROM
+// clause, or "". It tracks parenthesis depth so subqueries — whether in the
+// SELECT (child relationships) or the WHERE (semi-joins) — don't shadow the
+// queried object.
 func objectFromSOQL(soql string) string {
-	m := fromClause.FindStringSubmatch(soql)
-	if len(m) < 2 {
-		return ""
+	depth := 0
+	for i := 0; i < len(soql); {
+		switch soql[i] {
+		case '(':
+			depth++
+			i++
+		case ')':
+			if depth > 0 {
+				depth--
+			}
+			i++
+		default:
+			c := soql[i] | 0x20 // ASCII lower
+			if depth == 0 && c == 'f' && i+4 <= len(soql) &&
+				(soql[i+1]|0x20) == 'r' && (soql[i+2]|0x20) == 'o' && (soql[i+3]|0x20) == 'm' &&
+				(i == 0 || !isIdentByte(soql[i-1])) && (i+4 == len(soql) || !isIdentByte(soql[i+4])) {
+				j := i + 4
+				for j < len(soql) && (soql[j] == ' ' || soql[j] == '\t' || soql[j] == '\n' || soql[j] == '\r') {
+					j++
+				}
+				start := j
+				for j < len(soql) && isIdentByte(soql[j]) {
+					j++
+				}
+				if j > start {
+					return soql[start:j]
+				}
+				i = j
+			} else {
+				i++
+			}
+		}
 	}
-	return m[1]
+	return ""
 }
 
 // schemaRequest is the shared request body for /schema/ and /sample-data/.
@@ -146,9 +183,15 @@ func (s *salesforceConsumer) handleSampleData() http.HandlerFunc {
 			writeJSON(w, http.StatusBadRequest, map[string]interface{}{"ok": false, "error": "a SOQL query is required for a sample"})
 			return
 		}
-		soql := req.SOQL
-		if !regexp.MustCompile(`(?i)\blimit\s+\d+`).MatchString(soql) {
-			soql = strings.TrimRight(soql, "; \t\n") + " LIMIT 5"
+		// Always bound a preview to a small page, capping any existing LIMIT.
+		const sampleLimit = 5
+		soql := strings.TrimRight(req.SOQL, "; \t\n")
+		if m := limitClause.FindStringSubmatch(soql); m != nil {
+			if n, err := strconv.Atoi(m[1]); err == nil && n > sampleLimit {
+				soql = limitClause.ReplaceAllString(soql, fmt.Sprintf("LIMIT %d", sampleLimit))
+			}
+		} else {
+			soql += fmt.Sprintf(" LIMIT %d", sampleLimit)
 		}
 
 		base := strings.TrimRight(req.InstanceURL, "/")

--- a/src/cmd/salesforce-consumer/server.go
+++ b/src/cmd/salesforce-consumer/server.go
@@ -1,0 +1,168 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+)
+
+// Aux HTTP handlers served on the SDK auxiliary HTTP port (WORKER_HTTP_PORT,
+// 9700 in compose). Registered in Configure via RegisterHTTPHandler. These let
+// the UI discover a Salesforce object's field schema (describe) and fetch a
+// sample (SOQL) for the visual field-mapping UI (#79 / #81). /health is served
+// separately by the SDK on HEALTH_PORT.
+
+// fromClause extracts the SObject from a SOQL query's FROM clause.
+var fromClause = regexp.MustCompile(`(?i)\bfrom\s+([a-zA-Z0-9_]+)`)
+
+// objectFromSOQL returns the SObject named in a SOQL query's FROM clause, or "".
+func objectFromSOQL(soql string) string {
+	m := fromClause.FindStringSubmatch(soql)
+	if len(m) < 2 {
+		return ""
+	}
+	return m[1]
+}
+
+// schemaRequest is the shared request body for /schema/ and /sample-data/.
+type schemaRequest struct {
+	TenantID     string `json:"tenant_id"`
+	InstanceURL  string `json:"instance_url"`
+	OAuthGrantID string `json:"oauth_grant_id"`
+	APIVersion   string `json:"api_version"`
+	SOQL         string `json:"soql"`
+	Object       string `json:"object"` // optional; derived from SOQL when empty
+}
+
+type sfSchemaField struct {
+	Name     string `json:"name"`
+	Type     string `json:"type"`
+	Nullable bool   `json:"nullable"`
+}
+
+func writeJSON(w http.ResponseWriter, status int, body map[string]interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(body)
+}
+
+// preflight handles CORS preflight + method gating; returns true if the caller
+// should stop (preflight or wrong method already handled).
+func preflight(w http.ResponseWriter, r *http.Request) bool {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
+	w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+	if r.Method == http.MethodOptions {
+		w.WriteHeader(http.StatusNoContent)
+		return true
+	}
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return true
+	}
+	return false
+}
+
+func (s *salesforceConsumer) decodeSchemaRequest(w http.ResponseWriter, r *http.Request) (*schemaRequest, bool) {
+	var req schemaRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]interface{}{"ok": false, "error": "invalid JSON request body"})
+		return nil, false
+	}
+	if req.InstanceURL == "" || req.OAuthGrantID == "" || req.TenantID == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]interface{}{"ok": false, "error": "instance_url, oauth_grant_id and tenant_id are required"})
+		return nil, false
+	}
+	if req.APIVersion == "" {
+		req.APIVersion = defaultAPIVersion
+	}
+	return &req, true
+}
+
+// handleSchema returns a Salesforce object's field schema via the describe API,
+// so the UI's field-mapping tree shows live fields + types.
+func (s *salesforceConsumer) handleSchema() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if preflight(w, r) {
+			return
+		}
+		req, ok := s.decodeSchemaRequest(w, r)
+		if !ok {
+			return
+		}
+		object := req.Object
+		if object == "" {
+			object = objectFromSOQL(req.SOQL)
+		}
+		if object == "" {
+			writeJSON(w, http.StatusBadRequest, map[string]interface{}{"ok": false, "error": "could not determine the Salesforce object (set a SOQL query with a FROM clause)"})
+			return
+		}
+
+		base := strings.TrimRight(req.InstanceURL, "/")
+		describeURL := fmt.Sprintf("%s/services/data/%s/sobjects/%s/describe", base, req.APIVersion, url.PathEscape(object))
+		body, err := s.get(r.Context(), req.TenantID, req.OAuthGrantID, describeURL)
+		if err != nil {
+			writeJSON(w, http.StatusOK, map[string]interface{}{"ok": false, "error": err.Error()})
+			return
+		}
+
+		var describe struct {
+			Fields []struct {
+				Name     string `json:"name"`
+				Type     string `json:"type"`
+				Nillable bool   `json:"nillable"`
+			} `json:"fields"`
+		}
+		if err := json.Unmarshal(body, &describe); err != nil {
+			writeJSON(w, http.StatusOK, map[string]interface{}{"ok": false, "error": "parse describe response: " + err.Error()})
+			return
+		}
+
+		fields := make([]sfSchemaField, 0, len(describe.Fields))
+		for _, f := range describe.Fields {
+			fields = append(fields, sfSchemaField{Name: f.Name, Type: f.Type, Nullable: f.Nillable})
+		}
+		writeJSON(w, http.StatusOK, map[string]interface{}{"ok": true, "object": object, "fields": fields})
+	}
+}
+
+// handleSampleData runs the configured SOQL (bounded by LIMIT) and returns the
+// records, so the Converter's "Fetch from Input" / Test Transform works for a
+// Salesforce source.
+func (s *salesforceConsumer) handleSampleData() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if preflight(w, r) {
+			return
+		}
+		req, ok := s.decodeSchemaRequest(w, r)
+		if !ok {
+			return
+		}
+		if strings.TrimSpace(req.SOQL) == "" {
+			writeJSON(w, http.StatusBadRequest, map[string]interface{}{"ok": false, "error": "a SOQL query is required for a sample"})
+			return
+		}
+		soql := req.SOQL
+		if !regexp.MustCompile(`(?i)\blimit\s+\d+`).MatchString(soql) {
+			soql = strings.TrimRight(soql, "; \t\n") + " LIMIT 5"
+		}
+
+		base := strings.TrimRight(req.InstanceURL, "/")
+		queryURL := fmt.Sprintf("%s/services/data/%s/query/?q=%s", base, req.APIVersion, url.QueryEscape(soql))
+		body, err := s.get(r.Context(), req.TenantID, req.OAuthGrantID, queryURL)
+		if err != nil {
+			writeJSON(w, http.StatusOK, map[string]interface{}{"ok": false, "error": err.Error()})
+			return
+		}
+		var qr queryResponse
+		if err := json.Unmarshal(body, &qr); err != nil {
+			writeJSON(w, http.StatusOK, map[string]interface{}{"ok": false, "error": "parse query response: " + err.Error()})
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]interface{}{"ok": true, "data": qr.Records})
+	}
+}

--- a/src/cmd/salesforce-consumer/service.go
+++ b/src/cmd/salesforce-consumer/service.go
@@ -100,6 +100,10 @@ func (s *salesforceConsumer) Configure(ctx context.Context, res *sdk.Resources) 
 			return s.tokens.Token(ctx, tenantID, grantID)
 		}
 	}
+	// Aux HTTP endpoints for the UI's schema discovery / field mapping (#79).
+	s.RegisterHTTPHandler("/schema/", s.handleSchema())
+	s.RegisterHTTPHandler("/sample-data/", s.handleSampleData())
+
 	res.Health.SetReady(true)
 	return nil
 }

--- a/ui/src/components/Pipeline/PropertyEditor.tsx
+++ b/ui/src/components/Pipeline/PropertyEditor.tsx
@@ -2323,6 +2323,7 @@ function ConverterConfig({
   const [activeField, setActiveField] = useState<SchemaField | null>(null)
   // Activation distance so clicks on the tree's expand/pick buttons still work.
   const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 6 } }))
+  const { currentTenant } = useAuthStore()
 
   // Get the consumer that actually feeds this converter (walk edges upstream)
   const consumerNode = (currentNodeId && allNodes && allEdges)
@@ -2400,6 +2401,22 @@ function ConverterConfig({
         if (t.source_connection_id) params.set('source_connection_id', t.source_connection_id)
         const resp = await apiClient.get(`/api/v1/sample-data/source?${params.toString()}`)
         setPreviewInput(resp.data?.ok ? JSON.stringify(resp.data.data, null, 2) : '// Error: ' + (resp.data?.error || 'No data'))
+      } else if (consumerType === 'salesforce') {
+        const sf = (consumerConfig.salesforce as Record<string, unknown>) || {}
+        if (!sf.instance_url || !sf.oauth_grant_id || !sf.soql) {
+          setPreviewInput('// Set the Salesforce instance URL, account and a SOQL query first')
+          return
+        }
+        const resp = await fetch('http://localhost:9700/sample-data/', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            tenant_id: currentTenant?.id, instance_url: sf.instance_url,
+            oauth_grant_id: sf.oauth_grant_id, api_version: sf.api_version, soql: sf.soql,
+          }),
+        })
+        const data = await resp.json()
+        setPreviewInput(data.ok ? JSON.stringify(data.data, null, 2) : '// Error: ' + (data.error || 'No data'))
       } else {
         // http / webhook and others: only a deployed connection has a sample.
         if (!deployedConnectionId) {
@@ -2433,7 +2450,7 @@ function ConverterConfig({
     setDiscovering(true)
     setSchemaError('')
     try {
-      const fields = await discoverSchema(consumerType, consumerConfig, { deployedConnectionId })
+      const fields = await discoverSchema(consumerType, consumerConfig, { deployedConnectionId, tenantId: currentTenant?.id })
       setSchemaFields(fields)
       if (fields.length === 0) setSchemaError('No fields found in the sample.')
     } catch (err) {

--- a/ui/src/components/Pipeline/schema.ts
+++ b/ui/src/components/Pipeline/schema.ts
@@ -41,6 +41,25 @@ export function jsTypeOf(v: unknown): SchemaFieldType {
   }
 }
 
+// Coarse bucket for a Salesforce describe field type → drives the badge.
+export function sfTypeToBadge(sfType: string): SchemaFieldType {
+  switch (sfType.toLowerCase()) {
+    case 'int':
+    case 'integer':
+    case 'long':
+    case 'double':
+    case 'currency':
+    case 'percent':
+      return 'number'
+    case 'boolean':
+      return 'boolean'
+    default:
+      // string, textarea, picklist, reference, id, date, datetime, email,
+      // phone, url, address, base64, … all render as string-ish.
+      return 'string'
+  }
+}
+
 // Coarse bucket for a SQL data_type (information_schema) → drives the badge.
 export function sqlTypeToBadge(sqlType: string): SchemaFieldType {
   const t = sqlType.toLowerCase()

--- a/ui/src/components/Pipeline/schemaDiscovery.ts
+++ b/ui/src/components/Pipeline/schemaDiscovery.ts
@@ -2,7 +2,7 @@
 // DB uses the authoritative information_schema endpoint; the other sources reuse
 // the existing /sample-data/ endpoints and infer types client-side.
 import apiClient from '../../services/api'
-import { inferSchema, fieldsFromColumns, sqlTypeToBadge, type SchemaField } from './schema'
+import { inferSchema, fieldsFromColumns, sqlTypeToBadge, sfTypeToBadge, type SchemaField } from './schema'
 
 export type { SchemaField } from './schema'
 
@@ -42,7 +42,7 @@ async function postJSON(url: string, body: unknown): Promise<Record<string, unkn
 export async function discoverSchema(
   consumerType: string | undefined,
   consumerConfig: Record<string, unknown> | undefined,
-  opts?: { deployedConnectionId?: string },
+  opts?: { deployedConnectionId?: string; tenantId?: string },
 ): Promise<SchemaField[]> {
   if (!consumerType || !consumerConfig) {
     throw new Error('No upstream source is connected to this node')
@@ -93,6 +93,21 @@ export async function discoverSchema(
       const resp = await apiClient.get(`/api/v1/sample-data/source?${params.toString()}`)
       if (!resp.data?.ok) throw new Error(resp.data?.error || 'Sample request failed')
       return inferSchema(resp.data.data)
+    }
+
+    case 'salesforce': {
+      const sf = (consumerConfig.salesforce as Record<string, unknown>) || {}
+      if (!sf.instance_url || !sf.oauth_grant_id) throw new Error('Set the Salesforce instance URL and connect an account first')
+      if (!sf.soql) throw new Error('Enter a SOQL query (its FROM clause names the object to describe)')
+      if (!opts?.tenantId) throw new Error('No active tenant')
+      const data = await postJSON('http://localhost:9700/schema/', {
+        tenant_id: opts.tenantId,
+        instance_url: sf.instance_url, oauth_grant_id: sf.oauth_grant_id,
+        api_version: sf.api_version, soql: sf.soql,
+      })
+      if (!data.ok) throw new Error((data.error as string) || 'Salesforce describe failed')
+      const cols = (data.fields as DBColumn[] | undefined) || []
+      return fieldsFromColumns(cols.map((f) => ({ name: f.name, type: sfTypeToBadge(f.type || ''), nullable: f.nullable })))
     }
 
     default: {


### PR DESCRIPTION
Closes #79. Adds the last missing acceptance criterion — **"field mapping UI uses live schema from `describe`"** — by exposing a Salesforce describe → `/schema/` endpoint that the #81 schema-discovery field-mapping UI consumes. (OAuth-connect and Bulk-API ≥ 200 already shipped.)

### Backend — `src/cmd/salesforce-consumer/server.go` (new)
Aux HTTP handlers on `WORKER_HTTP_PORT` (9700), registered in `Configure` (mirrors db-consumer's `/schema/`):
- **`/schema/`** — derives the SObject from the SOQL `FROM` clause (`objectFromSOQL`, or an explicit `object`), calls `{instance}/services/data/{ver}/sobjects/{Object}/describe` via the existing OAuth-authed `get()` (Bearer + 401-retry), and returns `{ok, fields:[{name, type, nullable}]}`.
- **`/sample-data/`** — runs the configured SOQL (LIMIT-bounded) and returns the records, so the Converter's "Fetch from Input" / Test Transform works for a Salesforce source.
- Tenant comes from the request body (token resolution is tenant-scoped); aux port is `127.0.0.1`-only (same dev model as every other worker discover endpoint).

### docker-compose
salesforce-consumer: `WORKER_HTTP_PORT: "9700"` + `127.0.0.1:9700:9700`.

### UI
- `schema.ts`: `sfTypeToBadge` (Salesforce field type → badge bucket).
- `schemaDiscovery.ts`: a `salesforce` case (POST `:9700/schema/` with `tenant_id` + config → typed fields) and a `tenantId` opt.
- `PropertyEditor.tsx`: `ConverterConfig` passes the active tenant id into `discoverSchema`, and gains a `salesforce` "Fetch from Input" branch. The Salesforce **source** editor is unchanged.

## Acceptance criteria (#79)
- [x] Connect to a sandbox via OAuth without leaving the UI (shipped earlier).
- [x] Field mapping UI uses live schema from `describe` (this PR).
- [x] Bulk API used automatically for batches ≥ 200 (shipped earlier).

## Verification
- **Go:** build/vet, `go test ./cmd/salesforce-consumer/...` (mock describe + `objectFromSOQL`), `lint-connector`/`lint-tenant` — green.
- **UI:** `npm run build` + lint — clean.
- **Live (deferred, needs a sandbox):** Salesforce source (instance URL + OAuth grant + `SELECT … FROM Account`) → Converter → **Discover schema** shows Account's fields with type badges; drag-map + Test Transform. The httptest mock covers the describe→fields path without external creds.

## Notes
- CDC via Streaming API / platform events (mentioned in #79's prose, not its checkboxes) is out of scope; the three acceptance checkboxes are met.
- No secret-resolution needed — the grant id + instance url are plaintext config; the token is resolved server-side via the service-token-gated mgmt-api endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)