### PR TITLE
Close out Phase-2 connector follow-ups: #106 event parity + #107 CI integration tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,91 @@
+name: Integration Tests
+
+# Runs the //go:build integration connector tests against live test brokers
+# brought up from docker-compose: MinIO / Azurite / fake-gcs (cloud-storage,
+# #80), atmoz/sftp (#76), apache/kafka (#77), rabbitmq:3-management (#78).
+#
+# The Go tests run from a container ON vrsky-network so brokers resolve by
+# service name (notably fake-gcs, whose -public-host is fake-gcs-test:4443 — see
+# the header of gcs_integration_test.go). Each test self-skips unless its
+# *_TEST_* env var is set, so the same files are a no-op under a plain `go test`.
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+  pull_request:
+    branches:
+      - main
+      - develop
+  workflow_dispatch:
+
+jobs:
+  integration:
+    name: Connector integration tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Start test brokers
+        run: |
+          docker compose up -d \
+            minio-test minio-init azurite-test fake-gcs-test \
+            sftp-test kafka-test rabbitmq-test
+
+      - name: Wait for brokers to be ready
+        run: |
+          # Poll each broker's TCP port from inside vrsky-network (busybox nc),
+          # so we wait on actual reachability rather than a fixed sleep.
+          wait_tcp() {
+            local hostport="$1" name="$2" tries=60
+            for i in $(seq 1 "$tries"); do
+              if docker run --rm --network vrsky-network busybox \
+                   sh -c "nc -z -w2 ${hostport/:/ }" >/dev/null 2>&1; then
+                echo "$name ready ($hostport)"; return 0
+              fi
+              echo "waiting for $name ($hostport)… [$i/$tries]"; sleep 2
+            done
+            echo "ERROR: $name ($hostport) never became ready"; return 1
+          }
+          wait_tcp minio-test:9000     minio
+          wait_tcp azurite-test:10000  azurite
+          wait_tcp fake-gcs-test:4443  fake-gcs
+          wait_tcp sftp-test:22        sftp
+          wait_tcp kafka-test:9092     kafka
+          wait_tcp rabbitmq-test:5672  rabbitmq
+
+      - name: Run integration tests (in-network)
+        run: |
+          docker run --rm --network vrsky-network \
+            -v "$PWD/src":/src -w /src \
+            -e S3_TEST_ENDPOINT=http://minio-test:9000 \
+            -e S3_TEST_ACCESS_KEY=minioadmin \
+            -e S3_TEST_SECRET_KEY=minioadmin \
+            -e AZURE_TEST_CONN="DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://azurite-test:10000/devstoreaccount1;" \
+            -e GCS_TEST_EMULATOR_HOST=fake-gcs-test:4443 \
+            -e SFTP_TEST_HOST=sftp-test \
+            -e SFTP_TEST_PORT=22 \
+            -e KAFKA_TEST_BROKER=kafka-test:9092 \
+            -e RABBITMQ_TEST_URL=amqp://guest:guest@rabbitmq-test:5672/ \
+            -e GOFLAGS=-buildvcs=false \
+            golang:1.22 \
+            go test -tags=integration -count=1 -v \
+              ./pkg/objectstore/... \
+              ./cmd/sftp-consumer/... \
+              ./cmd/kafka-consumer/... \
+              ./cmd/rabbitmq-consumer/...
+
+      - name: Dump broker logs on failure
+        if: failure()
+        run: |
+          docker compose logs --tail=100 \
+            minio-test azurite-test fake-gcs-test \
+            sftp-test kafka-test rabbitmq-test || true
+
+      - name: Tear down
+        if: always()
+        run: docker compose down -v || true

--- a/src/cmd/cloud-storage-consumer/events.go
+++ b/src/cmd/cloud-storage-consumer/events.go
@@ -34,9 +34,8 @@ type eventSource interface {
 // newEventSource in Configure; tests inject a fake.
 type eventSourceFactory func(ctx context.Context, cfg *cloudConfig) (eventSource, error)
 
-// newEventSource builds the event source for the provider. Only S3 (-> SQS) is
-// implemented; Azure Storage Queue / GCS Pub/Sub are tracked follow-ups (poll
-// mode covers those providers today).
+// newEventSource builds the event source for the provider: S3 -> SQS, Azure
+// Blob -> Storage Queue (via Event Grid), GCS -> Pub/Sub pull subscription.
 func newEventSource(ctx context.Context, cfg *cloudConfig) (eventSource, error) {
 	provider := cfg.Provider
 	if provider == "" {
@@ -48,8 +47,12 @@ func newEventSource(ctx context.Context, cfg *cloudConfig) (eventSource, error) 
 			return nil, fmt.Errorf("event mode (s3) requires event_queue_url (an SQS queue URL)")
 		}
 		return newSQSEventSource(ctx, cfg)
+	case objectstore.ProviderAzure:
+		return newAzureQueueEventSource(ctx, cfg)
+	case objectstore.ProviderGCS:
+		return newGCSPubSubEventSource(ctx, cfg)
 	default:
-		return nil, fmt.Errorf("event-driven mode is not implemented for provider %q yet (use poll mode)", provider)
+		return nil, fmt.Errorf("event-driven mode is not implemented for provider %q", provider)
 	}
 }
 

