### PR TITLE
Phase 3B (#85): /healthz + /readyz probes with upstream checks + drain-on-shutdown

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -30,9 +30,30 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5
 
+      - name: Pull images (with retry)
+        # Docker Hub aggressively rate-limits / times out anonymous pulls from
+        # shared GitHub Actions IPs, so retry rather than fail the whole run on a
+        # transient "context deadline exceeded". busybox is pulled here too — the
+        # readiness step shells out to it.
+        run: |
+          retry() {
+            local n=0 max=5
+            until "$@"; do
+              n=$((n+1))
+              if [ "$n" -ge "$max" ]; then
+                echo "ERROR: '$*' failed after $max attempts"; return 1
+              fi
+              echo "attempt $n/$max failed; retrying in 15s…"; sleep 15
+            done
+          }
+          retry docker compose pull --quiet \
+            minio-test minio-init azurite-test fake-gcs-test \
+            sftp-test kafka-test rabbitmq-test
+          retry docker pull busybox:latest
+
       - name: Start test brokers
         run: |
-          docker compose up -d \
+          docker compose up -d --no-build \
             minio-test minio-init azurite-test fake-gcs-test \
             sftp-test kafka-test rabbitmq-test
 

--- a/infrastructure/kubernetes/converter/deployment.yaml
+++ b/infrastructure/kubernetes/converter/deployment.yaml
@@ -106,7 +106,7 @@ spec:
         # Liveness probe - restart if converter becomes unhealthy
         livenessProbe:
           httpGet:
-            path: /health
+            path: /healthz
             port: 8080
           initialDelaySeconds: 30
           periodSeconds: 10
@@ -116,7 +116,7 @@ spec:
         # Readiness probe - remove from service if not ready
         readinessProbe:
           httpGet:
-            path: /ready
+            path: /readyz
             port: 8080
           initialDelaySeconds: 10
           periodSeconds: 5

--- a/infrastructure/kubernetes/management-api/deployment.yaml
+++ b/infrastructure/kubernetes/management-api/deployment.yaml
@@ -80,7 +80,7 @@ spec:
         # Liveness probe - restart if API becomes unresponsive
         livenessProbe:
           httpGet:
-            path: /health
+            path: /healthz
             port: 3000
           initialDelaySeconds: 10
           periodSeconds: 15
@@ -90,7 +90,7 @@ spec:
         # Readiness probe - remove from load balancer if not ready
         readinessProbe:
           httpGet:
-            path: /ready
+            path: /readyz
             port: 3000
           initialDelaySeconds: 5
           periodSeconds: 10

--- a/src/cmd/api-consumer/Dockerfile
+++ b/src/cmd/api-consumer/Dockerfile
@@ -25,6 +25,6 @@ COPY --from=builder /app/api-consumer .
 EXPOSE 8080 9800
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
-    CMD curl -f http://localhost:8080/health || exit 1
+    CMD curl -f http://localhost:8080/healthz || exit 1
 
 ENTRYPOINT ["./api-consumer"]

--- a/src/cmd/cloud-storage-consumer/Dockerfile
+++ b/src/cmd/cloud-storage-consumer/Dockerfile
@@ -20,8 +20,8 @@ RUN apk --no-cache add ca-certificates curl
 WORKDIR /app
 COPY --from=builder /app/cloud-storage-consumer .
 
-# The SDK runner serves /health on HEALTH_PORT (default 8080).
+# The SDK runner serves /healthz + /readyz on HEALTH_PORT (default 8080).
 HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
-    CMD curl -f http://localhost:8080/health || exit 1
+    CMD curl -f http://localhost:8080/healthz || exit 1
 
 ENTRYPOINT ["./cloud-storage-consumer"]

--- a/src/cmd/cloud-storage-producer/Dockerfile
+++ b/src/cmd/cloud-storage-producer/Dockerfile
@@ -20,8 +20,8 @@ RUN apk --no-cache add ca-certificates curl
 WORKDIR /app
 COPY --from=builder /app/cloud-storage-producer .
 
-# The SDK runner serves /health on HEALTH_PORT (default 8080).
+# The SDK runner serves /healthz + /readyz on HEALTH_PORT (default 8080).
 HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
-    CMD curl -f http://localhost:8080/health || exit 1
+    CMD curl -f http://localhost:8080/healthz || exit 1
 
 ENTRYPOINT ["./cloud-storage-producer"]

--- a/src/cmd/data-converter/Dockerfile
+++ b/src/cmd/data-converter/Dockerfile
@@ -23,6 +23,6 @@ COPY --from=builder /app/data-converter .
 EXPOSE 9600
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
-  CMD curl -f http://localhost:9600/health || exit 1
+  CMD curl -f http://localhost:9600/healthz || exit 1
 
 ENTRYPOINT ["./data-converter"]

--- a/src/cmd/data-converter/main.go
+++ b/src/cmd/data-converter/main.go
@@ -35,9 +35,9 @@ type Config struct {
 type FieldMapping struct {
 	Source     string      `json:"source"`               // source field path (e.g. "name")
 	Target     string      `json:"target"`               // target field name (e.g. "full_name")
-	Type       string      `json:"type,omitempty"`        // "rename", "copy", "static", "remove", "template"
-	Value      interface{} `json:"value,omitempty"`       // for static type
-	Expression string      `json:"expression,omitempty"`  // for template type
+	Type       string      `json:"type,omitempty"`       // "rename", "copy", "static", "remove", "template"
+	Value      interface{} `json:"value,omitempty"`      // for static type
+	Expression string      `json:"expression,omitempty"` // for template type
 }
 
 // ConverterNodeConfig is what the UI stores in the node config
@@ -89,12 +89,12 @@ type ConverterService struct {
 }
 
 type ConvertEvent struct {
-	Type    string `json:"type"`              // "converted", "error", "info", "connected"
+	Type    string `json:"type"` // "converted", "error", "info", "connected"
 	Message string `json:"message,omitempty"`
 	Time    string `json:"time"`
-	Before  string `json:"before,omitempty"`  // original payload preview
-	After   string `json:"after,omitempty"`   // transformed payload preview
-	Fields  int    `json:"fields,omitempty"`  // number of fields mapped
+	Before  string `json:"before,omitempty"` // original payload preview
+	After   string `json:"after,omitempty"`  // transformed payload preview
+	Fields  int    `json:"fields,omitempty"` // number of fields mapped
 }
 
 func main() {
@@ -160,10 +160,10 @@ func main() {
 		pipelineCache:     make(map[string]*ConverterPipelineInfo),
 		pipelineCacheTime: make(map[string]time.Time),
 		pipelineCacheTTL:  5 * time.Minute,
-		eventSubs:       make(map[string][]chan ConvertEvent),
-		recentEvents:    make(map[string][]ConvertEvent),
-		stopCh:          make(chan struct{}),
-		stoppedCh:       make(chan struct{}),
+		eventSubs:         make(map[string][]chan ConvertEvent),
+		recentEvents:      make(map[string][]ConvertEvent),
+		stopCh:            make(chan struct{}),
+		stoppedCh:         make(chan struct{}),
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -824,9 +824,26 @@ func (s *ConverterService) getRecentEvents(connectionID string) []ConvertEvent {
 func startHTTPServer(port string, service *ConverterService, logger *slog.Logger) {
 	mux := http.NewServeMux()
 
-	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+	// Liveness: the process is up. /healthz is the canonical Kubernetes path;
+	// /health remains as a backward-compatible alias.
+	liveness := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"status":"ok"}`))
-	})
+	}
+	// Readiness: NATS must be connected (the only upstream this worker needs).
+	readiness := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if service.nc == nil || !service.nc.IsConnected() {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = w.Write([]byte(`{"status":"not ready","checks":{"nats":"error: not connected"}}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"status":"ready","checks":{"nats":"ok"}}`))
+	}
+	mux.HandleFunc("/health", liveness)
+	mux.HandleFunc("/healthz", liveness)
+	mux.HandleFunc("/ready", readiness)
+	mux.HandleFunc("/readyz", readiness)
 
 	// Preview endpoint: test transformations without deploying
 	mux.HandleFunc("/preview/", func(w http.ResponseWriter, r *http.Request) {

--- a/src/cmd/data-filter/Dockerfile
+++ b/src/cmd/data-filter/Dockerfile
@@ -23,6 +23,6 @@ COPY --from=builder /app/data-filter .
 EXPOSE 9700
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
-  CMD curl -f http://localhost:9700/health || exit 1
+  CMD curl -f http://localhost:9700/healthz || exit 1
 
 ENTRYPOINT ["./data-filter"]

--- a/src/cmd/data-filter/main.go
+++ b/src/cmd/data-filter/main.go
@@ -81,7 +81,7 @@ type FilterService struct {
 }
 
 type FilterEvent struct {
-	Type    string `json:"type"`              // "passed", "dropped", "error", "info", "connected"
+	Type    string `json:"type"` // "passed", "dropped", "error", "info", "connected"
 	Message string `json:"message,omitempty"`
 	Time    string `json:"time"`
 	Data    string `json:"data,omitempty"` // row that was evaluated
@@ -777,9 +777,26 @@ func (s *FilterService) getRecentEvents(connectionID string) []FilterEvent {
 func startHTTPServer(port string, service *FilterService, logger *slog.Logger) {
 	mux := http.NewServeMux()
 
-	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+	// Liveness: the process is up. /healthz is the canonical Kubernetes path;
+	// /health remains as a backward-compatible alias.
+	liveness := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"status":"ok"}`))
-	})
+	}
+	// Readiness: NATS must be connected (the only upstream this worker needs).
+	readiness := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if service.nc == nil || !service.nc.IsConnected() {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = w.Write([]byte(`{"status":"not ready","checks":{"nats":"error: not connected"}}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"status":"ready","checks":{"nats":"ok"}}`))
+	}
+	mux.HandleFunc("/health", liveness)
+	mux.HandleFunc("/healthz", liveness)
+	mux.HandleFunc("/ready", readiness)
+	mux.HandleFunc("/readyz", readiness)
 
 	mux.HandleFunc("/events/", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Access-Control-Allow-Origin", "*")

--- a/src/cmd/db-consumer/Dockerfile
+++ b/src/cmd/db-consumer/Dockerfile
@@ -25,6 +25,6 @@ EXPOSE 9300
 # Health is served by the SDK runner on HEALTH_PORT (default 8080); SSE +
 # /test-connection + /sample-data live on 9300.
 HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
-  CMD curl -f http://localhost:8080/health || exit 1
+  CMD curl -f http://localhost:8080/healthz || exit 1
 
 ENTRYPOINT ["./db-consumer"]

--- a/src/cmd/db-producer/Dockerfile
+++ b/src/cmd/db-producer/Dockerfile
@@ -25,6 +25,6 @@ EXPOSE 9500
 # Health is served by the SDK runner on HEALTH_PORT (default 8080); SSE +
 # /test-connection live on 9500.
 HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
-  CMD curl -f http://localhost:8080/health || exit 1
+  CMD curl -f http://localhost:8080/healthz || exit 1
 
 ENTRYPOINT ["./db-producer"]

--- a/src/cmd/file-consumer/Dockerfile
+++ b/src/cmd/file-consumer/Dockerfile
@@ -37,6 +37,6 @@ RUN chmod +x ./file-consumer
 EXPOSE 8080 9200
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD curl -f http://localhost:8080/health || exit 1
+    CMD curl -f http://localhost:8080/healthz || exit 1
 
 ENTRYPOINT ["./file-consumer"]

--- a/src/cmd/http-producer/Dockerfile
+++ b/src/cmd/http-producer/Dockerfile
@@ -25,6 +25,6 @@ EXPOSE 9400
 # Health is served by the SDK runner on HEALTH_PORT (default 8080); the SSE
 # stream lives on 9400.
 HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
-  CMD curl -f http://localhost:8080/health || exit 1
+  CMD curl -f http://localhost:8080/healthz || exit 1
 
 ENTRYPOINT ["./http-producer"]

--- a/src/cmd/kafka-consumer/Dockerfile
+++ b/src/cmd/kafka-consumer/Dockerfile
@@ -20,8 +20,8 @@ RUN apk --no-cache add ca-certificates curl
 WORKDIR /app
 COPY --from=builder /app/kafka-consumer .
 
-# The SDK runner serves /health on HEALTH_PORT (default 8080).
+# The SDK runner serves /healthz + /readyz on HEALTH_PORT (default 8080).
 HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
-    CMD curl -f http://localhost:8080/health || exit 1
+    CMD curl -f http://localhost:8080/healthz || exit 1
 
 ENTRYPOINT ["./kafka-consumer"]

--- a/src/cmd/kafka-producer/Dockerfile
+++ b/src/cmd/kafka-producer/Dockerfile
@@ -20,8 +20,8 @@ RUN apk --no-cache add ca-certificates curl
 WORKDIR /app
 COPY --from=builder /app/kafka-producer .
 
-# The SDK runner serves /health on HEALTH_PORT (default 8080).
+# The SDK runner serves /healthz + /readyz on HEALTH_PORT (default 8080).
 HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
-    CMD curl -f http://localhost:8080/health || exit 1
+    CMD curl -f http://localhost:8080/healthz || exit 1
 
 ENTRYPOINT ["./kafka-producer"]

--- a/src/cmd/management-api/Dockerfile
+++ b/src/cmd/management-api/Dockerfile
@@ -52,7 +52,7 @@ RUN chmod +x ./management-api ./entrypoint.sh
 
 # Health check
 HEALTHCHECK --interval=10s --timeout=5s --retries=5 \
-    CMD curl -f http://localhost:3000/health || exit 1
+    CMD curl -f http://localhost:3000/healthz || exit 1
 
 EXPOSE 3000
 

--- a/src/cmd/management-api/cors.go
+++ b/src/cmd/management-api/cors.go
@@ -71,7 +71,9 @@ func TenantIDMiddleware(tenantHeader string) func(http.Handler) http.Handler {
 				strings.HasPrefix(r.URL.Path, "/api/v1/tenants") ||
 				r.URL.Path == "/api/v1/oauth/callback" ||
 				r.URL.Path == "/health" ||
-				r.URL.Path == "/ready" {
+				r.URL.Path == "/healthz" ||
+				r.URL.Path == "/ready" ||
+				r.URL.Path == "/readyz" {
 				next.ServeHTTP(w, r)
 				return
 			}

--- a/src/cmd/management-api/main.go
+++ b/src/cmd/management-api/main.go
@@ -9,6 +9,8 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strconv"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -65,7 +67,8 @@ func main() {
 	defer nc.Close()
 
 	// Setup HTTP server with graceful shutdown
-	server, tenantProvisioner := setupServer(config, db, nc, logger)
+	var shuttingDown atomic.Bool
+	server, tenantProvisioner := setupServer(config, db, nc, logger, &shuttingDown)
 
 	// Start server in a goroutine
 	serverErrs := make(chan error, 1)
@@ -85,6 +88,16 @@ func main() {
 		}
 	case sig := <-sigChan:
 		logger.Printf("Received signal: %v, shutting down...", sig)
+
+		// Flip /readyz to not-ready and wait a short drain window so Kubernetes
+		// removes this pod from Service endpoints before the HTTP server stops
+		// accepting connections (zero dropped in-flight requests on rolling
+		// deploy). Tunable via SHUTDOWN_DRAIN_SECONDS (default 5s).
+		shuttingDown.Store(true)
+		if d := shutdownDrainSeconds(); d > 0 {
+			logger.Printf("draining for %s before shutdown", d)
+			time.Sleep(d)
+		}
 
 		// Graceful shutdown with timeout
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -153,19 +166,20 @@ func initNATS(natsURL string, logger *log.Logger) (*nats.Conn, error) {
 // tenant provisioner so main() can drive its lifecycle (Stop on shutdown);
 // its background worker must outlive this function, so it must not be stopped
 // via defer here.
-func setupServer(config *Config, db *sql.DB, nc *nats.Conn, logger *log.Logger) (*http.Server, *managementapi.TenantProvisioner) {
+func setupServer(config *Config, db *sql.DB, nc *nats.Conn, logger *log.Logger, shuttingDown *atomic.Bool) (*http.Server, *managementapi.TenantProvisioner) {
 	mux := http.NewServeMux()
 
-	// Health check endpoints
-	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+	// Health check endpoints. /healthz + /readyz are the canonical Kubernetes
+	// probe paths; /health + /ready remain as backward-compatible aliases.
+	liveness := func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]string{
 			"status":    "healthy",
 			"timestamp": time.Now().UTC().Format(time.RFC3339),
 		})
-	})
+	}
 
-	mux.HandleFunc("/ready", func(w http.ResponseWriter, r *http.Request) {
+	readiness := func(w http.ResponseWriter, r *http.Request) {
 		// Check dependencies
 		deps := map[string]string{
 			"database": "ok",
@@ -174,6 +188,14 @@ func setupServer(config *Config, db *sql.DB, nc *nats.Conn, logger *log.Logger) 
 
 		// Determine HTTP status based on dependencies
 		statusCode := http.StatusOK
+		status := "ready"
+
+		// During graceful shutdown, report not-ready so Kubernetes removes this
+		// pod from Service endpoints before the HTTP server drains.
+		if shuttingDown.Load() {
+			statusCode = http.StatusServiceUnavailable
+			status = "shutting down"
+		}
 
 		// Verify database connectivity
 		ctx, cancel := context.WithTimeout(r.Context(), 2*time.Second)
@@ -181,24 +203,31 @@ func setupServer(config *Config, db *sql.DB, nc *nats.Conn, logger *log.Logger) 
 		if err := db.PingContext(ctx); err != nil {
 			deps["database"] = "error: " + err.Error()
 			statusCode = http.StatusServiceUnavailable
+			status = "not ready"
 		}
 
 		// Verify NATS connectivity
 		if !nc.IsConnected() {
 			deps["nats"] = "error: not connected"
 			statusCode = http.StatusServiceUnavailable
+			status = "not ready"
 		}
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(statusCode)
 		_ = json.NewEncoder(w).Encode(map[string]interface{}{
-			"status":       "ready",
+			"status":       status,
 			"timestamp":    time.Now().UTC().Format(time.RFC3339),
 			"dependencies": deps,
 			"service_name": config.ServiceName,
 			"version":      config.Version,
 		})
-	})
+	}
+
+	mux.HandleFunc("/health", liveness)
+	mux.HandleFunc("/healthz", liveness)
+	mux.HandleFunc("/ready", readiness)
+	mux.HandleFunc("/readyz", readiness)
 
 	// Initialize repository and validator
 	repo := managementapi.NewPostgresRepository(db)
@@ -324,4 +353,16 @@ func initK8sNATSProvisioner(logger *log.Logger) *managementapi.K8sNATSProvisione
 
 	logger.Printf("K8s client initialized for tenant NATS provisioning")
 	return managementapi.NewK8sNATSProvisioner(clientset, logger)
+}
+
+// shutdownDrainSeconds is how long to keep serving (with /readyz reporting
+// not-ready) after a shutdown signal, so Kubernetes de-registers the pod before
+// the HTTP server stops. Tunable via SHUTDOWN_DRAIN_SECONDS (default 5s).
+func shutdownDrainSeconds() time.Duration {
+	if v := os.Getenv("SHUTDOWN_DRAIN_SECONDS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			return time.Duration(n) * time.Second
+		}
+	}
+	return 5 * time.Second
 }

--- a/src/cmd/rabbitmq-consumer/Dockerfile
+++ b/src/cmd/rabbitmq-consumer/Dockerfile
@@ -20,8 +20,8 @@ RUN apk --no-cache add ca-certificates curl
 WORKDIR /app
 COPY --from=builder /app/rabbitmq-consumer .
 
-# The SDK runner serves /health on HEALTH_PORT (default 8080).
+# The SDK runner serves /healthz + /readyz on HEALTH_PORT (default 8080).
 HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
-    CMD curl -f http://localhost:8080/health || exit 1
+    CMD curl -f http://localhost:8080/healthz || exit 1
 
 ENTRYPOINT ["./rabbitmq-consumer"]

--- a/src/cmd/rabbitmq-producer/Dockerfile
+++ b/src/cmd/rabbitmq-producer/Dockerfile
@@ -20,8 +20,8 @@ RUN apk --no-cache add ca-certificates curl
 WORKDIR /app
 COPY --from=builder /app/rabbitmq-producer .
 
-# The SDK runner serves /health on HEALTH_PORT (default 8080).
+# The SDK runner serves /healthz + /readyz on HEALTH_PORT (default 8080).
 HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
-    CMD curl -f http://localhost:8080/health || exit 1
+    CMD curl -f http://localhost:8080/healthz || exit 1
 
 ENTRYPOINT ["./rabbitmq-producer"]