--- a/src/cmd/cloud-storage-consumer/events_azure.go
+++ b/src/cmd/cloud-storage-consumer/events_azure.go
@@ -1,0 +1,182 @@
+package main
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azqueue"
+)
+
+// azureQueueEventSource long-polls an Azure Storage Queue that receives Blob
+// change notifications (Blob events routed through Event Grid into the queue).
+// It is the Azure parity of sqsEventSource: Receive dequeues messages and parses
+// the object keys; Ack deletes the message after a successful publish.
+type azureQueueEventSource struct {
+	client *azqueue.QueueClient
+}
+
+// azureAckHandle carries the two values Azure needs to delete a dequeued
+// message. It is JSON-encoded into eventMessage.ackHandle (a single string) so
+// the provider-agnostic event loop stays unchanged.
+type azureAckHandle struct {
+	ID         string `json:"id"`
+	PopReceipt string `json:"pr"`
+}
+
+// newAzureQueueEventSource builds a queue client from a connection string (also
+// the way to target the Azurite emulator) or an account name + shared key. The
+// queue name is the per-node event_queue_name.
+func newAzureQueueEventSource(_ context.Context, cfg *cloudConfig) (eventSource, error) {
+	queue := cfg.EventQueueName
+	if queue == "" {
+		return nil, fmt.Errorf("event mode (azure) requires event_queue_name (the Storage Queue receiving Blob events via Event Grid)")
+	}
+
+	var (
+		client *azqueue.QueueClient
+		err    error
+	)
+	switch {
+	case cfg.ConnectionString != "":
+		client, err = azqueue.NewQueueClientFromConnectionString(cfg.ConnectionString, queue, nil)
+	case cfg.AccountName != "" && cfg.AccountKey != "":
+		cred, cerr := azqueue.NewSharedKeyCredential(cfg.AccountName, cfg.AccountKey)
+		if cerr != nil {
+			return nil, fmt.Errorf("azure queue: shared key credential: %w", cerr)
+		}
+		// The queue service lives on a different host than blob; build the queue
+		// service URL (or use the explicit endpoint override for Azurite).
+		base := cfg.EventEndpoint
+		if base == "" {
+			base = fmt.Sprintf("https://%s.queue.core.windows.net", cfg.AccountName)
+		}
+		queueURL := strings.TrimRight(base, "/") + "/" + queue
+		client, err = azqueue.NewQueueClientWithSharedKeyCredential(queueURL, cred, nil)
+	default:
+		return nil, errors.New("azure queue: set connection_string, or account_name + account_key")
+	}
+	if err != nil {
+		return nil, fmt.Errorf("azure queue: new client: %w", err)
+	}
+	return &azureQueueEventSource{client: client}, nil
+}
+
+func (a *azureQueueEventSource) Receive(ctx context.Context) ([]eventMessage, error) {
+	n := int32(10)
+	vt := int32(30) // visibility timeout: redelivered if not deleted (ack) in time
+	resp, err := a.client.DequeueMessages(ctx, &azqueue.DequeueMessagesOptions{
+		NumberOfMessages:  &n,
+		VisibilityTimeout: &vt,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("azure queue dequeue: %w", err)
+	}
+	var msgs []eventMessage
+	for _, m := range resp.Messages {
+		if m == nil {
+			continue
+		}
+		text := ""
+		if m.MessageText != nil {
+			text = *m.MessageText
+		}
+		h := azureAckHandle{}
+		if m.MessageID != nil {
+			h.ID = *m.MessageID
+		}
+		if m.PopReceipt != nil {
+			h.PopReceipt = *m.PopReceipt
+		}
+		hb, _ := json.Marshal(h)
+		msgs = append(msgs, eventMessage{
+			objectKeys: parseAzureNotification([]byte(text)),
+			ackHandle:  string(hb),
+		})
+	}
+	return msgs, nil
+}
+
+func (a *azureQueueEventSource) Ack(ctx context.Context, handle string) error {
+	var h azureAckHandle
+	if err := json.Unmarshal([]byte(handle), &h); err != nil {
+		return fmt.Errorf("azure queue ack: bad handle: %w", err)
+	}
+	if _, err := a.client.DeleteMessage(ctx, h.ID, h.PopReceipt, nil); err != nil {
+		return fmt.Errorf("azure queue delete: %w", err)
+	}
+	return nil
+}
+
+// azureEvent is one Event Grid notification (the Storage Queue message body).
+type azureEvent struct {
+	EventType string `json:"eventType"`
+	Subject   string `json:"subject"`
+	Data      struct {
+		URL string `json:"url"`
+	} `json:"data"`
+}
+
+// parseAzureNotification extracts blob keys from an Event Grid Blob notification
+// delivered into a Storage Queue. Event Grid base64-encodes the message body by
+// default, so it is base64-decoded first (falling back to raw text). The body
+// may be a single event or an array. Only *Created events yield keys; other
+// events (deletes, test events) yield none so they drain without ingesting.
+func parseAzureNotification(body []byte) []string {
+	raw := body
+	if dec, err := base64.StdEncoding.DecodeString(strings.TrimSpace(string(body))); err == nil && json.Valid(dec) {
+		raw = dec
+	}
+
+	var events []azureEvent
+	if err := json.Unmarshal(raw, &events); err != nil {
+		var single azureEvent
+		if err := json.Unmarshal(raw, &single); err != nil {
+			return nil
+		}
+		events = []azureEvent{single}
+	}
+
+	var keys []string
+	for _, e := range events {
+		// Only ingest blob-created notifications.
+		if e.EventType != "" && !strings.Contains(e.EventType, "BlobCreated") {
+			continue
+		}
+		if k := azureKeyFromEvent(e); k != "" {
+			keys = append(keys, k)
+		}
+	}
+	return keys
+}
+
+// azureKeyFromEvent derives the blob path (the object key) from an event. The
+// subject is "/blobServices/default/containers/<container>/blobs/<key>"; the
+// data.url is "https://acct.blob.core.windows.net/<container>/<key>". The key is
+// everything after the container, URL-decoded.
+func azureKeyFromEvent(e azureEvent) string {
+	if i := strings.Index(e.Subject, "/blobs/"); i >= 0 {
+		return decodeAzureKey(e.Subject[i+len("/blobs/"):])
+	}
+	if e.Data.URL != "" {
+		if u, err := url.Parse(e.Data.URL); err == nil {
+			// Path is /<container>/<key...>; drop the leading slash + container.
+			p := strings.TrimPrefix(u.Path, "/")
+			if j := strings.Index(p, "/"); j >= 0 {
+				return decodeAzureKey(p[j+1:])
+			}
+		}
+	}
+	return ""
+}
+
+func decodeAzureKey(k string) string {
+	if dec, err := url.PathUnescape(k); err == nil {
+		return dec
+	}
+	return k
+}

--- a/src/cmd/cloud-storage-consumer/events_azure.go
+++ b/src/cmd/cloud-storage-consumer/events_azure.go
@@ -143,8 +143,10 @@ func parseAzureNotification(body []byte) []string {
 
 	var keys []string
 	for _, e := range events {
-		// Only ingest blob-created notifications.
-		if e.EventType != "" && !strings.Contains(e.EventType, "BlobCreated") {
+		// Only ingest blob-created notifications. A missing/other eventType
+		// (e.g. Event Grid subscription-validation or a delete event) is skipped
+		// so it drains without ingesting.
+		if !strings.Contains(e.EventType, "BlobCreated") {
 			continue
 		}
 		if k := azureKeyFromEvent(e); k != "" {

--- a/src/cmd/cloud-storage-consumer/events_gcs.go
+++ b/src/cmd/cloud-storage-consumer/events_gcs.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	subapi "cloud.google.com/go/pubsub/apiv1"
+	"cloud.google.com/go/pubsub/apiv1/pubsubpb"
+	"google.golang.org/api/option"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+// gcsPubSubEventSource pulls from a Pub/Sub subscription that receives GCS
+// object-change notifications (configured via `gcloud storage buckets
+// notifications create`). It is the GCS parity of sqsEventSource: Receive pulls
+// a batch of messages and parses their object keys; Ack acknowledges them after
+// a successful publish.
+//
+// It uses the low-level SubscriberClient (Pull/Acknowledge) rather than the
+// streaming high-level Subscription.Receive, because the pull/ack-handle shape
+// maps directly onto the eventSource interface.
+type gcsPubSubEventSource struct {
+	client *subapi.SubscriberClient
+	sub    string // full subscription path: projects/<project>/subscriptions/<sub>
+}
+
+// newGCSPubSubEventSource builds a SubscriberClient. Credentials come from a
+// service-account JSON when set; an endpoint override targets the Pub/Sub
+// emulator (no auth, insecure transport). The subscription may be a full path
+// or a bare name (then event_project is required to build the path).
+func newGCSPubSubEventSource(ctx context.Context, cfg *cloudConfig) (eventSource, error) {
+	sub := cfg.EventSubscription
+	if sub == "" {
+		return nil, fmt.Errorf("event mode (gcs) requires event_subscription (a Pub/Sub pull subscription)")
+	}
+
+	var opts []option.ClientOption
+	switch {
+	case cfg.EventEndpoint != "":
+		opts = append(opts,
+			option.WithEndpoint(cfg.EventEndpoint),
+			option.WithoutAuthentication(),
+			option.WithGRPCDialOption(grpc.WithTransportCredentials(insecure.NewCredentials())),
+		)
+	case cfg.CredentialsJSON != "":
+		opts = append(opts, option.WithCredentialsJSON([]byte(cfg.CredentialsJSON)))
+	}
+
+	client, err := subapi.NewSubscriberClient(ctx, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("gcs pubsub: new client: %w", err)
+	}
+
+	subPath := sub
+	if !strings.Contains(sub, "/") {
+		if cfg.EventProject == "" {
+			_ = client.Close()
+			return nil, fmt.Errorf("event mode (gcs) requires event_project when event_subscription is a bare name")
+		}
+		subPath = fmt.Sprintf("projects/%s/subscriptions/%s", cfg.EventProject, sub)
+	}
+	return &gcsPubSubEventSource{client: client, sub: subPath}, nil
+}
+
+func (g *gcsPubSubEventSource) Receive(ctx context.Context) ([]eventMessage, error) {
+	// Bound the pull so the event loop can observe ctx cancellation (stop /
+	// shutdown) between pulls rather than blocking on the server indefinitely.
+	cctx, cancel := context.WithTimeout(ctx, 20*time.Second)
+	defer cancel()
+
+	resp, err := g.client.Pull(cctx, &pubsubpb.PullRequest{Subscription: g.sub, MaxMessages: 10})
+	if err != nil {
+		// A pull that times out with no messages is normal (not a real error):
+		// report no messages so the loop pulls again without backing off.
+		if ctx.Err() == nil && cctx.Err() != nil {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("gcs pubsub pull: %w", err)
+	}
+
+	var msgs []eventMessage
+	for _, rm := range resp.GetReceivedMessages() {
+		if rm == nil || rm.GetMessage() == nil {
+			continue
+		}
+		msgs = append(msgs, eventMessage{
+			objectKeys: gcsObjectKeys(rm.GetMessage().GetAttributes()),
+			ackHandle:  rm.GetAckId(),
+		})
+	}
+	return msgs, nil
+}
+
+func (g *gcsPubSubEventSource) Ack(ctx context.Context, handle string) error {
+	if err := g.client.Acknowledge(ctx, &pubsubpb.AcknowledgeRequest{
+		Subscription: g.sub,
+		AckIds:       []string{handle},
+	}); err != nil {
+		return fmt.Errorf("gcs pubsub ack: %w", err)
+	}
+	return nil
+}
+
+// gcsObjectKeys extracts the object key from a GCS notification's Pub/Sub
+// attributes. GCS sets objectId (the key), bucketId and eventType. Only
+// OBJECT_FINALIZE (new/overwritten object) yields a key; other event types
+// (delete, metadata update) yield none so the message drains without ingesting.
+func gcsObjectKeys(attrs map[string]string) []string {
+	if attrs == nil {
+		return nil
+	}
+	if et := attrs["eventType"]; et != "" && et != "OBJECT_FINALIZE" {
+		return nil
+	}
+	if k := attrs["objectId"]; k != "" {
+		return []string{k}
+	}
+	return nil
+}

--- a/src/cmd/cloud-storage-consumer/events_providers_test.go
+++ b/src/cmd/cloud-storage-consumer/events_providers_test.go
@@ -39,6 +39,13 @@ func TestParseAzureNotification(t *testing.T) {
 		t.Errorf("BlobDeleted should yield no keys, got %v", got)
 	}
 
+	// A message with a subject/url but no eventType (e.g. an Event Grid
+	// subscription-validation event) must NOT be ingested.
+	noType := `{"subject":"/blobServices/default/containers/c/blobs/x","data":{"url":"https://acct.blob.core.windows.net/c/x"}}`
+	if got := parseAzureNotification([]byte(noType)); len(got) != 0 {
+		t.Errorf("missing eventType should yield no keys, got %v", got)
+	}
+
 	// Garbage yields no keys (and does not panic).
 	if got := parseAzureNotification([]byte("not json")); len(got) != 0 {
 		t.Errorf("garbage should yield no keys, got %v", got)
@@ -111,8 +118,9 @@ func TestValidateEventConfig(t *testing.T) {
 	ok := []*cloudConfig{
 		{Config: objectstore.Config{Provider: objectstore.ProviderS3}, EventQueueURL: "http://q"},
 		{Config: objectstore.Config{Provider: objectstore.ProviderAzure}, EventQueueName: "q"},
-		{Config: objectstore.Config{Provider: objectstore.ProviderGCS}, EventSubscription: "s"},
-		{Config: objectstore.Config{}, EventQueueURL: "http://q"}, // empty provider defaults to s3
+		{Config: objectstore.Config{Provider: objectstore.ProviderGCS}, EventSubscription: "s", EventProject: "p"},
+		{Config: objectstore.Config{Provider: objectstore.ProviderGCS}, EventSubscription: "projects/p/subscriptions/s"}, // full path needs no project
+		{Config: objectstore.Config{}, EventQueueURL: "http://q"},                                                       // empty provider defaults to s3
 	}
 	for i, c := range ok {
 		if err := c.validateEventConfig(); err != nil {
@@ -123,6 +131,7 @@ func TestValidateEventConfig(t *testing.T) {
 		{Config: objectstore.Config{Provider: objectstore.ProviderS3}},
 		{Config: objectstore.Config{Provider: objectstore.ProviderAzure}},
 		{Config: objectstore.Config{Provider: objectstore.ProviderGCS}},
+		{Config: objectstore.Config{Provider: objectstore.ProviderGCS}, EventSubscription: "s"}, // bare name, no project
 	}
 	for i, c := range bad {
 		if err := c.validateEventConfig(); err == nil {

--- a/src/cmd/cloud-storage-consumer/events_providers_test.go
+++ b/src/cmd/cloud-storage-consumer/events_providers_test.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"context"
+	"encoding/base64"
+	"strings"
+	"testing"
+
+	"github.com/ValueRetail/vrsky/pkg/objectstore"
+)
+
+// TestParseAzureNotification covers Event Grid Blob notifications delivered into
+// a Storage Queue: base64-encoded arrays, raw single events, the data.url
+// fallback, URL-decoding, and filtering out non-created events.
+func TestParseAzureNotification(t *testing.T) {
+	// Array of events, base64-encoded (Event Grid's default queue encoding); the
+	// key has a URL-encoded space and a prefix path.
+	arr := `[{"eventType":"Microsoft.Storage.BlobCreated","subject":"/blobServices/default/containers/c/blobs/incoming/orders%20list.json","data":{"url":"https://acct.blob.core.windows.net/c/incoming/orders%20list.json"}}]`
+	b64 := base64.StdEncoding.EncodeToString([]byte(arr))
+	if got := parseAzureNotification([]byte(b64)); len(got) != 1 || got[0] != "incoming/orders list.json" {
+		t.Errorf("base64 array: keys = %v, want [incoming/orders list.json]", got)
+	}
+
+	// Raw (non-base64) single event.
+	raw := `{"eventType":"Microsoft.Storage.BlobCreated","subject":"/blobServices/default/containers/c/blobs/a/b.csv"}`
+	if got := parseAzureNotification([]byte(raw)); len(got) != 1 || got[0] != "a/b.csv" {
+		t.Errorf("raw single: keys = %v, want [a/b.csv]", got)
+	}
+
+	// data.url fallback when there is no subject.
+	urlOnly := `{"eventType":"Microsoft.Storage.BlobCreated","data":{"url":"https://acct.blob.core.windows.net/cont/path/to/file.json"}}`
+	if got := parseAzureNotification([]byte(urlOnly)); len(got) != 1 || got[0] != "path/to/file.json" {
+		t.Errorf("data.url fallback: keys = %v, want [path/to/file.json]", got)
+	}
+
+	// Non-created events (delete) yield no keys so the message drains.
+	del := `[{"eventType":"Microsoft.Storage.BlobDeleted","subject":"/blobServices/default/containers/c/blobs/x"}]`
+	if got := parseAzureNotification([]byte(del)); len(got) != 0 {
+		t.Errorf("BlobDeleted should yield no keys, got %v", got)
+	}
+
+	// Garbage yields no keys (and does not panic).
+	if got := parseAzureNotification([]byte("not json")); len(got) != 0 {
+		t.Errorf("garbage should yield no keys, got %v", got)
+	}
+}
+
+// TestGCSObjectKeys covers the Pub/Sub attribute extraction + event-type filter.
+func TestGCSObjectKeys(t *testing.T) {
+	if got := gcsObjectKeys(map[string]string{"eventType": "OBJECT_FINALIZE", "objectId": "in/x.json"}); len(got) != 1 || got[0] != "in/x.json" {
+		t.Errorf("finalize: keys = %v, want [in/x.json]", got)
+	}
+	if got := gcsObjectKeys(map[string]string{"eventType": "OBJECT_DELETE", "objectId": "in/x.json"}); len(got) != 0 {
+		t.Errorf("delete should yield no keys, got %v", got)
+	}
+	// No eventType attribute: still ingest (treat as a finalize-style event).
+	if got := gcsObjectKeys(map[string]string{"objectId": "in/y.json"}); len(got) != 1 || got[0] != "in/y.json" {
+		t.Errorf("no eventType: keys = %v, want [in/y.json]", got)
+	}
+	if got := gcsObjectKeys(nil); got != nil {
+		t.Errorf("nil attrs should yield nil, got %v", got)
+	}
+}
+
+// TestNewEventSource_Dispatch verifies the provider dispatch + the
+// provider-specific required-identifier errors (no network / client build for
+// the error paths).
+func TestNewEventSource_Dispatch(t *testing.T) {
+	ctx := context.Background()
+	cases := []struct {
+		name    string
+		cfg     *cloudConfig
+		wantErr string // substring; "" means expect success
+	}{
+		{
+			name:    "s3 missing queue url",
+			cfg:     &cloudConfig{Config: objectstore.Config{Provider: objectstore.ProviderS3}, Mode: "event"},
+			wantErr: "event_queue_url",
+		},
+		{
+			name:    "azure missing queue name",
+			cfg:     &cloudConfig{Config: objectstore.Config{Provider: objectstore.ProviderAzure}, Mode: "event"},
+			wantErr: "event_queue_name",
+		},
+		{
+			name:    "gcs missing subscription",
+			cfg:     &cloudConfig{Config: objectstore.Config{Provider: objectstore.ProviderGCS}, Mode: "event"},
+			wantErr: "event_subscription",
+		},
+		{
+			name:    "unknown provider",
+			cfg:     &cloudConfig{Config: objectstore.Config{Provider: "wasabi"}, Mode: "event"},
+			wantErr: "not implemented",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := newEventSource(ctx, tc.cfg)
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("error = %q, want substring %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}
+
+// TestValidateEventConfig mirrors the provider-aware start-command gate.
+func TestValidateEventConfig(t *testing.T) {
+	ok := []*cloudConfig{
+		{Config: objectstore.Config{Provider: objectstore.ProviderS3}, EventQueueURL: "http://q"},
+		{Config: objectstore.Config{Provider: objectstore.ProviderAzure}, EventQueueName: "q"},
+		{Config: objectstore.Config{Provider: objectstore.ProviderGCS}, EventSubscription: "s"},
+		{Config: objectstore.Config{}, EventQueueURL: "http://q"}, // empty provider defaults to s3
+	}
+	for i, c := range ok {
+		if err := c.validateEventConfig(); err != nil {
+			t.Errorf("ok[%d]: unexpected error: %v", i, err)
+		}
+	}
+	bad := []*cloudConfig{
+		{Config: objectstore.Config{Provider: objectstore.ProviderS3}},
+		{Config: objectstore.Config{Provider: objectstore.ProviderAzure}},
+		{Config: objectstore.Config{Provider: objectstore.ProviderGCS}},
+	}
+	for i, c := range bad {
+		if err := c.validateEventConfig(); err == nil {
+			t.Errorf("bad[%d]: expected error, got nil", i)
+		}
+	}
+}

--- a/src/cmd/cloud-storage-consumer/service.go
+++ b/src/cmd/cloud-storage-consumer/service.go
@@ -55,7 +55,10 @@ type cloudConfig struct {
 
 	Mode                string `json:"mode"`                  // "poll" (default) | "event"
 	EventQueueURL       string `json:"event_queue_url"`       // SQS queue URL (S3 event mode)
-	EventEndpoint       string `json:"event_endpoint"`        // optional SQS endpoint override (e.g. LocalStack); NOT the S3 endpoint
+	EventQueueName      string `json:"event_queue_name"`      // Azure Storage Queue name (Azure event mode)
+	EventSubscription   string `json:"event_subscription"`    // Pub/Sub subscription, path or bare name (GCS event mode)
+	EventProject        string `json:"event_project"`         // GCP project ID (GCS event mode, when subscription is a bare name)
+	EventEndpoint       string `json:"event_endpoint"`        // optional event-broker endpoint override (LocalStack SQS / Azurite queue / Pub/Sub emulator); NOT the object-store endpoint
 	FilePattern         string `json:"file_pattern"`          // optional glob against the object base name, e.g. *.csv
 	PollIntervalSeconds int    `json:"poll_interval_seconds"` // <= 0 means run once
 	AfterAction         string `json:"after_action"`          // "delete" | "move" | "none" (default none)
@@ -171,9 +174,11 @@ func (s *cloudConsumer) handleStartCommand(msg *nats.Msg) {
 		logger.Error("after_action=move requires move_prefix")
 		return
 	}
-	if cfg.Mode == "event" && cfg.EventQueueURL == "" {
-		logger.Error("mode=event requires event_queue_url")
-		return
+	if cfg.Mode == "event" {
+		if err := cfg.validateEventConfig(); err != nil {
+			logger.Error("invalid event-mode config", "error", err)
+			return
+		}
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -184,7 +189,7 @@ func (s *cloudConsumer) handleStartCommand(msg *nats.Msg) {
 
 	if cfg.Mode == "event" {
 		logger.Info("Starting cloud-storage event loop",
-			"provider", cfg.providerOrDefault(), "bucket", cfg.Bucket, "queue", cfg.EventQueueURL)
+			"provider", cfg.providerOrDefault(), "bucket", cfg.Bucket, "event_target", cfg.eventTarget())
 		go s.runEventLoop(ctx, cmd.ConnectionID, cmd.TenantID, cfg)
 		return
 	}
@@ -299,7 +304,7 @@ func (s *cloudConsumer) runEventLoop(ctx context.Context, connID, tenantID strin
 		return
 	}
 
-	logger.Info("cloud-storage event loop started", "queue", cfg.EventQueueURL)
+	logger.Info("cloud-storage event loop started", "event_target", cfg.eventTarget())
 	for {
 		if ctx.Err() != nil {
 			return
@@ -458,6 +463,38 @@ func (c *cloudConfig) providerOrDefault() string {
 		return objectstore.ProviderS3
 	}
 	return c.Provider
+}
+
+// validateEventConfig checks that the provider-specific event-mode identifier is
+// set (SQS queue URL for S3, queue name for Azure, subscription for GCS).
+func (c *cloudConfig) validateEventConfig() error {
+	switch c.providerOrDefault() {
+	case objectstore.ProviderAzure:
+		if c.EventQueueName == "" {
+			return fmt.Errorf("mode=event (azure) requires event_queue_name")
+		}
+	case objectstore.ProviderGCS:
+		if c.EventSubscription == "" {
+			return fmt.Errorf("mode=event (gcs) requires event_subscription")
+		}
+	default: // s3
+		if c.EventQueueURL == "" {
+			return fmt.Errorf("mode=event (s3) requires event_queue_url")
+		}
+	}
+	return nil
+}
+
+// eventTarget returns the provider-specific event identifier, for logging.
+func (c *cloudConfig) eventTarget() string {
+	switch c.providerOrDefault() {
+	case objectstore.ProviderAzure:
+		return c.EventQueueName
+	case objectstore.ProviderGCS:
+		return c.EventSubscription
+	default:
+		return c.EventQueueURL
+	}
 }
 
 // detectContentType picks a MIME type from the object's base name, falling back

--- a/src/cmd/cloud-storage-consumer/service.go
+++ b/src/cmd/cloud-storage-consumer/service.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log/slog"
 	"path"
+	"strings"
 	"sync"
 	"time"
 
@@ -476,6 +477,11 @@ func (c *cloudConfig) validateEventConfig() error {
 	case objectstore.ProviderGCS:
 		if c.EventSubscription == "" {
 			return fmt.Errorf("mode=event (gcs) requires event_subscription")
+		}
+		// A bare subscription name (no path) needs a project to build the full
+		// subscription path; catch it here rather than failing later in newEventSource.
+		if !strings.Contains(c.EventSubscription, "/") && c.EventProject == "" {
+			return fmt.Errorf("mode=event (gcs) requires event_project when event_subscription is a bare name")
 		}
 	default: // s3
 		if c.EventQueueURL == "" {

--- a/src/cmd/kafka-consumer/kafka_integration_test.go
+++ b/src/cmd/kafka-consumer/kafka_integration_test.go
@@ -33,10 +33,13 @@ func TestKafka_RoundTrip_Integration(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
-	const topic = "vrsky-it-topic"
-	// Unique consumer group per run so a fresh read starts from the beginning
-	// (an existing group's committed offset would skip the produced message).
-	group := fmt.Sprintf("vrsky-it-group-%d", time.Now().UnixNano())
+	// Unique topic + consumer group per run: a fresh topic avoids the
+	// "already exists" case (so a CreateTopics error is actionable), and a fresh
+	// group reads from the beginning (an existing group's committed offset would
+	// skip the produced message).
+	stamp := time.Now().UnixNano()
+	topic := fmt.Sprintf("vrsky-it-topic-%d", stamp)
+	group := fmt.Sprintf("vrsky-it-group-%d", stamp)
 
 	createTopic(t, ctx, broker, topic)
 
@@ -79,8 +82,8 @@ func TestKafka_RoundTrip_Integration(t *testing.T) {
 	}
 }
 
-// createTopic creates the topic via the cluster controller (idempotent — an
-// "already exists" error is ignored).
+// createTopic creates the topic via the cluster controller. The topic is unique
+// per run, so any CreateTopics error is a real failure (not "already exists").
 func createTopic(t *testing.T, ctx context.Context, broker, topic string) {
 	t.Helper()
 	var conn *kafka.Conn
@@ -109,8 +112,7 @@ func createTopic(t *testing.T, ctx context.Context, broker, topic string) {
 	defer ctrlConn.Close()
 
 	if err := ctrlConn.CreateTopics(kafka.TopicConfig{Topic: topic, NumPartitions: 1, ReplicationFactor: 1}); err != nil {
-		// CreateTopics returns an error if the topic already exists; tolerate it.
-		t.Logf("CreateTopics(%q): %v (continuing — may already exist)", topic, err)
+		t.Fatalf("CreateTopics(%q): %v", topic, err)
 	}
 }
 

--- a/src/cmd/kafka-consumer/kafka_integration_test.go
+++ b/src/cmd/kafka-consumer/kafka_integration_test.go
@@ -1,0 +1,131 @@
+//go:build integration
+
+// Integration test for the Kafka consumer against a live broker (apache/kafka,
+// KRaft single-node, PLAINTEXT). It creates a topic, produces a message, then
+// exercises the connector's real consumer-group reader (realReader) + the
+// connection-test ping (realKafkaPing). Run:
+//
+//	docker compose up -d kafka-test
+//	KAFKA_TEST_BROKER=localhost:9092 \
+//	  go test -tags=integration -run Kafka ./cmd/kafka-consumer/...
+//
+// Skipped unless KAFKA_TEST_BROKER is set.
+package main
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/segmentio/kafka-go"
+)
+
+func TestKafka_RoundTrip_Integration(t *testing.T) {
+	broker := os.Getenv("KAFKA_TEST_BROKER")
+	if broker == "" {
+		t.Skip("KAFKA_TEST_BROKER not set; skipping Kafka integration test")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	const topic = "vrsky-it-topic"
+	// Unique consumer group per run so a fresh read starts from the beginning
+	// (an existing group's committed offset would skip the produced message).
+	group := fmt.Sprintf("vrsky-it-group-%d", time.Now().UnixNano())
+
+	createTopic(t, ctx, broker, topic)
+
+	// Produce one message.
+	w := &kafka.Writer{Addr: kafka.TCP(broker), Topic: topic, Balancer: &kafka.LeastBytes{}}
+	defer w.Close()
+	payload := []byte(`{"hello":"kafka"}`)
+	if err := writeWithRetry(ctx, w, kafka.Message{Key: []byte("k1"), Value: payload}); err != nil {
+		t.Fatalf("produce: %v", err)
+	}
+
+	// --- exercise the connector's real reader ---
+	cfg := &KafkaConfig{Brokers: []string{broker}, Topic: topic, ConsumerGroup: group}
+	reader, err := realReader(cfg)
+	if err != nil {
+		t.Fatalf("realReader: %v", err)
+	}
+	defer reader.Close()
+
+	fctx, fcancel := context.WithTimeout(ctx, 30*time.Second)
+	defer fcancel()
+	msg, err := reader.Fetch(fctx)
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if string(msg.Value) != string(payload) {
+		t.Errorf("Fetch value = %q, want %q", msg.Value, payload)
+	}
+	if err := msg.commit(ctx); err != nil {
+		t.Errorf("commit: %v", err)
+	}
+
+	// --- exercise the connection-test ping ---
+	parts, err := realKafkaPing(ctx, cfg)
+	if err != nil {
+		t.Fatalf("realKafkaPing: %v", err)
+	}
+	if parts < 1 {
+		t.Errorf("ping partitions = %d, want >= 1", parts)
+	}
+}
+
+// createTopic creates the topic via the cluster controller (idempotent — an
+// "already exists" error is ignored).
+func createTopic(t *testing.T, ctx context.Context, broker, topic string) {
+	t.Helper()
+	var conn *kafka.Conn
+	var err error
+	deadline := time.Now().Add(40 * time.Second)
+	for {
+		conn, err = (&kafka.Dialer{Timeout: 10 * time.Second}).DialContext(ctx, "tcp", broker)
+		if err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("dial broker %s: %v", broker, err)
+		}
+		time.Sleep(time.Second)
+	}
+	defer conn.Close()
+
+	controller, err := conn.Controller()
+	if err != nil {
+		t.Fatalf("controller: %v", err)
+	}
+	ctrlConn, err := kafka.Dial("tcp", net.JoinHostPort(controller.Host, strconv.Itoa(controller.Port)))
+	if err != nil {
+		t.Fatalf("dial controller: %v", err)
+	}
+	defer ctrlConn.Close()
+
+	if err := ctrlConn.CreateTopics(kafka.TopicConfig{Topic: topic, NumPartitions: 1, ReplicationFactor: 1}); err != nil {
+		// CreateTopics returns an error if the topic already exists; tolerate it.
+		t.Logf("CreateTopics(%q): %v (continuing — may already exist)", topic, err)
+	}
+}
+
+// writeWithRetry retries the produce briefly while leader election settles after
+// topic creation.
+func writeWithRetry(ctx context.Context, w *kafka.Writer, msg kafka.Message) error {
+	deadline := time.Now().Add(30 * time.Second)
+	var err error
+	for {
+		if err = w.WriteMessages(ctx, msg); err == nil {
+			return nil
+		}
+		if time.Now().After(deadline) || ctx.Err() != nil {
+			return err
+		}
+		time.Sleep(time.Second)
+	}
+}

--- a/src/cmd/rabbitmq-consumer/rabbitmq_integration_test.go
+++ b/src/cmd/rabbitmq-consumer/rabbitmq_integration_test.go
@@ -1,0 +1,91 @@
+//go:build integration
+
+// Integration test for the RabbitMQ consumer against a live broker
+// (rabbitmq:3-management). It declares a queue (durable, as the connector does),
+// publishes a message, and consumes it with manual ack — the same AMQP surface
+// the connector uses. Run:
+//
+//	docker compose up -d rabbitmq-test
+//	RABBITMQ_TEST_URL=amqp://guest:guest@localhost:5672/ \
+//	  go test -tags=integration -run RabbitMQ ./cmd/rabbitmq-consumer/...
+//
+// Skipped unless RABBITMQ_TEST_URL is set.
+package main
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	amqp "github.com/rabbitmq/amqp091-go"
+)
+
+func TestRabbitMQ_RoundTrip_Integration(t *testing.T) {
+	url := os.Getenv("RABBITMQ_TEST_URL")
+	if url == "" {
+		t.Skip("RABBITMQ_TEST_URL not set; skipping RabbitMQ integration test")
+	}
+
+	// rabbitmq:3-management can take a while to accept connections; retry briefly.
+	conn := dialRabbitWithRetry(t, url, 60*time.Second)
+	defer conn.Close()
+
+	ch, err := conn.Channel()
+	if err != nil {
+		t.Fatalf("channel: %v", err)
+	}
+	defer ch.Close()
+
+	const queue = "vrsky-it-queue"
+	if _, err := ch.QueueDeclare(queue, true /* durable */, false, false, false, nil); err != nil {
+		t.Fatalf("QueueDeclare: %v", err)
+	}
+	// Clean any leftovers from a previous run so we assert on our own message.
+	if _, err := ch.QueuePurge(queue, false); err != nil {
+		t.Fatalf("QueuePurge: %v", err)
+	}
+
+	payload := []byte(`{"hello":"rabbitmq"}`)
+	if err := ch.Publish("", queue, false, false, amqp.Publishing{
+		ContentType:  "application/json",
+		DeliveryMode: amqp.Persistent,
+		Body:         payload,
+	}); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+
+	// Consume with manual ack (the connector acks only after a successful publish).
+	deliveries, err := ch.Consume(queue, "", false /* autoAck */, false, false, false, nil)
+	if err != nil {
+		t.Fatalf("Consume: %v", err)
+	}
+
+	select {
+	case d := <-deliveries:
+		if string(d.Body) != string(payload) {
+			t.Errorf("delivery body = %q, want %q", d.Body, payload)
+		}
+		if err := d.Ack(false); err != nil {
+			t.Errorf("Ack: %v", err)
+		}
+	case <-time.After(20 * time.Second):
+		t.Fatal("timed out waiting for message")
+	}
+
+	_, _ = ch.QueueDelete(queue, false, false, false) // cleanup
+}
+
+func dialRabbitWithRetry(t *testing.T, url string, timeout time.Duration) *amqp.Connection {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for {
+		conn, err := amqp.Dial(url)
+		if err == nil {
+			return conn
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("amqp dial: %v", err)
+		}
+		time.Sleep(time.Second)
+	}
+}

--- a/src/cmd/sftp-consumer/sftp_integration_test.go
+++ b/src/cmd/sftp-consumer/sftp_integration_test.go
@@ -37,7 +37,11 @@ func TestSFTP_RoundTrip_Integration(t *testing.T) {
 	}
 	port := 22
 	if p := os.Getenv("SFTP_TEST_PORT"); p != "" {
-		port, _ = strconv.Atoi(p)
+		parsed, err := strconv.Atoi(p)
+		if err != nil {
+			t.Fatalf("invalid SFTP_TEST_PORT %q: %v", p, err)
+		}
+		port = parsed
 	}
 	user := sftpEnvOr("SFTP_TEST_USER", "vrsky")
 	pass := sftpEnvOr("SFTP_TEST_PASS", "vrsky")

--- a/src/cmd/sftp-consumer/sftp_integration_test.go
+++ b/src/cmd/sftp-consumer/sftp_integration_test.go
@@ -1,0 +1,138 @@
+//go:build integration
+
+// Integration test for the SFTP consumer against a live SFTP server
+// (atmoz/sftp). It uploads a file with a raw client (the connector's sftpConn is
+// read-only — it is a consumer), then exercises the connector's real connection
+// code (realDial) + List/Read/Rename/Remove. Run:
+//
+//	docker compose up -d sftp-test
+//	SFTP_TEST_HOST=localhost SFTP_TEST_PORT=2222 \
+//	  go test -tags=integration -run SFTP ./cmd/sftp-consumer/...
+//
+// Skipped unless SFTP_TEST_HOST is set.
+package main
+
+import (
+	"net"
+	"os"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/pkg/sftp"
+	"golang.org/x/crypto/ssh"
+)
+
+func sftpEnvOr(k, def string) string {
+	if v := os.Getenv(k); v != "" {
+		return v
+	}
+	return def
+}
+
+func TestSFTP_RoundTrip_Integration(t *testing.T) {
+	host := os.Getenv("SFTP_TEST_HOST")
+	if host == "" {
+		t.Skip("SFTP_TEST_HOST not set; skipping SFTP integration test")
+	}
+	port := 22
+	if p := os.Getenv("SFTP_TEST_PORT"); p != "" {
+		port, _ = strconv.Atoi(p)
+	}
+	user := sftpEnvOr("SFTP_TEST_USER", "vrsky")
+	pass := sftpEnvOr("SFTP_TEST_PASS", "vrsky")
+	// atmoz/sftp ("vrsky:vrsky:::upload") makes only the listed dir writable.
+	dir := sftpEnvOr("SFTP_TEST_DIR", "upload")
+
+	cfg := &SFTPConfig{Host: host, Port: port, Username: user, Password: pass, RemoteDir: dir}
+
+	// --- setup: upload a file with a raw client (connector only reads) ---
+	rawSSH, raw := rawSFTPClient(t, cfg)
+	defer rawSSH.Close()
+	defer raw.Close()
+
+	key := dir + "/it-order.json"
+	payload := []byte(`{"id":1,"name":"Acme"}`)
+	wf, err := raw.Create(key)
+	if err != nil {
+		t.Fatalf("raw create %q: %v", key, err)
+	}
+	if _, err := wf.Write(payload); err != nil {
+		t.Fatalf("raw write: %v", err)
+	}
+	if err := wf.Close(); err != nil {
+		t.Fatalf("raw close: %v", err)
+	}
+
+	// --- exercise the connector's real connection code ---
+	conn, err := realDial(cfg)
+	if err != nil {
+		t.Fatalf("realDial: %v", err)
+	}
+	defer conn.Close()
+
+	files, err := conn.List(dir)
+	if err != nil {
+		t.Fatalf("List(%q): %v", dir, err)
+	}
+	found := false
+	for _, f := range files {
+		if f.Name == "it-order.json" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("List(%q) missing it-order.json: %+v", dir, files)
+	}
+
+	body, err := conn.Read(key)
+	if err != nil {
+		t.Fatalf("Read(%q): %v", key, err)
+	}
+	if string(body) != string(payload) {
+		t.Errorf("Read body = %q, want %q", body, payload)
+	}
+
+	// Rename (after_action=move uses this) then Remove (after_action=delete).
+	moved := dir + "/it-order.processed.json"
+	if err := conn.Rename(key, moved); err != nil {
+		t.Fatalf("Rename: %v", err)
+	}
+	if err := conn.Remove(moved); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+}
+
+// rawSFTPClient opens a plain SSH+SFTP client for test setup (writing files the
+// read-only connector will then ingest).
+func rawSFTPClient(t *testing.T, cfg *SFTPConfig) (*ssh.Client, *sftp.Client) {
+	t.Helper()
+	sshCfg := &ssh.ClientConfig{
+		User:            cfg.Username,
+		Auth:            []ssh.AuthMethod{ssh.Password(cfg.Password)},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(), //nolint:gosec // test-only
+		Timeout:         15 * time.Second,
+	}
+	addr := net.JoinHostPort(cfg.Host, strconv.Itoa(cfg.Port))
+
+	// atmoz/sftp may still be starting; retry briefly.
+	var sshClient *ssh.Client
+	var err error
+	deadline := time.Now().Add(30 * time.Second)
+	for {
+		sshClient, err = ssh.Dial("tcp", addr, sshCfg)
+		if err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("ssh dial %s: %v", addr, err)
+		}
+		time.Sleep(time.Second)
+	}
+	client, err := sftp.NewClient(sshClient)
+	if err != nil {
+		_ = sshClient.Close()
+		t.Fatalf("sftp client: %v", err)
+	}
+	return sshClient, client
+}

--- a/src/go.mod
+++ b/src/go.mod
@@ -3,14 +3,17 @@ module github.com/ValueRetail/vrsky
 go 1.22
 
 require (
+	cloud.google.com/go/pubsub v1.40.0
 	cloud.google.com/go/storage v1.43.0
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.3.2
+	github.com/Azure/azure-sdk-for-go/sdk/storage/azqueue v1.0.0
 	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/PaesslerAG/jsonpath v0.1.1
 	github.com/aws/aws-sdk-go-v2 v1.30.5
 	github.com/aws/aws-sdk-go-v2/config v1.27.33
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.32
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.61.2
+	github.com/aws/aws-sdk-go-v2/service/sqs v1.34.9
 	github.com/bytecodealliance/wasmtime-go/v13 v13.0.0
 	github.com/coreos/go-oidc/v3 v3.10.0
 	github.com/expr-lang/expr v1.17.8
@@ -33,6 +36,7 @@ require (
 	golang.org/x/sync v0.7.0
 	golang.org/x/time v0.5.0
 	google.golang.org/api v0.187.0
+	google.golang.org/grpc v1.64.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.29.0
 	k8s.io/apimachinery v0.29.0
@@ -58,7 +62,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.3.19 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.11.19 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.17.17 // indirect
-	github.com/aws/aws-sdk-go-v2/service/sqs v1.34.9 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.22.7 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.26.7 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.30.7 // indirect
@@ -128,7 +131,6 @@ require (
 	google.golang.org/genproto v0.0.0-20240624140628-dc46fd24d27d // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240617180043-68d350f18fd4 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240624140628-dc46fd24d27d // indirect
-	google.golang.org/grpc v1.64.0 // indirect
 	google.golang.org/protobuf v1.34.2 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/src/go.sum
+++ b/src/go.sum
@@ -11,6 +11,8 @@ cloud.google.com/go/iam v1.1.8 h1:r7umDwhj+BQyz0ScZMp4QrGXjSTI3ZINnpgU2nlB/K0=
 cloud.google.com/go/iam v1.1.8/go.mod h1:GvE6lyMmfxXauzNq8NbgJbeVQNspG+tcdL/W8QO1+zE=
 cloud.google.com/go/longrunning v0.5.7 h1:WLbHekDbjK1fVFD3ibpFFVoyizlLRl73I7YKuAKilhU=
 cloud.google.com/go/longrunning v0.5.7/go.mod h1:8GClkudohy1Fxm3owmBGid8W0pSgodEMwEAztp38Xng=
+cloud.google.com/go/pubsub v1.40.0 h1:0LdP+zj5XaPAGtWr2V6r88VXJlmtaB/+fde1q3TU8M0=
+cloud.google.com/go/pubsub v1.40.0/go.mod h1:BVJI4sI2FyXp36KFKvFwcfDRDfR8MiLT8mMhmIhdAeA=
 cloud.google.com/go/storage v1.43.0 h1:CcxnSohZwizt4LCzQHWvBf1/kvtHUn7gk9QERXPyXFs=
 cloud.google.com/go/storage v1.43.0/go.mod h1:ajvxEa7WmZS1PxvKRq4bq0tFT3vMd502JwstCcYv0Q0=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.11.1 h1:E+OJmp2tPvt1W+amx48v1eqbjDYsgN+RzP4q16yV5eM=
@@ -23,6 +25,8 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.5.0 
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.5.0/go.mod h1:T5RfihdXtBDxt1Ch2wobif3TvzTdumDy29kahv6AV9A=
 github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.3.2 h1:YUUxeiOWgdAQE3pXt2H7QXzZs0q8UBjgRbl56qo8GYM=
 github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.3.2/go.mod h1:dmXQgZuiSubAecswZE+Sm8jkvEa7kQgTPVRvwL/nd0E=
+github.com/Azure/azure-sdk-for-go/sdk/storage/azqueue v1.0.0 h1:lJwNFV+xYjHREUTHJKx/ZF6CJSt9znxmLw9DqSTvyRU=
+github.com/Azure/azure-sdk-for-go/sdk/storage/azqueue v1.0.0/go.mod h1:GfT0aGew8Qj5yiQVqOO5v7N8fanbJGyUoHqXg56qcVY=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.2.1 h1:DzHpqpoJVaCgOUdVHxE8QB52S6NiVdDQvGlny1qvPqA=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.2.1/go.mod h1:wP83P5OoQ5p6ip3ScPr0BAq0BvuPAvacpEuSzyouqAI=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
@@ -130,6 +134,7 @@ github.com/gofrs/uuid v4.0.0+incompatible h1:1SD/1F5pU8p29ybwgQSwpQk+mwdRrXCYuPh
 github.com/gofrs/uuid v4.0.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
+github.com/golang-jwt/jwt v3.2.1+incompatible h1:73Z+4BJcrTC+KczS6WvTPvRGOp1WmfEP4Q1lOd9Z/+c=
 github.com/golang-jwt/jwt/v5 v5.2.0 h1:d/ix8ftRUorsN+5eMIlF4T6J8CAt9rch3My2winC1Jw=
 github.com/golang-jwt/jwt/v5 v5.2.0/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=

--- a/ui/src/components/Pipeline/PropertyEditor.tsx
+++ b/ui/src/components/Pipeline/PropertyEditor.tsx
@@ -1225,30 +1225,84 @@ function CloudStorageConfigEditor({
             onChange={(v) => update({ mode: v })}
             options={[
               { value: 'poll', label: 'Poll (list the bucket on an interval)' },
-              { value: 'event', label: 'Event-driven (S3 → SQS)' },
+              { value: 'event', label: 'Event-driven (queue / subscription)' },
             ]}
           />
 
           {mode === 'event' ? (
             <>
-              <StyledInput
-                label="SQS queue URL"
-                placeholder="https://sqs.us-east-1.amazonaws.com/123456789012/my-queue"
-                value={(cs.event_queue_url as string) || ''}
-                onChange={(v) => update({ event_queue_url: v })}
-              />
-              <StyledInput
-                label="SQS endpoint override (optional, e.g. LocalStack)"
-                placeholder="http://localstack:4566"
-                value={(cs.event_endpoint as string) || ''}
-                onChange={(v) => update({ event_endpoint: v })}
-              />
-              <div style={{ fontSize: '11px', color: '#6b7280' }}>
-                Subscribe the bucket's notifications to this SQS queue (S3 only). Each object is
-                ingested as it arrives; the message is acked only after a successful publish.
-                The endpoint override is for the SQS service (distinct from the object-store
-                endpoint above); leave blank for real AWS SQS. Azure Blob / GCS use poll mode.
-              </div>
+              {provider === 's3' && (
+                <>
+                  <StyledInput
+                    label="SQS queue URL"
+                    placeholder="https://sqs.us-east-1.amazonaws.com/123456789012/my-queue"
+                    value={(cs.event_queue_url as string) || ''}
+                    onChange={(v) => update({ event_queue_url: v })}
+                  />
+                  <StyledInput
+                    label="SQS endpoint override (optional, e.g. LocalStack)"
+                    placeholder="http://localstack:4566"
+                    value={(cs.event_endpoint as string) || ''}
+                    onChange={(v) => update({ event_endpoint: v })}
+                  />
+                  <div style={{ fontSize: '11px', color: '#6b7280' }}>
+                    Subscribe the bucket's notifications to this SQS queue. Each object is ingested
+                    as it arrives; the message is acked only after a successful publish. The
+                    endpoint override is for the SQS service (distinct from the object-store
+                    endpoint above); leave blank for real AWS SQS.
+                  </div>
+                </>
+              )}
+              {provider === 'azure' && (
+                <>
+                  <StyledInput
+                    label="Storage Queue name"
+                    placeholder="blob-events"
+                    value={(cs.event_queue_name as string) || ''}
+                    onChange={(v) => update({ event_queue_name: v })}
+                  />
+                  <StyledInput
+                    label="Queue endpoint override (optional, e.g. Azurite)"
+                    placeholder="http://azurite:10001/devstoreaccount1"
+                    value={(cs.event_endpoint as string) || ''}
+                    onChange={(v) => update({ event_endpoint: v })}
+                  />
+                  <div style={{ fontSize: '11px', color: '#6b7280' }}>
+                    Route the container's Blob events through Event Grid into this Storage Queue.
+                    The queue is long-polled and each message is deleted only after a successful
+                    publish. It uses the same connection string / account credentials as the
+                    container above; the endpoint override targets the Azurite emulator.
+                  </div>
+                </>
+              )}
+              {provider === 'gcs' && (
+                <>
+                  <StyledInput
+                    label="Pub/Sub subscription"
+                    placeholder="gcs-events-sub (or projects/…/subscriptions/…)"
+                    value={(cs.event_subscription as string) || ''}
+                    onChange={(v) => update({ event_subscription: v })}
+                  />
+                  <StyledInput
+                    label="GCP project ID (required for a bare subscription name)"
+                    placeholder="my-project"
+                    value={(cs.event_project as string) || ''}
+                    onChange={(v) => update({ event_project: v })}
+                  />
+                  <StyledInput
+                    label="Pub/Sub endpoint override (optional, e.g. emulator)"
+                    placeholder="localhost:8085"
+                    value={(cs.event_endpoint as string) || ''}
+                    onChange={(v) => update({ event_endpoint: v })}
+                  />
+                  <div style={{ fontSize: '11px', color: '#6b7280' }}>
+                    Create a bucket notification to a Pub/Sub topic and a pull subscription on it.
+                    Messages are pulled and acked only after a successful publish (OBJECT_FINALIZE
+                    events are ingested). Uses the service-account JSON above; the endpoint
+                    override targets the Pub/Sub emulator.
+                  </div>
+                </>
+              )}
             </>
           ) : (
             <StyledInput


### PR DESCRIPTION
Batches the two remaining open Phase-2 follow-ups into one PR.

## #106 — Cloud storage event-driven ingestion for Azure Blob + GCS
Brings Azure Blob and GCS to parity with the shipped S3→SQS event mode, behind the existing pluggable `eventSource` interface (`cmd/cloud-storage-consumer/events.go`).

- **Azure Blob → Storage Queue** (`events_azure.go`): long-poll `DequeueMessages`, parse Event Grid `BlobCreated` notifications (base64/raw, array/single, key from `subject` or `data.url`, URL-decode), delete-after-publish. Auth via connection string (also Azurite) or account+key.
- **GCS → Pub/Sub** (`events_gcs.go`): low-level `apiv1.SubscriberClient` Pull/Acknowledge (maps cleanly onto the pull/ack-handle interface), `OBJECT_FINALIZE` filter, ack-after-publish. Service-account JSON or emulator endpoint.
- `newEventSource` dispatches `azure`/`gcs`; new config fields `event_queue_name`, `event_subscription`, `event_project` with provider-aware `validateEventConfig()`/`eventTarget()`.
- **UI**: `CloudStorageConfigEditor` event-mode block is now provider-aware (SQS URL / Storage Queue name / Pub/Sub subscription + project), each with the right endpoint override + help text.
- Deps pinned for Go 1.22: `azqueue v1.0.0`, `pubsub v1.40.0` (go directive unchanged).

## #107 — CI: wire integration broker tests + author the missing ones
- New `//go:build integration` round-trip tests reusing the real connector paths: **sftp** (`realDial`→List/Read/Rename/Remove vs atmoz/sftp), **kafka** (`realReader`.Fetch+commit & `realKafkaPing` vs apache/kafka), **rabbitmq** (declare/publish/consume+ack vs rabbitmq:3-management). Each self-skips unless its `*_TEST_*` env var is set.
- New `.github/workflows/integration.yml`: brings up the six test brokers via compose, waits for TCP readiness, runs all integration-tagged tests (objectstore S3/Azure/GCS + sftp/kafka/rabbitmq) from a `golang:1.22` container **on `vrsky-network`** so fake-gcs resolves by service name (per the note in `gcs_integration_test.go`). Dumps broker logs on failure, tears down.

## Verification
- `go build ./...`, `go vet ./...` (incl. `-tags=integration`), `make lint` (tenant + connector), gofmt — all clean.
- Unit tests pass; UI builds (lint unchanged from baseline).
- **Integration tests run live in-network** — all four packages PASS against the real brokers/emulators:
  - `pkg/objectstore` (Azure/GCS/S3 round-trips) ✓
  - `cmd/sftp-consumer` ✓ · `cmd/kafka-consumer` ✓ · `cmd/rabbitmq-consumer` ✓

Closes #106
Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)