--- a/src/cmd/salesforce-consumer/Dockerfile
+++ b/src/cmd/salesforce-consumer/Dockerfile
@@ -20,8 +20,8 @@ RUN apk --no-cache add ca-certificates curl
 WORKDIR /app
 COPY --from=builder /app/salesforce-consumer .
 
-# The SDK runner serves /health on HEALTH_PORT (default 8080).
+# The SDK runner serves /healthz + /readyz on HEALTH_PORT (default 8080).
 HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
-    CMD curl -f http://localhost:8080/health || exit 1
+    CMD curl -f http://localhost:8080/healthz || exit 1
 
 ENTRYPOINT ["./salesforce-consumer"]

--- a/src/cmd/salesforce-producer/Dockerfile
+++ b/src/cmd/salesforce-producer/Dockerfile
@@ -20,8 +20,8 @@ RUN apk --no-cache add ca-certificates curl
 WORKDIR /app
 COPY --from=builder /app/salesforce-producer .
 
-# The SDK runner serves /health on HEALTH_PORT (default 8080).
+# The SDK runner serves /healthz + /readyz on HEALTH_PORT (default 8080).
 HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
-    CMD curl -f http://localhost:8080/health || exit 1
+    CMD curl -f http://localhost:8080/healthz || exit 1
 
 ENTRYPOINT ["./salesforce-producer"]

--- a/src/cmd/sftp-consumer/Dockerfile
+++ b/src/cmd/sftp-consumer/Dockerfile
@@ -20,8 +20,8 @@ RUN apk --no-cache add ca-certificates curl
 WORKDIR /app
 COPY --from=builder /app/sftp-consumer .
 
-# The SDK runner serves /health on HEALTH_PORT (default 8080).
+# The SDK runner serves /healthz + /readyz on HEALTH_PORT (default 8080).
 HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
-    CMD curl -f http://localhost:8080/health || exit 1
+    CMD curl -f http://localhost:8080/healthz || exit 1
 
 ENTRYPOINT ["./sftp-consumer"]

--- a/src/cmd/sftp-producer/Dockerfile
+++ b/src/cmd/sftp-producer/Dockerfile
@@ -20,8 +20,8 @@ RUN apk --no-cache add ca-certificates curl
 WORKDIR /app
 COPY --from=builder /app/sftp-producer .
 
-# The SDK runner serves /health on HEALTH_PORT (default 8080).
+# The SDK runner serves /healthz + /readyz on HEALTH_PORT (default 8080).
 HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
-    CMD curl -f http://localhost:8080/health || exit 1
+    CMD curl -f http://localhost:8080/healthz || exit 1
 
 ENTRYPOINT ["./sftp-producer"]

--- a/src/cmd/webhook-consumer/Dockerfile
+++ b/src/cmd/webhook-consumer/Dockerfile
@@ -28,6 +28,6 @@ COPY --from=builder /app/webhook-consumer .
 EXPOSE 8080 9100
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
-    CMD curl -f http://localhost:8080/health || exit 1
+    CMD curl -f http://localhost:8080/healthz || exit 1
 
 ENTRYPOINT ["./webhook-consumer"]

--- a/src/pkg/health/server.go
+++ b/src/pkg/health/server.go
@@ -8,11 +8,21 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"sync"
 	"sync/atomic"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
+
+// readinessCheckTimeout bounds each upstream readiness check so a hung
+// dependency can't stall the /readyz response (and the K8s probe).
+const readinessCheckTimeout = 2 * time.Second
+
+// ReadinessCheck verifies one upstream dependency (e.g. NATS connected, DB
+// reachable). It should return quickly and respect ctx; a non-nil error marks
+// the service not-ready.
+type ReadinessCheck func(ctx context.Context) error
 
 // Status represents the health check response
 type Status struct {
@@ -21,6 +31,9 @@ type Status struct {
 	Uptime    int64     `json:"uptime_seconds,omitempty"`
 	Component string    `json:"component,omitempty"`
 	NodeID    string    `json:"node_id,omitempty"`
+	// Checks reports per-dependency readiness status ("ok" or "error: …"); only
+	// populated on the readiness endpoint when checks are registered.
+	Checks map[string]string `json:"checks,omitempty"`
 }
 
 // Server provides HTTP health and metrics endpoints for Kubernetes probes
@@ -35,6 +48,14 @@ type Server struct {
 	metricsPath string
 	healthPath  string
 	readyPath   string
+
+	mu     sync.RWMutex
+	checks []namedCheck // upstream readiness checks, run on every /readyz request
+}
+
+type namedCheck struct {
+	name string
+	fn   ReadinessCheck
 }
 
 // Config holds configuration for the health server
@@ -97,10 +118,19 @@ func NewServer(cfg Config) *Server {
 	hs.isHealthy.Store(true)
 	hs.isReady.Store(true)
 
-	// Setup routes
+	// Setup routes. /healthz + /readyz are the canonical Kubernetes probe paths;
+	// the configured /health + /ready remain as backward-compatible aliases (so
+	// existing Dockerfile/compose/k8s probes keep working). Registering the same
+	// path twice would panic, so only add an alias when it differs.
 	mux := http.NewServeMux()
 	mux.HandleFunc(cfg.HealthPath, hs.handleHealth)
+	if cfg.HealthPath != "/healthz" {
+		mux.HandleFunc("/healthz", hs.handleHealth)
+	}
 	mux.HandleFunc(cfg.ReadyPath, hs.handleReady)
+	if cfg.ReadyPath != "/readyz" {
+		mux.HandleFunc("/readyz", hs.handleReady)
+	}
 	mux.Handle(cfg.MetricsPath, promhttp.Handler())
 
 	// Create HTTP server
@@ -143,6 +173,45 @@ func (s *Server) Stop(ctx context.Context) error {
 
 	s.logger.InfoContext(ctx, "Stopping health server")
 	return s.server.Shutdown(ctx)
+}
+
+// AddReadinessCheck registers an upstream dependency check run on every
+// readiness probe (e.g. "nats", "database"). Safe to call before or after
+// Start. Checks run in addition to the SetReady gate.
+func (s *Server) AddReadinessCheck(name string, fn ReadinessCheck) {
+	if s == nil || fn == nil {
+		return
+	}
+	s.mu.Lock()
+	s.checks = append(s.checks, namedCheck{name: name, fn: fn})
+	s.mu.Unlock()
+}
+
+// runReadinessChecks runs every registered check (each bounded by
+// readinessCheckTimeout) and returns the per-check results plus whether all
+// passed.
+func (s *Server) runReadinessChecks(ctx context.Context) (map[string]string, bool) {
+	s.mu.RLock()
+	checks := make([]namedCheck, len(s.checks))
+	copy(checks, s.checks)
+	s.mu.RUnlock()
+	if len(checks) == 0 {
+		return nil, true
+	}
+	results := make(map[string]string, len(checks))
+	ok := true
+	for _, c := range checks {
+		cctx, cancel := context.WithTimeout(ctx, readinessCheckTimeout)
+		err := c.fn(cctx)
+		cancel()
+		if err != nil {
+			results[c.name] = "error: " + err.Error()
+			ok = false
+		} else {
+			results[c.name] = "ok"
+		}
+	}
+	return results, ok
 }
 
 // SetReady marks the service as ready for traffic
@@ -200,8 +269,9 @@ func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 	_ = json.NewEncoder(w).Encode(response)
 }
 
-// handleReady handles GET /ready (readiness probe)
-// Returns 200 OK only when the service is ready to accept traffic
+// handleReady handles GET /ready and /readyz (readiness probe). Returns 200 OK
+// only when the service is marked ready (the SetReady gate — flipped false on
+// shutdown to drain) AND every registered upstream check passes.
 func (s *Server) handleReady(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
@@ -213,11 +283,20 @@ func (s *Server) handleReady(w http.ResponseWriter, r *http.Request) {
 		code = http.StatusServiceUnavailable
 	}
 
+	// Upstream dependency checks (NATS connected, DB reachable, …). Run even
+	// when already not-ready so the response names every failing dependency.
+	checks, ok := s.runReadinessChecks(r.Context())
+	if !ok {
+		status = "not ready"
+		code = http.StatusServiceUnavailable
+	}
+
 	response := Status{
 		Status:    status,
 		Timestamp: time.Now(),
 		Component: s.componentID,
 		NodeID:    s.nodeID,
+		Checks:    checks,
 	}
 
 	w.WriteHeader(code)

--- a/src/pkg/health/server_test.go
+++ b/src/pkg/health/server_test.go
@@ -201,7 +201,9 @@ func TestServer_ReadinessChecks(t *testing.T) {
 			t.Errorf("status = %d, want 200", resp.StatusCode)
 		}
 		var st Status
-		_ = json.NewDecoder(resp.Body).Decode(&st)
+		if err := json.NewDecoder(resp.Body).Decode(&st); err != nil {
+			t.Fatalf("decode /readyz response: %v", err)
+		}
 		if st.Checks["nats"] != "ok" {
 			t.Errorf("checks[nats] = %q, want ok", st.Checks["nats"])
 		}
@@ -222,7 +224,9 @@ func TestServer_ReadinessChecks(t *testing.T) {
 			t.Errorf("status = %d, want 503", resp.StatusCode)
 		}
 		var st Status
-		_ = json.NewDecoder(resp.Body).Decode(&st)
+		if err := json.NewDecoder(resp.Body).Decode(&st); err != nil {
+			t.Fatalf("decode /readyz response: %v", err)
+		}
 		if st.Status != "not ready" {
 			t.Errorf("status = %q, want 'not ready'", st.Status)
 		}

--- a/src/pkg/health/server_test.go
+++ b/src/pkg/health/server_test.go
@@ -184,6 +184,90 @@ func TestServer_handleReady(t *testing.T) {
 	}
 }
 
+func TestServer_ReadinessChecks(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	t.Run("passing check returns 200 with ok detail", func(t *testing.T) {
+		s := NewServer(Config{Logger: logger})
+		s.AddReadinessCheck("nats", func(context.Context) error { return nil })
+
+		req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+		w := httptest.NewRecorder()
+		s.handleReady(w, req)
+
+		resp := w.Result()
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("status = %d, want 200", resp.StatusCode)
+		}
+		var st Status
+		_ = json.NewDecoder(resp.Body).Decode(&st)
+		if st.Checks["nats"] != "ok" {
+			t.Errorf("checks[nats] = %q, want ok", st.Checks["nats"])
+		}
+	})
+
+	t.Run("failing check returns 503 and names the dependency", func(t *testing.T) {
+		s := NewServer(Config{Logger: logger})
+		s.AddReadinessCheck("nats", func(context.Context) error { return nil })
+		s.AddReadinessCheck("database", func(context.Context) error { return context.DeadlineExceeded })
+
+		req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+		w := httptest.NewRecorder()
+		s.handleReady(w, req)
+
+		resp := w.Result()
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusServiceUnavailable {
+			t.Errorf("status = %d, want 503", resp.StatusCode)
+		}
+		var st Status
+		_ = json.NewDecoder(resp.Body).Decode(&st)
+		if st.Status != "not ready" {
+			t.Errorf("status = %q, want 'not ready'", st.Status)
+		}
+		if st.Checks["nats"] != "ok" {
+			t.Errorf("checks[nats] = %q, want ok", st.Checks["nats"])
+		}
+		if st.Checks["database"] == "ok" || st.Checks["database"] == "" {
+			t.Errorf("checks[database] = %q, want an error", st.Checks["database"])
+		}
+	})
+
+	t.Run("no checks falls back to the static ready gate", func(t *testing.T) {
+		s := NewServer(Config{Logger: logger})
+		s.SetReady(false)
+		req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+		w := httptest.NewRecorder()
+		s.handleReady(w, req)
+		resp := w.Result()
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusServiceUnavailable {
+			t.Errorf("status = %d, want 503 (static gate)", resp.StatusCode)
+		}
+	})
+}
+
+// TestServer_CanonicalPaths confirms /healthz + /readyz are served alongside
+// the legacy /health + /ready aliases via the real mux.
+func TestServer_CanonicalPaths(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	s := NewServer(Config{Logger: logger, Port: 0})
+	srv := httptest.NewServer(s.server.Handler)
+	defer srv.Close()
+
+	for _, path := range []string{"/healthz", "/health", "/readyz", "/ready"} {
+		resp, err := http.Get(srv.URL + path)
+		if err != nil {
+			t.Fatalf("GET %s: %v", path, err)
+		}
+		_ = resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("GET %s = %d, want 200", path, resp.StatusCode)
+		}
+	}
+}
+
 func TestServer_SettersAndGetters(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	s := NewServer(Config{Logger: logger})

--- a/src/pkg/sdk/base.go
+++ b/src/pkg/sdk/base.go
@@ -36,12 +36,22 @@ type Resources struct {
 // healthToggle is the narrow slice of the health server connectors may touch.
 type healthToggle struct {
 	setReady func(bool)
+	addCheck func(name string, fn func(ctx context.Context) error)
 }
 
 // SetReady marks the worker ready/not-ready for traffic (Kubernetes readiness).
 func (h *healthToggle) SetReady(ready bool) {
 	if h != nil && h.setReady != nil {
 		h.setReady(ready)
+	}
+}
+
+// AddReadinessCheck registers an upstream dependency check run on every
+// readiness probe (/readyz). The runner already registers NATS (and DB when
+// configured); a connector can add its own (e.g. broker reachability).
+func (h *healthToggle) AddReadinessCheck(name string, fn func(ctx context.Context) error) {
+	if h != nil && h.addCheck != nil {
+		h.addCheck(name, fn)
 	}
 }
 

--- a/src/pkg/sdk/lifecycle.go
+++ b/src/pkg/sdk/lifecycle.go
@@ -183,14 +183,31 @@ func run(ctx context.Context, name string, c interface{}, configure func(context
 		}
 	}
 
-	// Health/metrics server (skippable in tests).
-	var setReady func(bool)
+	// Health/metrics server (skippable in tests). Registers default upstream
+	// readiness checks (NATS connected, DB reachable) so /readyz reflects real
+	// dependency state; flipped not-ready on shutdown to drain (see below).
+	var (
+		setReady func(bool)
+		addCheck func(string, func(context.Context) error)
+		drainFn  func()
+	)
 	if !o.disableHealth {
 		hsrv := health.NewServer(health.Config{
 			Port:        envInt("HEALTH_PORT", 8080),
 			ComponentID: name,
 			Logger:      logger,
 		})
+		hsrv.AddReadinessCheck("nats", func(context.Context) error {
+			if nc == nil || !nc.IsConnected() {
+				return fmt.Errorf("nats not connected")
+			}
+			return nil
+		})
+		if db != nil {
+			hsrv.AddReadinessCheck("database", func(cctx context.Context) error {
+				return db.PingContext(cctx)
+			})
+		}
 		if err := hsrv.Start(ctx); err != nil {
 			return fmt.Errorf("start health server: %w", err)
 		}
@@ -200,13 +217,15 @@ func run(ctx context.Context, name string, c interface{}, configure func(context
 			_ = hsrv.Stop(sctx)
 		}()
 		setReady = hsrv.SetReady
+		addCheck = func(name string, fn func(context.Context) error) { hsrv.AddReadinessCheck(name, fn) }
+		drainFn = func() { hsrv.SetReady(false) }
 	}
 
 	res := &Resources{
 		Logger: logger,
 		DB:     db,
 		NATS:   nc,
-		Health: &healthToggle{setReady: setReady},
+		Health: &healthToggle{setReady: setReady, addCheck: addCheck},
 	}
 
 	if err := configure(ctx, res); err != nil {
@@ -229,10 +248,31 @@ func run(ctx context.Context, name string, c interface{}, configure func(context
 	// Block until signalled (or parent ctx cancelled).
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+	fromSignal := false
 	select {
 	case <-runCtx.Done():
 	case <-sigCh:
+		fromSignal = true
 		logger.Info("shutdown signal received")
+	}
+
+	// Drain (signal-initiated shutdown only — i.e. a real SIGTERM from a K8s
+	// rolling deploy; programmatic ctx-cancel is the caller's own lifecycle):
+	// flip readiness to not-ready so Kubernetes removes this pod from Service
+	// endpoints BEFORE we stop consuming — the key to losing zero in-flight
+	// messages. Wait a short pre-stop window for that de-registration to land.
+	if fromSignal && drainFn != nil {
+		drainFn()
+		if d := shutdownDrain(); d > 0 {
+			logger.Info("draining before stop", "drain", d)
+			t := time.NewTimer(d)
+			select {
+			case <-t.C:
+			case <-sigCh: // a second signal skips the drain wait
+				t.Stop()
+				logger.Info("second signal; skipping drain wait")
+			}
+		}
 	}
 
 	// Graceful stop: cancel work, then wait for stop() within the grace window.
@@ -352,6 +392,13 @@ func openDB(dsn string) (*sql.DB, error) {
 		return nil, err
 	}
 	return db, nil
+}
+
+// shutdownDrain is how long the runner waits after flipping readiness to
+// not-ready (so K8s de-registers the pod) before it stops consuming. Tunable
+// via SHUTDOWN_DRAIN_SECONDS (default 5s; set 0 to disable, e.g. in tests).
+func shutdownDrain() time.Duration {
+	return time.Duration(envInt("SHUTDOWN_DRAIN_SECONDS", 5)) * time.Second
 }
 
 func envInt(key string, def int) int {

--- a/src/pkg/sdk/lifecycle.go
+++ b/src/pkg/sdk/lifecycle.go
@@ -217,7 +217,7 @@ func run(ctx context.Context, name string, c interface{}, configure func(context
 			_ = hsrv.Stop(sctx)
 		}()
 		setReady = hsrv.SetReady
-		addCheck = func(name string, fn func(context.Context) error) { hsrv.AddReadinessCheck(name, fn) }
+		addCheck = func(checkName string, fn func(context.Context) error) { hsrv.AddReadinessCheck(checkName, fn) }
 		drainFn = func() { hsrv.SetReady(false) }
 	}
 

--- a/src/pkg/sdk/runner_test.go
+++ b/src/pkg/sdk/runner_test.go
@@ -232,12 +232,14 @@ func TestRun_ProductionPath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GET /readyz: %v", err)
 	}
+	defer rr.Body.Close()
 	var ready struct {
 		Status string            `json:"status"`
 		Checks map[string]string `json:"checks"`
 	}
-	_ = json.NewDecoder(rr.Body).Decode(&ready)
-	_ = rr.Body.Close()
+	if err := json.NewDecoder(rr.Body).Decode(&ready); err != nil {
+		t.Fatalf("decode /readyz response: %v", err)
+	}
 	if rr.StatusCode != http.StatusOK {
 		t.Errorf("/readyz = %d, want 200", rr.StatusCode)
 	}

--- a/src/pkg/sdk/runner_test.go
+++ b/src/pkg/sdk/runner_test.go
@@ -2,6 +2,7 @@ package sdk_test
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"sync/atomic"
@@ -223,6 +224,25 @@ func TestRun_ProductionPath(t *testing.T) {
 	_ = resp.Body.Close()
 	if resp.StatusCode != http.StatusNoContent {
 		t.Errorf("aux /probe = %d, want 204", resp.StatusCode)
+	}
+
+	// /readyz runs the runner's default upstream checks; NATS is connected so it
+	// must be 200 with the nats check reported ok.
+	rr, err := http.Get("http://127.0.0.1:18195/readyz")
+	if err != nil {
+		t.Fatalf("GET /readyz: %v", err)
+	}
+	var ready struct {
+		Status string            `json:"status"`
+		Checks map[string]string `json:"checks"`
+	}
+	_ = json.NewDecoder(rr.Body).Decode(&ready)
+	_ = rr.Body.Close()
+	if rr.StatusCode != http.StatusOK {
+		t.Errorf("/readyz = %d, want 200", rr.StatusCode)
+	}
+	if ready.Checks["nats"] != "ok" {
+		t.Errorf("/readyz checks[nats] = %q, want ok", ready.Checks["nats"])
 	}
 
 	cancel()


### PR DESCRIPTION
Closes #85 — the first Phase 3 (operational maturity) issue.

## What
Every microservice now exposes **`/healthz`** (liveness) and **`/readyz`** (readiness *with upstream checks* — NATS connected, DB reachable), and rolling deploys **drain before stopping** so in-flight messages aren't lost.

### `pkg/health` — one change covers ~26 SDK/runtime services
- Serve `/healthz` + `/readyz` as the canonical K8s paths; **keep `/health` + `/ready` as backward-compatible aliases** (nothing breaks mid-rollout).
- New `AddReadinessCheck(name, fn)` registry. `/readyz` runs each check (2s timeout) and returns **503 + JSON `{checks:{dep:status}}`** on failure, alongside the existing `SetReady` gate (used for shutdown draining).

### `pkg/sdk` runner
- Registers default readiness checks: **NATS** (`IsConnected`) and **DB** (`PingContext`, when `DATABASE_URL` set) — every SDK connector gets real upstream checks for free.
- On **SIGTERM**, flips readiness → not-ready and waits `SHUTDOWN_DRAIN_SECONDS` (default 5s) before cancelling work, so K8s removes the pod from Service endpoints **before** it stops consuming. Programmatic ctx-cancel (tests/embedding) skips the drain.

### `management-api`
- `/healthz` + `/readyz` aliases reusing the existing DB+NATS dependency check; readiness flips not-ready on shutdown with the same drain. New paths exempted from the tenant-ID middleware.

### `data-converter` + `data-filter` (bespoke servers)
- Added `/ready`, `/healthz`, `/readyz` with a NATS-connected upstream check.

### Manifests / Dockerfiles
- K8s `livenessProbe`→`/healthz`, `readinessProbe`→`/readyz` (converter, management-api); Dockerfile HEALTHCHECKs → `/healthz`.

## Verification
- `go build/vet`, `make lint` (tenant + connector), gofmt — clean. New unit tests in `pkg/health` (aliases, check pass/fail → 503 + named dep, static gate) and `pkg/sdk` (`/readyz` reflects the NATS check). All pass.
- **Live (compose):** `/healthz` + `/readyz` return 200 on an SDK worker (db-consumer), management-api, and data-converter. **Stopping NATS** flips every `/readyz` to **503** naming the failed dependency while `/healthz` stays 200; **restart recovers** to 200.
- **Acceptance #1** (all services expose both probes, readiness includes upstream checks): ✅ verified across all three service patterns.
- **Acceptance #2** (rolling deploy loses zero messages): the mechanism is verified live — `SIGTERM` flips `/readyz`→503 and holds the worker alive through the 5s drain (`shutdown signal received` → `draining before stop drain=5s` → `connector stopped`), then exits cleanly. Combined with JetStream ack/redelivery this de-registers the pod before it stops consuming. A full 1 msg/s pipeline + DLQ-assertion run is recommended in staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)