### PR TITLE
Phase 3A (#84): Alerting rules + per-tenant notifiers (Slack/email/PagerDuty/webhook)

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -25,25 +25,41 @@ jobs:
     name: Connector integration tests
     runs-on: ubuntu-latest
     timeout-minutes: 25
+    # Surface the Docker Hub secrets as env so the login step's `if` can test
+    # them (the `secrets` context isn't available in step-level conditionals).
+    env:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
 
+      # Authenticated Docker Hub pulls when the secrets are configured — far
+      # higher rate limits + reliability than anonymous pulls from shared
+      # runner IPs. No-op (anonymous fallback) when the secrets are absent.
+      - name: Log in to Docker Hub
+        if: ${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' }}
+        uses: docker/login-action@v3
+        with:
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ env.DOCKERHUB_TOKEN }}
+
       - name: Pull images (with retry)
-        # Docker Hub aggressively rate-limits / times out anonymous pulls from
-        # shared GitHub Actions IPs, so retry rather than fail the whole run on a
-        # transient "context deadline exceeded". busybox is pulled here too — the
-        # readiness step shells out to it.
+        # Docker Hub rate-limits / times out anonymous pulls from shared GitHub
+        # Actions IPs, so retry rather than fail the whole run on a transient
+        # "context deadline exceeded". busybox is pulled here too — the
+        # readiness step shells out to it. (Authenticated pulls above make this
+        # far less likely to be needed.)
         run: |
           retry() {
-            local n=0 max=5
+            local n=0 max=8
             until "$@"; do
               n=$((n+1))
               if [ "$n" -ge "$max" ]; then
                 echo "ERROR: '$*' failed after $max attempts"; return 1
               fi
-              echo "attempt $n/$max failed; retrying in 15s…"; sleep 15
+              echo "attempt $n/$max failed; retrying in 20s…"; sleep 20
             done
           }
           retry docker compose pull --quiet \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -106,12 +106,59 @@ services:
       - "--storage.tsdb.path=/prometheus"
     volumes:
       - ./infrastructure/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ./infrastructure/prometheus-rules.yml:/etc/prometheus/prometheus-rules.yml:ro
       - prometheus-data:/prometheus
     networks:
       - vrsky-network
     depends_on:
       - postgres-consumer
       - postgres-producer
+    restart: unless-stopped
+
+  # Alertmanager (#84) — routes every alert to the management-api's webhook
+  # receiver, which dispatches to per-tenant notification targets. UI on 9093.
+  alertmanager:
+    image: prom/alertmanager:latest
+    container_name: vrsky-alertmanager
+    ports:
+      - "127.0.0.1:9093:9093"
+    volumes:
+      - ./infrastructure/alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
+    networks:
+      - vrsky-network
+    restart: unless-stopped
+
+  # NATS metrics exporter (#84) — exposes JetStream consumer lag for the
+  # JetStreamLagHigh alert. Scraped in-network at nats-exporter:7777.
+  nats-exporter:
+    image: natsio/prometheus-nats-exporter:latest
+    container_name: vrsky-nats-exporter
+    command: "-varz -jsz=all http://nats:8222"
+    networks:
+      - vrsky-network
+    depends_on:
+      nats:
+        condition: service_healthy
+    restart: unless-stopped
+
+  # Host/filesystem metrics (#84) — powers the DiskUsageHigh alert. Scraped
+  # in-network at node-exporter:9100.
+  node-exporter:
+    image: prom/node-exporter:latest
+    container_name: vrsky-node-exporter
+    networks:
+      - vrsky-network
+    restart: unless-stopped
+
+  # Local SMTP catcher (#84) — email notification targets deliver here in dev;
+  # browse received mail at http://localhost:8025.
+  mailpit:
+    image: axllent/mailpit:latest
+    container_name: vrsky-mailpit
+    ports:
+      - "127.0.0.1:8025:8025"
+    networks:
+      - vrsky-network
     restart: unless-stopped
 
   # PostgreSQL Consumer (CDC from source to NATS)
@@ -275,10 +322,19 @@ services:
       
       # Logging
       LOG_LEVEL: "info"
-      
+
       # Timeouts - Matches config.go
       MGMT_API_READ_TIMEOUT_SEC: "15"
       MGMT_API_WRITE_TIMEOUT_SEC: "30"
+
+      # Alerting (#84): bearer token Alertmanager presents on
+      # POST /api/v1/alerts/webhook (must match infrastructure/alertmanager.yml;
+      # dev default — override both in prod), and the platform SMTP identity
+      # email notification targets send through (mailpit in dev).
+      ALERTS_WEBHOOK_TOKEN: "${ALERTS_WEBHOOK_TOKEN:-dev-alerts-webhook-token}"
+      SMTP_HOST: "mailpit"
+      SMTP_PORT: "1025"
+      SMTP_FROM: "alerts@vrsky.local"
 
       # Master key for AES-256-GCM secret encryption (#66 / Phase 1A).
       # DEV-ONLY value baked into compose so a local stack starts without

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -611,9 +611,10 @@ services:
       MGMT_API_URL: "http://management-api:3000"
       OAUTH_TOKEN_SERVICE_SECRET: "${OAUTH_TOKEN_SERVICE_SECRET:-dev-oauth-service-secret-change-me}"
       # Aux HTTP port serving /schema (describe) + /sample-data for the UI's field mapping (#79).
-      WORKER_HTTP_PORT: "9700"
+      # 9250 (next in the consumer family after cloud-storage 9240); 9700 belongs to data-filter.
+      WORKER_HTTP_PORT: "9250"
     ports:
-      - "127.0.0.1:9700:9700"
+      - "127.0.0.1:9250:9250"
     depends_on:
       nats:
         condition: service_healthy

--- a/infrastructure/alertmanager.yml
+++ b/infrastructure/alertmanager.yml
@@ -1,0 +1,28 @@
+# Alertmanager configuration (Phase 3A — #84).
+#
+# Single-receiver model: every alert is delivered to the management-api's
+# webhook endpoint, which looks up the owning tenant's notification targets
+# (or platform-flagged targets for tenant-less alerts) and fans out to
+# Slack / email / PagerDuty / webhooks. Per-tenant routing therefore lives in
+# the database, not in this file.
+#
+# The bearer token must match the management-api's ALERTS_WEBHOOK_TOKEN env.
+# The value below is the docker-compose dev default — override this file (and
+# the env) in production.
+
+route:
+  receiver: vrsky-management-api
+  group_by: ['alertname', 'tenant_id']
+  group_wait: 10s
+  group_interval: 1m
+  repeat_interval: 4h
+
+receivers:
+  - name: vrsky-management-api
+    webhook_configs:
+      - url: http://management-api:3000/api/v1/alerts/webhook
+        send_resolved: true
+        http_config:
+          authorization:
+            type: Bearer
+            credentials: dev-alerts-webhook-token

--- a/infrastructure/migrations/000015_notification_targets.down.sql
+++ b/infrastructure/migrations/000015_notification_targets.down.sql
@@ -1,0 +1,2 @@
+-- Phase 3A (#84) rollback.
+DROP TABLE IF EXISTS notification_targets;

--- a/infrastructure/migrations/000015_notification_targets.up.sql
+++ b/infrastructure/migrations/000015_notification_targets.up.sql
@@ -1,0 +1,32 @@
+-- Phase 3A (#84): per-tenant alert notification targets.
+--
+-- One table:
+--   notification_targets — where a tenant's alerts get delivered (Slack
+--                          incoming webhook, email recipient, PagerDuty
+--                          routing key, or a generic webhook).
+--
+-- Sensitive values (Slack webhook URL, PagerDuty routing key, webhook HMAC
+-- secret) are NEVER stored in plaintext: secret_id references a row in the
+-- secrets table (#66) holding aes256:base64(...) ciphertext. Non-secret
+-- settings (email address, minimum severity, platform flag) live in config.
+--
+-- Routing model: alerts carrying a tenant_id label are dispatched to that
+-- tenant's enabled targets; platform-level alerts (disk, NATS, mgmt-api,
+-- certs) go to targets with config->>'platform' = 'true'.
+
+CREATE TABLE notification_targets (
+    id          UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id   UUID         NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+    name        TEXT         NOT NULL,                          -- human label, e.g. "Ops Slack #alerts"
+    type        TEXT         NOT NULL,                          -- slack | email | pagerduty | webhook
+    config      JSONB        NOT NULL DEFAULT '{}'::JSONB,      -- non-secret: email/url/min_severity/platform
+    secret_id   UUID         NULL,                              -- -> secrets.id (webhook URL / routing key / HMAC secret)
+    enabled     BOOLEAN      NOT NULL DEFAULT TRUE,
+    created_at  TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    updated_at  TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    UNIQUE (tenant_id, name),
+    CONSTRAINT notification_targets_type_check
+        CHECK (type IN ('slack', 'email', 'pagerduty', 'webhook'))
+);
+
+CREATE INDEX idx_notification_targets_tenant ON notification_targets(tenant_id);

--- a/infrastructure/prometheus-rules-test.yml
+++ b/infrastructure/prometheus-rules-test.yml
@@ -1,0 +1,126 @@
+# promtool unit tests for the VRSky default alert ruleset (#84).
+# Run: docker run --rm -v "$PWD/infrastructure":/cfg --entrypoint promtool \
+#        prom/prometheus:latest test rules /cfg/prometheus-rules-test.yml
+# All 6 default rules are driven to FIRING — the "staged test" acceptance
+# criterion, deterministic and CI-runnable.
+
+rule_files:
+  - prometheus-rules.yml
+
+evaluation_interval: 1m
+
+tests:
+  # 1. PipelineDown — tenant publishes for an hour, then goes silent.
+  - interval: 1m
+    input_series:
+      - series: 'vrsky_messages_published_total{tenant_id="t1"}'
+        values: '0+10x60 600x30' # rising 10/min for 60m, then flat (silent)
+    alert_rule_test:
+      - eval_time: 80m
+        alertname: PipelineDown
+        exp_alerts:
+          - exp_labels:
+              alertname: PipelineDown
+              severity: critical
+              tenant_id: t1
+            exp_annotations:
+              summary: "no messages published for tenant t1 in 10+ minutes"
+              description: "The pipeline throughput for tenant t1 dropped to zero after being active in the previous hour."
+      # While still publishing, no alert.
+      - eval_time: 30m
+        alertname: PipelineDown
+        exp_alerts: []
+
+  # 2. DLQGrowing — dead-lettered messages start arriving at minute 10.
+  - interval: 1m
+    input_series:
+      - series: 'vrsky_dlq_messages_total{pipeline_id="p1",worker="db-producer"}'
+        values: '0x10 0+1x20' # flat, then +1/min from minute 10
+    alert_rule_test:
+      - eval_time: 25m
+        alertname: DLQGrowing
+        exp_alerts:
+          - exp_labels:
+              alertname: DLQGrowing
+              severity: warning
+              pipeline_id: p1
+            exp_annotations:
+              summary: "DLQ growing for pipeline p1"
+              description: "Messages moved to the dead-letter queue in the last 10 minutes — a producer is repeatedly failing to deliver."
+      - eval_time: 5m
+        alertname: DLQGrowing
+        exp_alerts: []
+
+  # 3. JetStreamLagHigh — consumer backlog sits above the threshold.
+  - interval: 1m
+    input_series:
+      - series: 'jetstream_consumer_num_pending{stream_name="VRSKY_DATA",consumer_name="db-producer"}'
+        values: '2000x30'
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: JetStreamLagHigh
+        exp_alerts:
+          - exp_labels:
+              alertname: JetStreamLagHigh
+              severity: warning
+              stream_name: VRSKY_DATA
+              consumer_name: db-producer
+            exp_annotations:
+              summary: "JetStream consumer db-producer lag above 1000"
+              description: "Pending (undelivered) messages for the consumer exceeded 1000 for 10 minutes — the worker is falling behind or down."
+
+  # 4. CertExpirySoon — cert expires ~7 days from t=0 (< 14-day threshold).
+  - interval: 1m
+    input_series:
+      - series: 'vrsky_tls_cert_expiry_timestamp_seconds{path="/certs/tls.crt"}'
+        values: '604800x180' # NotAfter = 7 days (in seconds), constant
+    alert_rule_test:
+      - eval_time: 90m
+        alertname: CertExpirySoon
+        exp_alerts:
+          - exp_labels:
+              alertname: CertExpirySoon
+              severity: warning
+              path: /certs/tls.crt
+            exp_annotations:
+              summary: "TLS certificate /certs/tls.crt expires in under 14 days"
+              description: "Renew the certificate at /certs/tls.crt before it expires."
+
+  # 5. MgmtAPIErrorRate — half of all requests are 500s (50% > 5%).
+  - interval: 1m
+    input_series:
+      - series: 'vrsky_mgmtapi_http_requests_total{method="GET",path="/api/v1/connections",status="500"}'
+        values: '0+10x30'
+      - series: 'vrsky_mgmtapi_http_requests_total{method="GET",path="/api/v1/connections",status="200"}'
+        values: '0+10x30'
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: MgmtAPIErrorRate
+        exp_alerts:
+          - exp_labels:
+              alertname: MgmtAPIErrorRate
+              severity: critical
+            exp_annotations:
+              summary: "management-api 5xx error rate above 5%"
+              description: "More than 5% of management API requests returned a server error over the last 5 minutes."
+
+  # 6. DiskUsageHigh — 90% full filesystem.
+  - interval: 1m
+    input_series:
+      - series: 'node_filesystem_avail_bytes{fstype="ext4",mountpoint="/",device="/dev/sda1"}'
+        values: '10x30'
+      - series: 'node_filesystem_size_bytes{fstype="ext4",mountpoint="/",device="/dev/sda1"}'
+        values: '100x30'
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: DiskUsageHigh
+        exp_alerts:
+          - exp_labels:
+              alertname: DiskUsageHigh
+              severity: warning
+              fstype: ext4
+              mountpoint: /
+              device: /dev/sda1
+            exp_annotations:
+              summary: "disk usage above 80% on /"
+              description: "Filesystem / (/dev/sda1) is over 80% full."

--- a/infrastructure/prometheus-rules.yml
+++ b/infrastructure/prometheus-rules.yml
@@ -1,0 +1,83 @@
+# VRSky default alert ruleset (Phase 3A — #84).
+#
+# Routing: alerts with a tenant_id label are dispatched by the management-api
+# to that tenant's notification targets; the rest are platform alerts and go
+# to targets flagged platform=true. Unit tests: prometheus-rules-test.yml
+# (promtool test rules).
+
+groups:
+  - name: vrsky-pipelines
+    rules:
+      # A tenant that was publishing messages in the previous hour has gone
+      # silent: rate is zero now AND there was activity in the hour before the
+      # current quiet window (so never-active tenants don't alert).
+      - alert: PipelineDown
+        expr: |
+          sum by (tenant_id) (rate(vrsky_messages_published_total[5m])) == 0
+          and
+          sum by (tenant_id) (increase(vrsky_messages_published_total[1h] offset 10m)) > 0
+        for: 10m
+        labels:
+          severity: critical
+        annotations:
+          summary: "no messages published for tenant {{ $labels.tenant_id }} in 10+ minutes"
+          description: "The pipeline throughput for tenant {{ $labels.tenant_id }} dropped to zero after being active in the previous hour."
+
+      # Messages are being dead-lettered. pipeline_id is the connection id;
+      # the metric carries no tenant label, so this routes as a platform alert.
+      - alert: DLQGrowing
+        expr: sum by (pipeline_id) (increase(vrsky_dlq_messages_total[10m])) > 0
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "DLQ growing for pipeline {{ $labels.pipeline_id }}"
+          description: "Messages moved to the dead-letter queue in the last 10 minutes — a producer is repeatedly failing to deliver."
+
+  - name: vrsky-platform
+    rules:
+      # JetStream consumer backlog (prometheus-nats-exporter -jsz).
+      - alert: JetStreamLagHigh
+        expr: jetstream_consumer_num_pending > 1000
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "JetStream consumer {{ $labels.consumer_name }} lag above 1000"
+          description: "Pending (undelivered) messages for the consumer exceeded 1000 for 10 minutes — the worker is falling behind or down."
+
+      # TLS certificate within 14 days of expiry (management-api gauge from
+      # TLS_CERT_PATHS).
+      - alert: CertExpirySoon
+        expr: (vrsky_tls_cert_expiry_timestamp_seconds - time()) < 14 * 24 * 3600
+        for: 1h
+        labels:
+          severity: warning
+        annotations:
+          summary: "TLS certificate {{ $labels.path }} expires in under 14 days"
+          description: "Renew the certificate at {{ $labels.path }} before it expires."
+
+      # Management API 5xx ratio above 5% over 5 minutes.
+      - alert: MgmtAPIErrorRate
+        expr: |
+          sum(rate(vrsky_mgmtapi_http_requests_total{status=~"5.."}[5m]))
+          /
+          sum(rate(vrsky_mgmtapi_http_requests_total[5m])) > 0.05
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "management-api 5xx error rate above 5%"
+          description: "More than 5% of management API requests returned a server error over the last 5 minutes."
+
+      # Host filesystem above 80% (node-exporter; tmpfs/overlay excluded).
+      - alert: DiskUsageHigh
+        expr: |
+          (1 - node_filesystem_avail_bytes{fstype!~"tmpfs|overlay"}
+             / node_filesystem_size_bytes{fstype!~"tmpfs|overlay"}) > 0.80
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "disk usage above 80% on {{ $labels.mountpoint }}"
+          description: "Filesystem {{ $labels.mountpoint }} ({{ $labels.device }}) is over 80% full."

--- a/infrastructure/prometheus.yml
+++ b/infrastructure/prometheus.yml
@@ -5,14 +5,16 @@ global:
   external_labels:
     monitor: 'vrsky-monitor'
 
-# Alertmanager configuration (optional)
+# Alerts route to Alertmanager, which fans them into the management-api's
+# webhook receiver (POST /api/v1/alerts/webhook) for per-tenant dispatch (#84).
 alerting:
   alertmanagers:
     - static_configs:
-        - targets: []
+        - targets: ['alertmanager:9093']
 
-# Load rules once and periodically evaluate them
-rule_files: []
+# Default VRSky alert ruleset (#84). Unit tests: prometheus-rules-test.yml.
+rule_files:
+  - /etc/prometheus/prometheus-rules.yml
 
 # Scrape configurations
 scrape_configs:
@@ -36,3 +38,46 @@ scrape_configs:
     metrics_path: '/metrics'
     scrape_interval: 10s
     scrape_timeout: 5s
+
+  # Management API (#84): HTTP request counters/durations (MgmtAPIErrorRate)
+  # + the TLS cert-expiry gauge (CertExpirySoon).
+  - job_name: 'management-api'
+    static_configs:
+      - targets: ['management-api:3000']
+    metrics_path: '/metrics'
+
+  # SDK workers serve Prometheus metrics on HEALTH_PORT 8080 (pkg/health):
+  # messaging throughput (vrsky_messages_published_total → PipelineDown) and
+  # DLQ counters (vrsky_dlq_messages_total → DLQGrowing).
+  - job_name: 'vrsky-workers'
+    metrics_path: '/metrics'
+    static_configs:
+      - targets:
+          - 'webhook-consumer:8080'
+          - 'file-consumer:8080'
+          - 'db-consumer:8080'
+          - 'api-consumer:8080'
+          - 'tenant-consumer:8080'
+          - 'salesforce-consumer:8080'
+          - 'sftp-consumer:8080'
+          - 'kafka-consumer:8080'
+          - 'rabbitmq-consumer:8080'
+          - 'cloud-storage-consumer:8080'
+          - 'http-producer:8080'
+          - 'file-producer:8080'
+          - 'db-producer:8080'
+          - 'salesforce-producer:8080'
+          - 'sftp-producer:8080'
+          - 'kafka-producer:8080'
+          - 'rabbitmq-producer:8080'
+          - 'cloud-storage-producer:8080'
+
+  # NATS server metrics via prometheus-nats-exporter (JetStreamLagHigh).
+  - job_name: 'nats'
+    static_configs:
+      - targets: ['nats-exporter:7777']
+
+  # Host disk/filesystem metrics via node-exporter (DiskUsageHigh).
+  - job_name: 'node'
+    static_configs:
+      - targets: ['node-exporter:9100']

--- a/src/cmd/lint-tenant-filter/main.go
+++ b/src/cmd/lint-tenant-filter/main.go
@@ -50,6 +50,7 @@ var tenantScopedTables = []string{
 	"tenant_api_keys",
 	"oauth_providers",
 	"oauth_grants",
+	"notification_targets",
 }
 
 // sqlStmt extracts the backtick-quoted SQL string that follows a

--- a/src/cmd/management-api/cors.go
+++ b/src/cmd/management-api/cors.go
@@ -70,6 +70,8 @@ func TenantIDMiddleware(tenantHeader string) func(http.Handler) http.Handler {
 			if strings.HasPrefix(r.URL.Path, "/api/v1/auth/") ||
 				strings.HasPrefix(r.URL.Path, "/api/v1/tenants") ||
 				r.URL.Path == "/api/v1/oauth/callback" ||
+				r.URL.Path == "/api/v1/alerts/webhook" ||
+				r.URL.Path == "/metrics" ||
 				r.URL.Path == "/health" ||
 				r.URL.Path == "/healthz" ||
 				r.URL.Path == "/ready" ||

--- a/src/cmd/management-api/main.go
+++ b/src/cmd/management-api/main.go
@@ -16,6 +16,7 @@ import (
 
 	_ "github.com/jackc/pgx/v4/stdlib"
 	"github.com/nats-io/nats.go"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -69,6 +70,10 @@ func main() {
 	// Setup HTTP server with graceful shutdown
 	var shuttingDown atomic.Bool
 	server, tenantProvisioner := setupServer(config, db, nc, logger, &shuttingDown)
+
+	// TLS cert-expiry gauge for the CertExpirySoon alert (#84). No-op unless
+	// TLS_CERT_PATHS is set.
+	watchCertExpiry(logger)
 
 	// Start server in a goroutine
 	serverErrs := make(chan error, 1)
@@ -229,6 +234,11 @@ func setupServer(config *Config, db *sql.DB, nc *nats.Conn, logger *log.Logger, 
 	mux.HandleFunc("/ready", readiness)
 	mux.HandleFunc("/readyz", readiness)
 
+	// Prometheus scrape endpoint (#84) — request counters/durations from
+	// MetricsMiddleware + the TLS cert-expiry gauge. Exempt from tenant
+	// middleware in cors.go (Prometheus sends no X-Tenant-ID).
+	mux.Handle("GET /metrics", promhttp.Handler())
+
 	// Initialize repository and validator
 	repo := managementapi.NewPostgresRepository(db)
 	validator := managementapi.NewValidator()
@@ -314,11 +324,12 @@ func setupServer(config *Config, db *sql.DB, nc *nats.Conn, logger *log.Logger, 
 	// Wrap mux with middleware (applied in reverse order — innermost is rightmost).
 	// Audit must sit INSIDE TenantID so it can read the tenant from context,
 	// and OUTSIDE the route mux so it observes every handler.
-	//   Logging → CORS → TenantID → Audit → Routes
+	//   Logging → Metrics → CORS → TenantID → Audit → Routes
 	var handler http.Handler = mux
 	handler = managementapi.AuditMiddleware(repo, logger)(handler)
 	handler = TenantIDMiddleware(config.TenantHeader)(handler)
 	handler = CORSMiddleware(config.CORSOrigins, config.TenantHeader)(handler)
+	handler = MetricsMiddleware(handler)
 	handler = LoggingMiddleware(logger)(handler)
 
 	return &http.Server{

--- a/src/cmd/management-api/metrics.go
+++ b/src/cmd/management-api/metrics.go
@@ -1,0 +1,177 @@
+package main
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// Phase 3A (#84): management-api Prometheus instrumentation. Powers the
+// MgmtAPIErrorRate alert (5xx ratio > 5% over 5m) and the CertExpirySoon
+// alert (vrsky_tls_cert_expiry_timestamp_seconds - time() < 14d).
+
+var (
+	httpRequestsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "vrsky_mgmtapi_http_requests_total",
+		Help: "Management API HTTP requests by method, normalized path, and status code.",
+	}, []string{"method", "path", "status"})
+
+	httpRequestDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "vrsky_mgmtapi_http_request_duration_seconds",
+		Help:    "Management API HTTP request duration by method and normalized path.",
+		Buckets: prometheus.DefBuckets,
+	}, []string{"method", "path"})
+
+	certExpiry = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "vrsky_tls_cert_expiry_timestamp_seconds",
+		Help: "NotAfter (unix seconds) of each TLS certificate listed in TLS_CERT_PATHS.",
+	}, []string{"path"})
+)
+
+// statusRecorder captures the response status for the metrics labels.
+type statusRecorder struct {
+	http.ResponseWriter
+	status int
+}
+
+func (r *statusRecorder) WriteHeader(code int) {
+	r.status = code
+	r.ResponseWriter.WriteHeader(code)
+}
+
+// normalizePath collapses ID-like path segments to ":id" so the path label has
+// bounded cardinality (Go 1.22's ServeMux doesn't expose the matched pattern).
+func normalizePath(p string) string {
+	segs := strings.Split(p, "/")
+	for i, s := range segs {
+		if looksLikeID(s) {
+			segs[i] = ":id"
+		}
+	}
+	return strings.Join(segs, "/")
+}
+
+// looksLikeID reports whether a path segment is an identifier rather than a
+// route word: UUIDs, hex hashes, or long digit runs.
+func looksLikeID(s string) bool {
+	if len(s) < 8 {
+		// Short segments are route words ("oauth", "test") — except pure numbers.
+		for _, c := range s {
+			if c < '0' || c > '9' {
+				return false
+			}
+		}
+		return len(s) > 0
+	}
+	hexish := 0
+	for _, c := range s {
+		switch {
+		case c >= '0' && c <= '9', c >= 'a' && c <= 'f', c >= 'A' && c <= 'F', c == '-':
+			hexish++
+		}
+	}
+	return hexish == len(s)
+}
+
+// MetricsMiddleware records a counter + duration histogram per request. Probe
+// and scrape endpoints are skipped so they don't drown the request metrics.
+func MetricsMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/metrics", "/health", "/healthz", "/ready", "/readyz":
+			next.ServeHTTP(w, r)
+			return
+		}
+		rec := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
+		start := time.Now()
+		next.ServeHTTP(rec, r)
+
+		path := normalizePath(r.URL.Path)
+		httpRequestsTotal.WithLabelValues(r.Method, path, itoa(rec.status)).Inc()
+		httpRequestDuration.WithLabelValues(r.Method, path).Observe(time.Since(start).Seconds())
+	})
+}
+
+// itoa avoids strconv for the tiny 3-digit status codes.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b [4]byte
+	i := len(b)
+	for n > 0 {
+		i--
+		b[i] = byte('0' + n%10)
+		n /= 10
+	}
+	return string(b[i:])
+}
+
+// watchCertExpiry parses each PEM in TLS_CERT_PATHS (comma-separated) and sets
+// the expiry gauge, refreshing hourly (certs rotate). No-op when unset.
+func watchCertExpiry(logger *log.Logger) {
+	paths := strings.TrimSpace(os.Getenv("TLS_CERT_PATHS"))
+	if paths == "" {
+		return
+	}
+	refresh := func() {
+		for _, p := range strings.Split(paths, ",") {
+			p = strings.TrimSpace(p)
+			if p == "" {
+				continue
+			}
+			notAfter, err := certNotAfter(p)
+			if err != nil {
+				logger.Printf("cert expiry watch: %s: %v", p, err)
+				continue
+			}
+			certExpiry.WithLabelValues(p).Set(float64(notAfter.Unix()))
+		}
+	}
+	refresh()
+	go func() {
+		t := time.NewTicker(time.Hour)
+		defer t.Stop()
+		for range t.C {
+			refresh()
+		}
+	}()
+}
+
+// certNotAfter returns the earliest NotAfter among the certificates in a PEM
+// file (a chain's leaf usually expires first, but take the minimum to be safe).
+func certNotAfter(path string) (time.Time, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return time.Time{}, err
+	}
+	var earliest time.Time
+	for {
+		var block *pem.Block
+		block, data = pem.Decode(data)
+		if block == nil {
+			break
+		}
+		if block.Type != "CERTIFICATE" {
+			continue
+		}
+		cert, err := x509.ParseCertificate(block.Bytes)
+		if err != nil {
+			continue
+		}
+		if earliest.IsZero() || cert.NotAfter.Before(earliest) {
+			earliest = cert.NotAfter
+		}
+	}
+	if earliest.IsZero() {
+		return time.Time{}, os.ErrInvalid
+	}
+	return earliest, nil
+}

--- a/src/pkg/managementapi/connection_test_endpoint.go
+++ b/src/pkg/managementapi/connection_test_endpoint.go
@@ -106,7 +106,7 @@ func buildTestTarget(typ, role string, raw map[string]json.RawMessage, tenantID 
 			"api_version":    sf.APIVersion,
 			"soql":           sf.SOQL,
 		})
-		return testWorkerURL("TEST_URL_SALESFORCE", "http://salesforce-consumer:9700") + "/schema/", b, true, ""
+		return testWorkerURL("TEST_URL_SALESFORCE", "http://salesforce-consumer:9250") + "/schema/", b, true, ""
 	case "http":
 		return "", nil, false, "An inbound HTTP webhook can't be tested before deploy — deploy the pipeline and send it a request."
 	default:

--- a/src/pkg/managementapi/handler.go
+++ b/src/pkg/managementapi/handler.go
@@ -934,6 +934,18 @@ func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
 	// middleware (workers have no session). Registered plain for that reason.
 	mux.HandleFunc("GET /api/v1/oauth/grants/{id}/token", h.TokenForGrant)
 
+	// Notification targets (Phase 3A — #84). Writes are admin; listing is
+	// viewer; the test send is admin (it uses the stored secret).
+	mux.HandleFunc("GET /api/v1/notifications/targets", h.ListNotificationTargets)
+	mux.Handle("POST /api/v1/notifications/targets", adminMW(http.HandlerFunc(h.CreateNotificationTarget)))
+	mux.Handle("PUT /api/v1/notifications/targets/{id}", adminMW(http.HandlerFunc(h.UpdateNotificationTarget)))
+	mux.Handle("DELETE /api/v1/notifications/targets/{id}", adminMW(http.HandlerFunc(h.DeleteNotificationTarget)))
+	mux.Handle("POST /api/v1/notifications/targets/{id}/test", adminMW(http.HandlerFunc(h.TestNotificationTarget)))
+	// Alertmanager's webhook receiver — authenticated by the shared
+	// ALERTS_WEBHOOK_TOKEN bearer inside the handler (Alertmanager has no
+	// session or tenant header). Exempted from TenantIDMiddleware in cors.go.
+	mux.HandleFunc("POST /api/v1/alerts/webhook", h.AlertsWebhook)
+
 	// Auth routes (these bypass TenantIDMiddleware)
 	h.RegisterAuthRoutes(mux)
 }

--- a/src/pkg/managementapi/notifications_handler.go
+++ b/src/pkg/managementapi/notifications_handler.go
@@ -274,6 +274,12 @@ func (h *Handler) TestNotificationTarget(w http.ResponseWriter, r *http.Request)
 		_ = writeError(w, http.StatusInternalServerError, "InternalError", "failed to load target", nil)
 		return
 	}
+	// A disabled target receives no alerts; Test must honour that too, otherwise
+	// "disabled" is misleading (real dispatch already filters on enabled).
+	if !t.Enabled {
+		_ = writeJSON(w, http.StatusOK, map[string]interface{}{"ok": false, "error": "target is disabled — enable it to send a test"})
+		return
+	}
 	n, err := h.buildNotifier(ctx, t)
 	if err != nil {
 		_ = writeJSON(w, http.StatusOK, map[string]interface{}{"ok": false, "error": err.Error()})

--- a/src/pkg/managementapi/notifications_handler.go
+++ b/src/pkg/managementapi/notifications_handler.go
@@ -157,6 +157,10 @@ func (h *Handler) CreateNotificationTarget(w http.ResponseWriter, r *http.Reques
 	}
 	t := targetFromRequest(tenantID, &req)
 	if err := h.repo.CreateNotificationTarget(ctx, t, req.Secret); err != nil {
+		if errors.Is(err, ErrNotificationTargetNameExists) {
+			_ = writeError(w, http.StatusConflict, "Conflict", "a notification target named "+req.Name+" already exists", nil)
+			return
+		}
 		_ = writeError(w, http.StatusInternalServerError, "InternalError", "failed to create target", nil)
 		return
 	}
@@ -216,6 +220,10 @@ func (h *Handler) UpdateNotificationTarget(w http.ResponseWriter, r *http.Reques
 	if err := h.repo.UpdateNotificationTarget(ctx, t, req.Secret); err != nil {
 		if errors.Is(err, ErrNotificationTargetNotFound) {
 			_ = writeError(w, http.StatusNotFound, "NotFound", "target not found", nil)
+			return
+		}
+		if errors.Is(err, ErrNotificationTargetNameExists) {
+			_ = writeError(w, http.StatusConflict, "Conflict", "a notification target named "+req.Name+" already exists", nil)
 			return
 		}
 		_ = writeError(w, http.StatusInternalServerError, "InternalError", "failed to update target", nil)

--- a/src/pkg/managementapi/notifications_handler.go
+++ b/src/pkg/managementapi/notifications_handler.go
@@ -2,6 +2,7 @@ package managementapi
 
 import (
 	"context"
+	"crypto/subtle"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -84,8 +85,8 @@ func validateTargetRequest(req *notificationTargetRequest, create bool) error {
 			return errors.New("pagerduty targets need the Events API routing key (secret)")
 		}
 	case "webhook":
-		if req.URL == "" || !strings.HasPrefix(req.URL, "http") {
-			return errors.New("webhook targets need a destination URL")
+		if !strings.HasPrefix(req.URL, "http://") && !strings.HasPrefix(req.URL, "https://") {
+			return errors.New("webhook targets need an http:// or https:// destination URL")
 		}
 	default:
 		return fmt.Errorf("unknown target type %q (slack | email | pagerduty | webhook)", req.Type)
@@ -193,9 +194,22 @@ func (h *Handler) UpdateNotificationTarget(w http.ResponseWriter, r *http.Reques
 		_ = writeError(w, http.StatusBadRequest, "ValidationError", err.Error(), nil)
 		return
 	}
+	// On a type change the stored secret belonged to the old type and no longer
+	// applies: require a fresh one for types that mandate it (slack/pagerduty),
+	// and drop the stale reference otherwise.
+	if existing.Type != req.Type && req.Secret == "" && (req.Type == "slack" || req.Type == "pagerduty") {
+		_ = writeError(w, http.StatusBadRequest, "ValidationError",
+			"switching this target to "+req.Type+" requires its secret", nil)
+		return
+	}
 	t := targetFromRequest(tenantID, &req)
 	t.ID = existing.ID
 	t.SecretID = existing.SecretID // kept unless a new secret re-encrypts below
+	if existing.Type != req.Type {
+		// Old secret is irrelevant to the new type; a provided secret will be
+		// stored fresh by the repo, otherwise the reference is dropped.
+		t.SecretID = ""
+	}
 	if req.Enabled == nil {
 		t.Enabled = existing.Enabled
 	}
@@ -299,10 +313,15 @@ func (h *Handler) AlertsWebhook(w http.ResponseWriter, r *http.Request) {
 		_ = writeError(w, http.StatusServiceUnavailable, "NotConfigured", "ALERTS_WEBHOOK_TOKEN is not set", nil)
 		return
 	}
-	if r.Header.Get("Authorization") != "Bearer "+token {
+	// Constant-time compare to avoid leaking the token via response timing.
+	got := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
+	if subtle.ConstantTimeCompare([]byte(got), []byte(token)) != 1 {
 		_ = writeError(w, http.StatusUnauthorized, "Unauthorized", "invalid alerts webhook token", nil)
 		return
 	}
+	// Cap the body — this endpoint is reachable by Alertmanager (and possibly
+	// the public internet) with only a bearer token, so bound the read.
+	r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
 	var payload amWebhookPayload
 	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
 		_ = writeError(w, http.StatusBadRequest, "InvalidJSON", err.Error(), nil)

--- a/src/pkg/managementapi/notifications_handler.go
+++ b/src/pkg/managementapi/notifications_handler.go
@@ -1,0 +1,411 @@
+package managementapi
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/ValueRetail/vrsky/pkg/notify"
+)
+
+// Phase 3A (#84): notification-target CRUD + the Alertmanager webhook receiver.
+// Layout mirrors oauth_admin_handler.go — tenant-from-context extraction,
+// audit calls, writeError/writeJSON. Routing model: Alertmanager has ONE
+// webhook receiver pointing at POST /api/v1/alerts/webhook; this handler fans
+// each alert out to the owning tenant's targets (tenant_id label) or to
+// platform-flagged targets (no tenant_id label).
+
+// notificationTargetRequest is the JSON shape of a create / update request.
+type notificationTargetRequest struct {
+	Name        string `json:"name"`
+	Type        string `json:"type"`             // slack | email | pagerduty | webhook
+	Secret      string `json:"secret,omitempty"` // Slack webhook URL / PD routing key / webhook HMAC key; PUT may omit
+	Email       string `json:"email,omitempty"`
+	URL         string `json:"url,omitempty"`
+	Platform    bool   `json:"platform,omitempty"`
+	MinSeverity string `json:"min_severity,omitempty"`
+	Enabled     *bool  `json:"enabled,omitempty"` // nil -> true on create / unchanged on update
+}
+
+// notificationTargetResponse is the safe (secret-less) shape returned to clients.
+type notificationTargetResponse struct {
+	ID          string    `json:"id"`
+	Name        string    `json:"name"`
+	Type        string    `json:"type"`
+	Email       string    `json:"email,omitempty"`
+	URL         string    `json:"url,omitempty"`
+	Platform    bool      `json:"platform"`
+	MinSeverity string    `json:"min_severity,omitempty"`
+	Enabled     bool      `json:"enabled"`
+	HasSecret   bool      `json:"has_secret"`
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
+}
+
+func toNotificationTargetResponse(t *NotificationTarget) notificationTargetResponse {
+	return notificationTargetResponse{
+		ID:          t.ID,
+		Name:        t.Name,
+		Type:        t.Type,
+		Email:       t.Config.Email,
+		URL:         t.Config.URL,
+		Platform:    t.Config.Platform,
+		MinSeverity: t.Config.MinSeverity,
+		Enabled:     t.Enabled,
+		HasSecret:   t.SecretID != "",
+		CreatedAt:   t.CreatedAt,
+		UpdatedAt:   t.UpdatedAt,
+	}
+}
+
+// validateTargetRequest enforces the per-type required fields. create governs
+// whether the secret itself is mandatory (PUT may omit it to keep the old one).
+func validateTargetRequest(req *notificationTargetRequest, create bool) error {
+	if req.Name == "" {
+		return errors.New("name is required")
+	}
+	switch req.Type {
+	case "slack":
+		if create && req.Secret == "" {
+			return errors.New("slack targets need the incoming-webhook URL (secret)")
+		}
+	case "email":
+		if req.Email == "" || !strings.Contains(req.Email, "@") {
+			return errors.New("email targets need a valid recipient address")
+		}
+	case "pagerduty":
+		if create && req.Secret == "" {
+			return errors.New("pagerduty targets need the Events API routing key (secret)")
+		}
+	case "webhook":
+		if req.URL == "" || !strings.HasPrefix(req.URL, "http") {
+			return errors.New("webhook targets need a destination URL")
+		}
+	default:
+		return fmt.Errorf("unknown target type %q (slack | email | pagerduty | webhook)", req.Type)
+	}
+	switch req.MinSeverity {
+	case "", "info", "warning", "critical":
+	default:
+		return fmt.Errorf("invalid min_severity %q (info | warning | critical)", req.MinSeverity)
+	}
+	return nil
+}
+
+func targetFromRequest(tenantID string, req *notificationTargetRequest) *NotificationTarget {
+	enabled := true
+	if req.Enabled != nil {
+		enabled = *req.Enabled
+	}
+	return &NotificationTarget{
+		TenantID: tenantID,
+		Name:     req.Name,
+		Type:     req.Type,
+		Enabled:  enabled,
+		Config: NotificationTargetConfig{
+			Email:       req.Email,
+			URL:         req.URL,
+			Platform:    req.Platform,
+			MinSeverity: req.MinSeverity,
+		},
+	}
+}
+
+// ListNotificationTargets handles GET /api/v1/notifications/targets.
+func (h *Handler) ListNotificationTargets(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	tenantID, err := GetTenantIDFromContext(ctx)
+	if err != nil {
+		_ = writeError(w, http.StatusBadRequest, "InvalidTenant", err.Error(), nil)
+		return
+	}
+	targets, err := h.repo.ListNotificationTargets(ctx, tenantID)
+	if err != nil {
+		_ = writeError(w, http.StatusInternalServerError, "InternalError", "failed to list targets", nil)
+		return
+	}
+	out := make([]notificationTargetResponse, 0, len(targets))
+	for _, t := range targets {
+		out = append(out, toNotificationTargetResponse(t))
+	}
+	_ = writeJSON(w, http.StatusOK, map[string]interface{}{"targets": out})
+}
+
+// CreateNotificationTarget handles POST /api/v1/notifications/targets.
+func (h *Handler) CreateNotificationTarget(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	tenantID, err := GetTenantIDFromContext(ctx)
+	if err != nil {
+		_ = writeError(w, http.StatusBadRequest, "InvalidTenant", err.Error(), nil)
+		return
+	}
+	var req notificationTargetRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		_ = writeError(w, http.StatusBadRequest, "InvalidJSON", err.Error(), nil)
+		return
+	}
+	if err := validateTargetRequest(&req, true); err != nil {
+		_ = writeError(w, http.StatusBadRequest, "ValidationError", err.Error(), nil)
+		return
+	}
+	t := targetFromRequest(tenantID, &req)
+	if err := h.repo.CreateNotificationTarget(ctx, t, req.Secret); err != nil {
+		_ = writeError(w, http.StatusInternalServerError, "InternalError", "failed to create target", nil)
+		return
+	}
+	SetAuditAction(ctx, "notification.target.create")
+	SetAuditResource(ctx, "notification_target", t.ID)
+	SetAuditDetail(ctx, "type", t.Type)
+	SetAuditDetail(ctx, "name", t.Name)
+	_ = writeJSON(w, http.StatusCreated, toNotificationTargetResponse(t))
+}
+
+// UpdateNotificationTarget handles PUT /api/v1/notifications/targets/{id}.
+func (h *Handler) UpdateNotificationTarget(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	tenantID, err := GetTenantIDFromContext(ctx)
+	if err != nil {
+		_ = writeError(w, http.StatusBadRequest, "InvalidTenant", err.Error(), nil)
+		return
+	}
+	id := r.PathValue("id")
+	existing, err := h.repo.GetNotificationTarget(ctx, tenantID, id)
+	if err != nil {
+		if errors.Is(err, ErrNotificationTargetNotFound) {
+			_ = writeError(w, http.StatusNotFound, "NotFound", "target not found", nil)
+			return
+		}
+		_ = writeError(w, http.StatusInternalServerError, "InternalError", "failed to load target", nil)
+		return
+	}
+	var req notificationTargetRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		_ = writeError(w, http.StatusBadRequest, "InvalidJSON", err.Error(), nil)
+		return
+	}
+	if err := validateTargetRequest(&req, false); err != nil {
+		_ = writeError(w, http.StatusBadRequest, "ValidationError", err.Error(), nil)
+		return
+	}
+	t := targetFromRequest(tenantID, &req)
+	t.ID = existing.ID
+	t.SecretID = existing.SecretID // kept unless a new secret re-encrypts below
+	if req.Enabled == nil {
+		t.Enabled = existing.Enabled
+	}
+	if err := h.repo.UpdateNotificationTarget(ctx, t, req.Secret); err != nil {
+		if errors.Is(err, ErrNotificationTargetNotFound) {
+			_ = writeError(w, http.StatusNotFound, "NotFound", "target not found", nil)
+			return
+		}
+		_ = writeError(w, http.StatusInternalServerError, "InternalError", "failed to update target", nil)
+		return
+	}
+	SetAuditAction(ctx, "notification.target.update")
+	SetAuditResource(ctx, "notification_target", t.ID)
+	_ = writeJSON(w, http.StatusOK, toNotificationTargetResponse(t))
+}
+
+// DeleteNotificationTarget handles DELETE /api/v1/notifications/targets/{id}.
+func (h *Handler) DeleteNotificationTarget(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	tenantID, err := GetTenantIDFromContext(ctx)
+	if err != nil {
+		_ = writeError(w, http.StatusBadRequest, "InvalidTenant", err.Error(), nil)
+		return
+	}
+	id := r.PathValue("id")
+	if err := h.repo.DeleteNotificationTarget(ctx, tenantID, id); err != nil {
+		if errors.Is(err, ErrNotificationTargetNotFound) {
+			_ = writeError(w, http.StatusNotFound, "NotFound", "target not found", nil)
+			return
+		}
+		_ = writeError(w, http.StatusInternalServerError, "InternalError", "failed to delete target", nil)
+		return
+	}
+	SetAuditAction(ctx, "notification.target.delete")
+	SetAuditResource(ctx, "notification_target", id)
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// TestNotificationTarget handles POST /api/v1/notifications/targets/{id}/test —
+// sends a synthetic alert through the target so the user can confirm delivery.
+func (h *Handler) TestNotificationTarget(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	tenantID, err := GetTenantIDFromContext(ctx)
+	if err != nil {
+		_ = writeError(w, http.StatusBadRequest, "InvalidTenant", err.Error(), nil)
+		return
+	}
+	t, err := h.repo.GetNotificationTarget(ctx, tenantID, r.PathValue("id"))
+	if err != nil {
+		if errors.Is(err, ErrNotificationTargetNotFound) {
+			_ = writeError(w, http.StatusNotFound, "NotFound", "target not found", nil)
+			return
+		}
+		_ = writeError(w, http.StatusInternalServerError, "InternalError", "failed to load target", nil)
+		return
+	}
+	n, err := h.buildNotifier(ctx, t)
+	if err != nil {
+		_ = writeJSON(w, http.StatusOK, map[string]interface{}{"ok": false, "error": err.Error()})
+		return
+	}
+	alert := &notify.Alert{
+		Name:        "TestNotification",
+		Status:      "firing",
+		Severity:    "info",
+		Summary:     "test notification from VRSky",
+		Description: fmt.Sprintf("Target %q (%s) is wired up correctly.", t.Name, t.Type),
+		TenantID:    tenantID,
+		StartsAt:    time.Now().UTC(),
+	}
+	sctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	if err := n.Send(sctx, alert); err != nil {
+		_ = writeJSON(w, http.StatusOK, map[string]interface{}{"ok": false, "error": err.Error()})
+		return
+	}
+	SetAuditAction(ctx, "notification.target.test")
+	SetAuditResource(ctx, "notification_target", t.ID)
+	_ = writeJSON(w, http.StatusOK, map[string]interface{}{"ok": true})
+}
+
+// --- Alertmanager webhook receiver + dispatch ---
+
+// amWebhookPayload is the Alertmanager webhook_config payload (version "4").
+type amWebhookPayload struct {
+	Status string `json:"status"`
+	Alerts []struct {
+		Status      string            `json:"status"`
+		Labels      map[string]string `json:"labels"`
+		Annotations map[string]string `json:"annotations"`
+		StartsAt    time.Time         `json:"startsAt"`
+	} `json:"alerts"`
+}
+
+// AlertsWebhook handles POST /api/v1/alerts/webhook — the single Alertmanager
+// receiver. Authenticated by the ALERTS_WEBHOOK_TOKEN bearer token (the route
+// is exempt from tenant middleware since Alertmanager can't send X-Tenant-ID).
+func (h *Handler) AlertsWebhook(w http.ResponseWriter, r *http.Request) {
+	token := os.Getenv("ALERTS_WEBHOOK_TOKEN")
+	if token == "" {
+		_ = writeError(w, http.StatusServiceUnavailable, "NotConfigured", "ALERTS_WEBHOOK_TOKEN is not set", nil)
+		return
+	}
+	if r.Header.Get("Authorization") != "Bearer "+token {
+		_ = writeError(w, http.StatusUnauthorized, "Unauthorized", "invalid alerts webhook token", nil)
+		return
+	}
+	var payload amWebhookPayload
+	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+		_ = writeError(w, http.StatusBadRequest, "InvalidJSON", err.Error(), nil)
+		return
+	}
+
+	ctx := r.Context()
+	delivered, failed := 0, 0
+	for _, a := range payload.Alerts {
+		alert := &notify.Alert{
+			Name:        a.Labels["alertname"],
+			Status:      a.Status,
+			Severity:    a.Labels["severity"],
+			Summary:     a.Annotations["summary"],
+			Description: a.Annotations["description"],
+			TenantID:    a.Labels["tenant_id"],
+			Labels:      a.Labels,
+			StartsAt:    a.StartsAt,
+		}
+		d, f := h.dispatchAlert(ctx, alert)
+		delivered += d
+		failed += f
+	}
+	_ = writeJSON(w, http.StatusOK, map[string]interface{}{"delivered": delivered, "failed": failed})
+}
+
+// severityRank orders severities for min_severity filtering.
+func severityRank(s string) int {
+	switch s {
+	case "critical":
+		return 3
+	case "warning":
+		return 2
+	default: // info / ""
+		return 1
+	}
+}
+
+// dispatchAlert fans one alert out to its targets (the tenant's, or platform
+// ones for tenant-less alerts), honouring per-target min_severity. Send errors
+// are logged and counted, never fatal — one broken webhook must not block the
+// other targets.
+func (h *Handler) dispatchAlert(ctx context.Context, alert *notify.Alert) (delivered, failed int) {
+	targets, err := h.repo.ListNotificationTargetsForDispatch(ctx, alert.TenantID)
+	if err != nil {
+		slog.Error("alerts: list dispatch targets", "error", err, "alert", alert.Name)
+		return 0, 0
+	}
+	for _, t := range targets {
+		if t.Config.MinSeverity != "" && severityRank(alert.Severity) < severityRank(t.Config.MinSeverity) {
+			continue
+		}
+		n, err := h.buildNotifier(ctx, t)
+		if err != nil {
+			slog.Error("alerts: build notifier", "target", t.Name, "type", t.Type, "error", err)
+			failed++
+			continue
+		}
+		sctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		err = n.Send(sctx, alert)
+		cancel()
+		if err != nil {
+			slog.Error("alerts: send failed", "target", t.Name, "type", t.Type, "error", err)
+			failed++
+			continue
+		}
+		delivered++
+	}
+	return delivered, failed
+}
+
+// buildNotifier constructs the pkg/notify sender for a target, resolving its
+// encrypted secret. Email uses the platform SMTP_* env identity.
+func (h *Handler) buildNotifier(ctx context.Context, t *NotificationTarget) (notify.Notifier, error) {
+	secret, err := h.repo.ResolveNotificationSecret(ctx, t)
+	if err != nil {
+		return nil, fmt.Errorf("resolve secret: %w", err)
+	}
+	switch t.Type {
+	case "slack":
+		return &notify.Slack{WebhookURL: secret}, nil
+	case "email":
+		return &notify.Email{SMTP: smtpFromEnv(), To: t.Config.Email}, nil
+	case "pagerduty":
+		return &notify.PagerDuty{RoutingKey: secret}, nil
+	case "webhook":
+		return &notify.Webhook{URL: t.Config.URL, Secret: secret}, nil
+	default:
+		return nil, fmt.Errorf("unknown target type %q", t.Type)
+	}
+}
+
+// smtpFromEnv reads the platform mail identity (compose/k8s env).
+func smtpFromEnv() notify.SMTPConfig {
+	port := os.Getenv("SMTP_PORT")
+	if port == "" {
+		port = "587"
+	}
+	return notify.SMTPConfig{
+		Host:     os.Getenv("SMTP_HOST"),
+		Port:     port,
+		From:     os.Getenv("SMTP_FROM"),
+		Username: os.Getenv("SMTP_USERNAME"),
+		Password: os.Getenv("SMTP_PASSWORD"),
+	}
+}

--- a/src/pkg/managementapi/notifications_handler_test.go
+++ b/src/pkg/managementapi/notifications_handler_test.go
@@ -155,6 +155,38 @@ func TestUpdateNotificationTarget_TypeChangeRequiresSecret(t *testing.T) {
 	}
 }
 
+func TestTestNotificationTarget_DisabledRefuses(t *testing.T) {
+	handler, repo := setupTestHandler()
+	created := createTargetForTest(t, handler, "tenant-1", map[string]interface{}{
+		"name": "wh", "type": "webhook", "url": "http://example.invalid/hook",
+	})
+	// Disable it.
+	dis := false
+	if err := repo.UpdateNotificationTarget(contextWithTenant("tenant-1"),
+		&NotificationTarget{ID: created.ID, TenantID: "tenant-1", Name: "wh", Type: "webhook",
+			Config: NotificationTargetConfig{URL: "http://example.invalid/hook"}, Enabled: dis}, ""); err != nil {
+		t.Fatalf("disable: %v", err)
+	}
+	// Test must refuse (ok:false) without attempting delivery — a real send to
+	// example.invalid would otherwise error differently.
+	r := httptest.NewRequest("POST", "/api/v1/notifications/targets/"+created.ID+"/test", nil).
+		WithContext(contextWithTenant("tenant-1"))
+	r.SetPathValue("id", created.ID)
+	w := httptest.NewRecorder()
+	handler.TestNotificationTarget(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d, want 200", w.Code)
+	}
+	var res struct {
+		OK    bool   `json:"ok"`
+		Error string `json:"error"`
+	}
+	_ = json.Unmarshal(w.Body.Bytes(), &res)
+	if res.OK || !strings.Contains(res.Error, "disabled") {
+		t.Errorf("disabled test = %+v, want ok:false + 'disabled' message", res)
+	}
+}
+
 func TestAlertsWebhook_AuthAndDispatch(t *testing.T) {
 	t.Setenv("ALERTS_WEBHOOK_TOKEN", "tok-123")
 	handler, _ := setupTestHandler()

--- a/src/pkg/managementapi/notifications_handler_test.go
+++ b/src/pkg/managementapi/notifications_handler_test.go
@@ -114,6 +114,30 @@ func TestUpdateNotificationTarget_KeepsSecretWhenOmitted(t *testing.T) {
 	}
 }
 
+func TestCreateNotificationTarget_DuplicateNameConflict(t *testing.T) {
+	handler, _ := setupTestHandler()
+	createTargetForTest(t, handler, "tenant-1", map[string]interface{}{
+		"name": "dupe", "type": "email", "email": "a@b.c",
+	})
+	// A second target with the same name for the same tenant → 409, not 500.
+	body, _ := json.Marshal(map[string]interface{}{"name": "dupe", "type": "email", "email": "x@y.z"})
+	r := httptest.NewRequest("POST", "/api/v1/notifications/targets", bytes.NewReader(body)).
+		WithContext(contextWithTenant("tenant-1"))
+	w := httptest.NewRecorder()
+	handler.CreateNotificationTarget(w, r)
+	if w.Code != http.StatusConflict {
+		t.Errorf("duplicate name: status=%d, want 409 (body=%s)", w.Code, w.Body.String())
+	}
+	// Same name under a different tenant is fine.
+	r2 := httptest.NewRequest("POST", "/api/v1/notifications/targets", bytes.NewReader(body)).
+		WithContext(contextWithTenant("tenant-2"))
+	w2 := httptest.NewRecorder()
+	handler.CreateNotificationTarget(w2, r2)
+	if w2.Code != http.StatusCreated {
+		t.Errorf("same name other tenant: status=%d, want 201", w2.Code)
+	}
+}
+
 func TestUpdateNotificationTarget_TypeChangeRequiresSecret(t *testing.T) {
 	handler, _ := setupTestHandler()
 	created := createTargetForTest(t, handler, "tenant-1", map[string]interface{}{

--- a/src/pkg/managementapi/notifications_handler_test.go
+++ b/src/pkg/managementapi/notifications_handler_test.go
@@ -1,0 +1,228 @@
+package managementapi
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func createTargetForTest(t *testing.T, h *Handler, tenant string, body map[string]interface{}) notificationTargetResponse {
+	t.Helper()
+	b, _ := json.Marshal(body)
+	r := httptest.NewRequest("POST", "/api/v1/notifications/targets", bytes.NewReader(b)).
+		WithContext(contextWithTenant(tenant))
+	w := httptest.NewRecorder()
+	h.CreateNotificationTarget(w, r)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("create target: status=%d body=%s", w.Code, w.Body.String())
+	}
+	var resp notificationTargetResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	return resp
+}
+
+func TestCreateNotificationTarget_SuccessAndNoSecretLeak(t *testing.T) {
+	handler, _ := setupTestHandler()
+	resp := createTargetForTest(t, handler, "tenant-1", map[string]interface{}{
+		"name":   "ops-slack",
+		"type":   "slack",
+		"secret": "https://hooks.slack.com/services/T0/B0/supersecret",
+	})
+	if resp.ID == "" || !resp.HasSecret || !resp.Enabled {
+		t.Errorf("unexpected response: %+v", resp)
+	}
+	// The webhook URL is a secret and must never appear in any response.
+	list := httptest.NewRequest("GET", "/api/v1/notifications/targets", nil).
+		WithContext(contextWithTenant("tenant-1"))
+	w := httptest.NewRecorder()
+	handler.ListNotificationTargets(w, list)
+	if strings.Contains(w.Body.String(), "supersecret") {
+		t.Errorf("response leaks the secret: %s", w.Body.String())
+	}
+}
+
+func TestCreateNotificationTarget_Validation(t *testing.T) {
+	handler, _ := setupTestHandler()
+	cases := []map[string]interface{}{
+		{"type": "slack", "secret": "https://hooks..."},                          // no name
+		{"name": "x", "type": "slack"},                                           // slack without secret
+		{"name": "x", "type": "email", "email": "not-an-email"},                  // bad email
+		{"name": "x", "type": "pagerduty"},                                       // pd without routing key
+		{"name": "x", "type": "webhook", "url": "ftp://nope"},                    // non-http url
+		{"name": "x", "type": "carrier-pigeon"},                                  // unknown type
+		{"name": "x", "type": "email", "email": "a@b.c", "min_severity": "loud"}, // bad severity
+	}
+	for i, body := range cases {
+		b, _ := json.Marshal(body)
+		r := httptest.NewRequest("POST", "/api/v1/notifications/targets", bytes.NewReader(b)).
+			WithContext(contextWithTenant("tenant-1"))
+		w := httptest.NewRecorder()
+		handler.CreateNotificationTarget(w, r)
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("case %d: status=%d, want 400 (body=%s)", i, w.Code, w.Body.String())
+		}
+	}
+}
+
+func TestNotificationTarget_TenantIsolation(t *testing.T) {
+	handler, _ := setupTestHandler()
+	created := createTargetForTest(t, handler, "tenant-1", map[string]interface{}{
+		"name": "mail", "type": "email", "email": "ops@a.com",
+	})
+	// Another tenant cannot read, update, or delete it.
+	r := httptest.NewRequest("DELETE", "/api/v1/notifications/targets/"+created.ID, nil).
+		WithContext(contextWithTenant("tenant-2"))
+	r.SetPathValue("id", created.ID)
+	w := httptest.NewRecorder()
+	handler.DeleteNotificationTarget(w, r)
+	if w.Code != http.StatusNotFound {
+		t.Errorf("cross-tenant delete: status=%d, want 404", w.Code)
+	}
+}
+
+func TestUpdateNotificationTarget_KeepsSecretWhenOmitted(t *testing.T) {
+	handler, repo := setupTestHandler()
+	created := createTargetForTest(t, handler, "tenant-1", map[string]interface{}{
+		"name": "ops-slack", "type": "slack", "secret": "hook-url-1",
+	})
+	body, _ := json.Marshal(map[string]interface{}{
+		"name": "ops-slack-renamed", "type": "slack", // no secret in PUT
+	})
+	r := httptest.NewRequest("PUT", "/api/v1/notifications/targets/"+created.ID, bytes.NewReader(body)).
+		WithContext(contextWithTenant("tenant-1"))
+	r.SetPathValue("id", created.ID)
+	w := httptest.NewRecorder()
+	handler.UpdateNotificationTarget(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("update: status=%d body=%s", w.Code, w.Body.String())
+	}
+	tgt, err := repo.GetNotificationTarget(contextWithTenant("tenant-1"), "tenant-1", created.ID)
+	if err != nil {
+		t.Fatalf("get after update: %v", err)
+	}
+	if tgt.SecretID == "" {
+		t.Error("secret reference lost on PUT without a new secret")
+	}
+	if tgt.Name != "ops-slack-renamed" {
+		t.Errorf("name = %q", tgt.Name)
+	}
+}
+
+func TestAlertsWebhook_AuthAndDispatch(t *testing.T) {
+	t.Setenv("ALERTS_WEBHOOK_TOKEN", "tok-123")
+	handler, _ := setupTestHandler()
+
+	// A webhook target catches the dispatched alert (no secret → plain POST).
+	var received []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		received, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+	createTargetForTest(t, handler, "tenant-1", map[string]interface{}{
+		"name": "catcher", "type": "webhook", "url": srv.URL,
+	})
+
+	payload := map[string]interface{}{
+		"status": "firing",
+		"alerts": []map[string]interface{}{{
+			"status": "firing",
+			"labels": map[string]string{
+				"alertname": "PipelineDown", "severity": "critical", "tenant_id": "tenant-1",
+			},
+			"annotations": map[string]string{"summary": "no messages for 10m"},
+		}},
+	}
+	b, _ := json.Marshal(payload)
+
+	// Wrong token → 401, nothing delivered.
+	r := httptest.NewRequest("POST", "/api/v1/alerts/webhook", bytes.NewReader(b))
+	r.Header.Set("Authorization", "Bearer wrong")
+	w := httptest.NewRecorder()
+	handler.AlertsWebhook(w, r)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("bad token: status=%d, want 401", w.Code)
+	}
+
+	// Correct token → dispatched to the tenant's webhook target.
+	r = httptest.NewRequest("POST", "/api/v1/alerts/webhook", bytes.NewReader(b))
+	r.Header.Set("Authorization", "Bearer tok-123")
+	w = httptest.NewRecorder()
+	handler.AlertsWebhook(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("webhook: status=%d body=%s", w.Code, w.Body.String())
+	}
+	var res struct {
+		Delivered int `json:"delivered"`
+		Failed    int `json:"failed"`
+	}
+	_ = json.Unmarshal(w.Body.Bytes(), &res)
+	if res.Delivered != 1 || res.Failed != 0 {
+		t.Errorf("delivered/failed = %d/%d, want 1/0", res.Delivered, res.Failed)
+	}
+	if !strings.Contains(string(received), "PipelineDown") {
+		t.Errorf("target did not receive the alert: %s", received)
+	}
+}
+
+func TestAlertsWebhook_PlatformRoutingAndSeverityFilter(t *testing.T) {
+	t.Setenv("ALERTS_WEBHOOK_TOKEN", "tok-123")
+	handler, _ := setupTestHandler()
+
+	var hits int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	// Platform-flagged target with min_severity=critical.
+	createTargetForTest(t, handler, "tenant-1", map[string]interface{}{
+		"name": "platform-hook", "type": "webhook", "url": srv.URL,
+		"platform": true, "min_severity": "critical",
+	})
+
+	send := func(severity string) {
+		payload := map[string]interface{}{
+			"alerts": []map[string]interface{}{{
+				"status":      "firing",
+				"labels":      map[string]string{"alertname": "DiskUsageHigh", "severity": severity},
+				"annotations": map[string]string{"summary": "disk > 80%"},
+			}},
+		}
+		b, _ := json.Marshal(payload)
+		r := httptest.NewRequest("POST", "/api/v1/alerts/webhook", bytes.NewReader(b))
+		r.Header.Set("Authorization", "Bearer tok-123")
+		w := httptest.NewRecorder()
+		handler.AlertsWebhook(w, r)
+		if w.Code != http.StatusOK {
+			t.Fatalf("webhook: status=%d", w.Code)
+		}
+	}
+
+	send("warning") // below min_severity — filtered out
+	if hits != 0 {
+		t.Errorf("warning alert should be filtered, hits=%d", hits)
+	}
+	send("critical") // platform alert (no tenant_id) reaches the platform target
+	if hits != 1 {
+		t.Errorf("critical platform alert should deliver, hits=%d", hits)
+	}
+}
+
+func TestAlertsWebhook_NotConfigured(t *testing.T) {
+	t.Setenv("ALERTS_WEBHOOK_TOKEN", "")
+	handler, _ := setupTestHandler()
+	r := httptest.NewRequest("POST", "/api/v1/alerts/webhook", strings.NewReader("{}"))
+	w := httptest.NewRecorder()
+	handler.AlertsWebhook(w, r)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("status=%d, want 503 when token unset", w.Code)
+	}
+}

--- a/src/pkg/managementapi/notifications_handler_test.go
+++ b/src/pkg/managementapi/notifications_handler_test.go
@@ -114,6 +114,23 @@ func TestUpdateNotificationTarget_KeepsSecretWhenOmitted(t *testing.T) {
 	}
 }
 
+func TestUpdateNotificationTarget_TypeChangeRequiresSecret(t *testing.T) {
+	handler, _ := setupTestHandler()
+	created := createTargetForTest(t, handler, "tenant-1", map[string]interface{}{
+		"name": "mail", "type": "email", "email": "ops@a.com",
+	})
+	// email → slack with no secret must be rejected (the old type had none).
+	body, _ := json.Marshal(map[string]interface{}{"name": "mail", "type": "slack"})
+	r := httptest.NewRequest("PUT", "/api/v1/notifications/targets/"+created.ID, bytes.NewReader(body)).
+		WithContext(contextWithTenant("tenant-1"))
+	r.SetPathValue("id", created.ID)
+	w := httptest.NewRecorder()
+	handler.UpdateNotificationTarget(w, r)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("email→slack without secret: status=%d, want 400 (body=%s)", w.Code, w.Body.String())
+	}
+}
+
 func TestAlertsWebhook_AuthAndDispatch(t *testing.T) {
 	t.Setenv("ALERTS_WEBHOOK_TOKEN", "tok-123")
 	handler, _ := setupTestHandler()

--- a/src/pkg/managementapi/notifications_mock_stubs_test.go
+++ b/src/pkg/managementapi/notifications_mock_stubs_test.go
@@ -41,6 +41,12 @@ func (m *MockRepository) CreateNotificationTarget(_ context.Context, t *Notifica
 	s := notifStateFor(m)
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	// Enforce UNIQUE (tenant_id, name) like Postgres does.
+	for _, ex := range s.targets {
+		if ex.TenantID == t.TenantID && ex.Name == t.Name {
+			return ErrNotificationTargetNameExists
+		}
+	}
 	s.nextID++
 	t.ID = fmt.Sprintf("nt-%d", s.nextID)
 	t.CreatedAt = time.Now()

--- a/src/pkg/managementapi/notifications_mock_stubs_test.go
+++ b/src/pkg/managementapi/notifications_mock_stubs_test.go
@@ -1,0 +1,140 @@
+package managementapi
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+)
+
+// MockRepository's notification-target methods carry real in-memory behaviour
+// so notifications_handler_test.go can drive the handlers end-to-end. Same
+// keyed-state pattern as oauth_mock_stubs_test.go.
+
+type mockNotifState struct {
+	mu      sync.Mutex
+	targets map[string]*NotificationTarget
+	secrets map[string]string // target ID -> plaintext secret
+	nextID  int
+}
+
+var (
+	notifStateMu sync.Mutex
+	notifStates  = map[*MockRepository]*mockNotifState{}
+)
+
+func notifStateFor(m *MockRepository) *mockNotifState {
+	notifStateMu.Lock()
+	defer notifStateMu.Unlock()
+	s, ok := notifStates[m]
+	if !ok {
+		s = &mockNotifState{
+			targets: map[string]*NotificationTarget{},
+			secrets: map[string]string{},
+		}
+		notifStates[m] = s
+	}
+	return s
+}
+
+func (m *MockRepository) CreateNotificationTarget(_ context.Context, t *NotificationTarget, secret string) error {
+	s := notifStateFor(m)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.nextID++
+	t.ID = fmt.Sprintf("nt-%d", s.nextID)
+	t.CreatedAt = time.Now()
+	t.UpdatedAt = t.CreatedAt
+	if secret != "" {
+		t.SecretID = "sec-" + t.ID
+		s.secrets[t.ID] = secret
+	}
+	cp := *t
+	s.targets[t.ID] = &cp
+	return nil
+}
+
+func (m *MockRepository) ListNotificationTargets(_ context.Context, tenantID string) ([]*NotificationTarget, error) {
+	s := notifStateFor(m)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var out []*NotificationTarget
+	for _, t := range s.targets {
+		if t.TenantID == tenantID {
+			cp := *t
+			out = append(out, &cp)
+		}
+	}
+	return out, nil
+}
+
+func (m *MockRepository) GetNotificationTarget(_ context.Context, tenantID, id string) (*NotificationTarget, error) {
+	s := notifStateFor(m)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	t, ok := s.targets[id]
+	if !ok || t.TenantID != tenantID {
+		return nil, ErrNotificationTargetNotFound
+	}
+	cp := *t
+	return &cp, nil
+}
+
+func (m *MockRepository) UpdateNotificationTarget(_ context.Context, t *NotificationTarget, secret string) error {
+	s := notifStateFor(m)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	old, ok := s.targets[t.ID]
+	if !ok || old.TenantID != t.TenantID {
+		return ErrNotificationTargetNotFound
+	}
+	if secret != "" {
+		t.SecretID = "sec-" + t.ID
+		s.secrets[t.ID] = secret
+	}
+	t.UpdatedAt = time.Now()
+	cp := *t
+	s.targets[t.ID] = &cp
+	return nil
+}
+
+func (m *MockRepository) DeleteNotificationTarget(_ context.Context, tenantID, id string) error {
+	s := notifStateFor(m)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	t, ok := s.targets[id]
+	if !ok || t.TenantID != tenantID {
+		return ErrNotificationTargetNotFound
+	}
+	delete(s.targets, id)
+	delete(s.secrets, id)
+	return nil
+}
+
+func (m *MockRepository) ListNotificationTargetsForDispatch(_ context.Context, tenantID string) ([]*NotificationTarget, error) {
+	s := notifStateFor(m)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var out []*NotificationTarget
+	for _, t := range s.targets {
+		if !t.Enabled {
+			continue
+		}
+		if tenantID != "" && t.TenantID == tenantID {
+			cp := *t
+			out = append(out, &cp)
+		}
+		if tenantID == "" && t.Config.Platform {
+			cp := *t
+			out = append(out, &cp)
+		}
+	}
+	return out, nil
+}
+
+func (m *MockRepository) ResolveNotificationSecret(_ context.Context, t *NotificationTarget) (string, error) {
+	s := notifStateFor(m)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.secrets[t.ID], nil
+}

--- a/src/pkg/managementapi/repo_notifications.go
+++ b/src/pkg/managementapi/repo_notifications.go
@@ -159,11 +159,18 @@ func (r *PostgresRepository) UpdateNotificationTarget(ctx context.Context, t *No
 		if err != nil {
 			return fmt.Errorf("encrypt notification secret: %w", err)
 		}
-		id, err := createSecretTx(ctx, tx, t.TenantID, notificationSecretName(t.Name), ct)
-		if err != nil {
-			return fmt.Errorf("persist notification secret: %w", err)
+		if t.SecretID != "" {
+			// Rotate in place (same reference) — avoids orphaning secrets rows.
+			if err := updateSecretCiphertextTx(ctx, tx, t.TenantID, t.SecretID, ct); err != nil {
+				return fmt.Errorf("rotate notification secret: %w", err)
+			}
+		} else {
+			id, err := createSecretTx(ctx, tx, t.TenantID, notificationSecretName(t.Name), ct)
+			if err != nil {
+				return fmt.Errorf("persist notification secret: %w", err)
+			}
+			t.SecretID = id
 		}
-		t.SecretID = id
 	}
 
 	var secretID sql.NullString

--- a/src/pkg/managementapi/repo_notifications.go
+++ b/src/pkg/managementapi/repo_notifications.go
@@ -1,0 +1,249 @@
+package managementapi
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/ValueRetail/vrsky/pkg/crypto"
+)
+
+// Phase 3A (#84): per-tenant notification targets — where a tenant's alerts
+// are delivered. Secrets (Slack webhook URL, PagerDuty routing key, webhook
+// HMAC key) are encrypted into the secrets table and referenced by secret_id,
+// mirroring the OAuth client-secret pattern (repo_oauth.go).
+
+// ErrNotificationTargetNotFound is returned for lookups of missing targets.
+var ErrNotificationTargetNotFound = errors.New("notification target not found")
+
+// NotificationTargetConfig is the non-secret per-target configuration stored
+// as JSONB. Which fields apply depends on Type: email → Email; webhook → URL.
+type NotificationTargetConfig struct {
+	Email       string `json:"email,omitempty"`        // email: recipient address
+	URL         string `json:"url,omitempty"`          // webhook: destination URL (non-secret)
+	Platform    bool   `json:"platform,omitempty"`     // also receive platform-level alerts (no tenant_id label)
+	MinSeverity string `json:"min_severity,omitempty"` // "" | info | warning | critical
+}
+
+// NotificationTarget is one delivery destination for alerts.
+type NotificationTarget struct {
+	ID        string
+	TenantID  string
+	Name      string
+	Type      string // slack | email | pagerduty | webhook
+	Config    NotificationTargetConfig
+	SecretID  string // "" when the type carries no secret
+	Enabled   bool
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}
+
+// notificationSecretName labels the encrypted secret row for a target.
+func notificationSecretName(targetName string) string {
+	return "notification-target:" + targetName
+}
+
+// CreateNotificationTarget inserts a target; when secret is non-empty it is
+// encrypted and stored first (same transaction).
+func (r *PostgresRepository) CreateNotificationTarget(ctx context.Context, t *NotificationTarget, secret string) error {
+	cfgJSON, err := json.Marshal(t.Config)
+	if err != nil {
+		return fmt.Errorf("encode config: %w", err)
+	}
+
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	var secretID sql.NullString
+	if secret != "" {
+		key, err := crypto.Key()
+		if err != nil {
+			return err
+		}
+		ct, err := crypto.Encrypt(secret, key)
+		if err != nil {
+			return fmt.Errorf("encrypt notification secret: %w", err)
+		}
+		id, err := createSecretTx(ctx, tx, t.TenantID, notificationSecretName(t.Name), ct)
+		if err != nil {
+			return fmt.Errorf("persist notification secret: %w", err)
+		}
+		secretID = sql.NullString{String: id, Valid: true}
+		t.SecretID = id
+	}
+
+	const q = `
+		INSERT INTO notification_targets (tenant_id, name, type, config, secret_id, enabled)
+		VALUES ($1, $2, $3, $4, $5, $6)
+		RETURNING id, created_at, updated_at`
+	if err := tx.QueryRowContext(ctx, q,
+		t.TenantID, t.Name, t.Type, cfgJSON, secretID, t.Enabled,
+	).Scan(&t.ID, &t.CreatedAt, &t.UpdatedAt); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+// scanNotificationTarget reads one row (column order of selectTargetCols).
+const selectTargetCols = `id, tenant_id, name, type, config, COALESCE(secret_id::text, ''), enabled, created_at, updated_at`
+
+func scanNotificationTarget(scan func(dest ...interface{}) error) (*NotificationTarget, error) {
+	var t NotificationTarget
+	var cfgJSON []byte
+	if err := scan(&t.ID, &t.TenantID, &t.Name, &t.Type, &cfgJSON, &t.SecretID, &t.Enabled, &t.CreatedAt, &t.UpdatedAt); err != nil {
+		return nil, err
+	}
+	if len(cfgJSON) > 0 {
+		if err := json.Unmarshal(cfgJSON, &t.Config); err != nil {
+			return nil, fmt.Errorf("decode config: %w", err)
+		}
+	}
+	return &t, nil
+}
+
+// ListNotificationTargets returns every target owned by a tenant.
+func (r *PostgresRepository) ListNotificationTargets(ctx context.Context, tenantID string) ([]*NotificationTarget, error) {
+	q := `SELECT ` + selectTargetCols + ` FROM notification_targets WHERE tenant_id = $1 ORDER BY created_at`
+	rows, err := r.db.QueryContext(ctx, q, tenantID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []*NotificationTarget
+	for rows.Next() {
+		t, err := scanNotificationTarget(rows.Scan)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, t)
+	}
+	return out, rows.Err()
+}
+
+// GetNotificationTarget returns one target scoped to a tenant.
+func (r *PostgresRepository) GetNotificationTarget(ctx context.Context, tenantID, id string) (*NotificationTarget, error) {
+	q := `SELECT ` + selectTargetCols + ` FROM notification_targets WHERE tenant_id = $1 AND id = $2`
+	t, err := scanNotificationTarget(r.db.QueryRowContext(ctx, q, tenantID, id).Scan)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, ErrNotificationTargetNotFound
+	}
+	return t, err
+}
+
+// UpdateNotificationTarget rewrites the mutable fields; a non-empty secret is
+// re-encrypted into a fresh secrets row (the old reference is replaced).
+func (r *PostgresRepository) UpdateNotificationTarget(ctx context.Context, t *NotificationTarget, secret string) error {
+	cfgJSON, err := json.Marshal(t.Config)
+	if err != nil {
+		return fmt.Errorf("encode config: %w", err)
+	}
+
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if secret != "" {
+		key, err := crypto.Key()
+		if err != nil {
+			return err
+		}
+		ct, err := crypto.Encrypt(secret, key)
+		if err != nil {
+			return fmt.Errorf("encrypt notification secret: %w", err)
+		}
+		id, err := createSecretTx(ctx, tx, t.TenantID, notificationSecretName(t.Name), ct)
+		if err != nil {
+			return fmt.Errorf("persist notification secret: %w", err)
+		}
+		t.SecretID = id
+	}
+
+	var secretID sql.NullString
+	if t.SecretID != "" {
+		secretID = sql.NullString{String: t.SecretID, Valid: true}
+	}
+	const q = `
+		UPDATE notification_targets
+		SET name = $1, type = $2, config = $3, secret_id = $4, enabled = $5, updated_at = NOW()
+		WHERE tenant_id = $6 AND id = $7`
+	res, err := tx.ExecContext(ctx, q, t.Name, t.Type, cfgJSON, secretID, t.Enabled, t.TenantID, t.ID)
+	if err != nil {
+		return err
+	}
+	if n, _ := res.RowsAffected(); n == 0 {
+		return ErrNotificationTargetNotFound
+	}
+	return tx.Commit()
+}
+
+// DeleteNotificationTarget removes one target scoped to a tenant.
+func (r *PostgresRepository) DeleteNotificationTarget(ctx context.Context, tenantID, id string) error {
+	res, err := r.db.ExecContext(ctx,
+		`DELETE FROM notification_targets WHERE tenant_id = $1 AND id = $2`, tenantID, id)
+	if err != nil {
+		return err
+	}
+	if n, _ := res.RowsAffected(); n == 0 {
+		return ErrNotificationTargetNotFound
+	}
+	return nil
+}
+
+// ListNotificationTargetsForDispatch returns the enabled targets an incoming
+// alert should fan out to. Tenant alerts (tenantID != "") go to that tenant's
+// targets; platform alerts (tenantID == "") go to every enabled target flagged
+// platform=true across tenants — that cross-tenant read is the intended
+// routing model for platform-level alerts (disk, NATS, mgmt-api, certs).
+func (r *PostgresRepository) ListNotificationTargetsForDispatch(ctx context.Context, tenantID string) ([]*NotificationTarget, error) {
+	var (
+		q    string
+		args []interface{}
+	)
+	if tenantID != "" {
+		q = `SELECT ` + selectTargetCols + ` FROM notification_targets WHERE tenant_id = $1 AND enabled`
+		args = []interface{}{tenantID}
+	} else {
+		// lint:tenant-ok — platform alerts intentionally fan out to every
+		// tenant's platform-flagged targets (see routing model above).
+		q = `SELECT ` + selectTargetCols + ` FROM notification_targets WHERE enabled AND config->>'platform' = 'true'`
+	}
+	rows, err := r.db.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []*NotificationTarget
+	for rows.Next() {
+		t, err := scanNotificationTarget(rows.Scan)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, t)
+	}
+	return out, rows.Err()
+}
+
+// ResolveNotificationSecret decrypts a target's secret (webhook URL / routing
+// key / HMAC key). Returns "" when the target has none.
+func (r *PostgresRepository) ResolveNotificationSecret(ctx context.Context, t *NotificationTarget) (string, error) {
+	if t.SecretID == "" {
+		return "", nil
+	}
+	ct, err := r.GetSecretCiphertext(ctx, t.TenantID, t.SecretID)
+	if err != nil {
+		return "", err
+	}
+	key, err := crypto.Key()
+	if err != nil {
+		return "", err
+	}
+	return crypto.Decrypt(ct, key)
+}

--- a/src/pkg/managementapi/repo_notifications.go
+++ b/src/pkg/managementapi/repo_notifications.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/ValueRetail/vrsky/pkg/crypto"
@@ -18,6 +19,23 @@ import (
 
 // ErrNotificationTargetNotFound is returned for lookups of missing targets.
 var ErrNotificationTargetNotFound = errors.New("notification target not found")
+
+// ErrNotificationTargetNameExists is returned when a target name collides with
+// an existing one for the tenant (UNIQUE (tenant_id, name)). Handlers map it to
+// 409 Conflict with a clear message instead of a generic 500.
+var ErrNotificationTargetNameExists = errors.New("a notification target with this name already exists")
+
+// isDuplicateNameErr reports whether a DB error is the (tenant_id, name) unique
+// violation. String-matched to stay driver-agnostic (pgx stdlib), matching the
+// secrets handler's approach.
+func isDuplicateNameErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "notification_targets_tenant_id_name_key") ||
+		strings.Contains(msg, "duplicate key value")
+}
 
 // NotificationTargetConfig is the non-secret per-target configuration stored
 // as JSONB. Which fields apply depends on Type: email → Email; webhook → URL.
@@ -85,6 +103,9 @@ func (r *PostgresRepository) CreateNotificationTarget(ctx context.Context, t *No
 	if err := tx.QueryRowContext(ctx, q,
 		t.TenantID, t.Name, t.Type, cfgJSON, secretID, t.Enabled,
 	).Scan(&t.ID, &t.CreatedAt, &t.UpdatedAt); err != nil {
+		if isDuplicateNameErr(err) {
+			return ErrNotificationTargetNameExists
+		}
 		return err
 	}
 	return tx.Commit()
@@ -183,6 +204,9 @@ func (r *PostgresRepository) UpdateNotificationTarget(ctx context.Context, t *No
 		WHERE tenant_id = $6 AND id = $7`
 	res, err := tx.ExecContext(ctx, q, t.Name, t.Type, cfgJSON, secretID, t.Enabled, t.TenantID, t.ID)
 	if err != nil {
+		if isDuplicateNameErr(err) {
+			return ErrNotificationTargetNameExists
+		}
 		return err
 	}
 	if n, _ := res.RowsAffected(); n == 0 {

--- a/src/pkg/managementapi/repository.go
+++ b/src/pkg/managementapi/repository.go
@@ -361,6 +361,33 @@ type Repository interface {
 	ListOAuthProviders(ctx context.Context, tenantID string) ([]*oauth.ProviderConfig, error)
 
 	// ============================================
+	// Notification Targets (Phase 3A — #84)
+	// ============================================
+
+	// CreateNotificationTarget inserts a target; a non-empty secret is encrypted
+	// into the secrets table and referenced by secret_id.
+	CreateNotificationTarget(ctx context.Context, t *NotificationTarget, secret string) error
+
+	// ListNotificationTargets returns every target owned by a tenant.
+	ListNotificationTargets(ctx context.Context, tenantID string) ([]*NotificationTarget, error)
+
+	// GetNotificationTarget returns one target scoped to a tenant.
+	GetNotificationTarget(ctx context.Context, tenantID, id string) (*NotificationTarget, error)
+
+	// UpdateNotificationTarget rewrites a target; empty secret keeps the old one.
+	UpdateNotificationTarget(ctx context.Context, t *NotificationTarget, secret string) error
+
+	// DeleteNotificationTarget removes one target scoped to a tenant.
+	DeleteNotificationTarget(ctx context.Context, tenantID, id string) error
+
+	// ListNotificationTargetsForDispatch returns enabled targets for an alert:
+	// the tenant's targets when tenantID != "", else all platform-flagged ones.
+	ListNotificationTargetsForDispatch(ctx context.Context, tenantID string) ([]*NotificationTarget, error)
+
+	// ResolveNotificationSecret decrypts a target's secret ("" when none).
+	ResolveNotificationSecret(ctx context.Context, t *NotificationTarget) (string, error)
+
+	// ============================================
 	// Lifecycle
 	// ============================================
 

--- a/src/pkg/notify/email.go
+++ b/src/pkg/notify/email.go
@@ -1,0 +1,73 @@
+package notify
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/smtp"
+	"strings"
+)
+
+// SMTPConfig is the platform-wide mail identity (one set of SMTP credentials
+// for the deployment, from SMTP_* env). Per-target state is just the recipient.
+type SMTPConfig struct {
+	Host     string // e.g. mailpit (dev) or smtp.sendgrid.net
+	Port     string // e.g. 1025 / 587
+	From     string // e.g. alerts@vrsky.example.com
+	Username string // empty -> unauthenticated (dev SMTP)
+	Password string
+}
+
+// Email sends an alert as a plain-text mail to one recipient.
+type Email struct {
+	SMTP SMTPConfig
+	To   string
+
+	// sendMail is swapped in tests; defaults to smtp.SendMail.
+	sendMail func(addr string, a smtp.Auth, from string, to []string, msg []byte) error
+}
+
+func (e *Email) Send(ctx context.Context, alert *Alert) error {
+	if e.SMTP.Host == "" || e.SMTP.From == "" {
+		return fmt.Errorf("email: SMTP is not configured (set SMTP_HOST and SMTP_FROM)")
+	}
+	if e.To == "" {
+		return fmt.Errorf("email: recipient is empty")
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	var auth smtp.Auth
+	if e.SMTP.Username != "" {
+		auth = smtp.PlainAuth("", e.SMTP.Username, e.SMTP.Password, e.SMTP.Host)
+	}
+
+	body := alert.Title() + "\r\n\r\n"
+	if alert.Description != "" {
+		body += alert.Description + "\r\n\r\n"
+	}
+	for k, v := range alert.Labels {
+		body += k + " = " + v + "\r\n"
+	}
+
+	msg := strings.Join([]string{
+		"From: " + e.SMTP.From,
+		"To: " + e.To,
+		"Subject: " + alert.Title(),
+		"MIME-Version: 1.0",
+		"Content-Type: text/plain; charset=utf-8",
+		"",
+		body,
+	}, "\r\n")
+
+	send := e.sendMail
+	if send == nil {
+		send = smtp.SendMail
+	}
+	addr := net.JoinHostPort(e.SMTP.Host, e.SMTP.Port)
+	if err := send(addr, auth, e.SMTP.From, []string{e.To}, []byte(msg)); err != nil {
+		return fmt.Errorf("email: send via %s: %w", addr, err)
+	}
+	return nil
+}

--- a/src/pkg/notify/notify.go
+++ b/src/pkg/notify/notify.go
@@ -1,0 +1,62 @@
+// Package notify delivers alert notifications to per-tenant targets (#84):
+// Slack incoming webhooks, email (SMTP), PagerDuty Events API v2, and generic
+// webhooks. The management-api's Alertmanager receiver normalizes incoming
+// alerts into Alert values and fans them out to a Notifier per target.
+package notify
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+// Alert is one normalized alert (firing or resolved) ready for delivery.
+type Alert struct {
+	Name        string            `json:"name"`     // alertname label
+	Status      string            `json:"status"`   // "firing" | "resolved"
+	Severity    string            `json:"severity"` // "critical" | "warning" | "info"
+	Summary     string            `json:"summary"`
+	Description string            `json:"description,omitempty"`
+	TenantID    string            `json:"tenant_id,omitempty"` // empty for platform alerts
+	Labels      map[string]string `json:"labels,omitempty"`
+	StartsAt    time.Time         `json:"starts_at"`
+}
+
+// Title renders the conventional one-line headline, e.g.
+// "[FIRING:critical] PipelineDown — no messages published for tenant X".
+func (a *Alert) Title() string {
+	status := a.Status
+	if status == "" {
+		status = "firing"
+	}
+	sev := a.Severity
+	if sev == "" {
+		sev = "warning"
+	}
+	t := fmt.Sprintf("[%s:%s] %s", upper(status), sev, a.Name)
+	if a.Summary != "" {
+		t += " — " + a.Summary
+	}
+	return t
+}
+
+func upper(s string) string {
+	b := []byte(s)
+	for i := range b {
+		if 'a' <= b[i] && b[i] <= 'z' {
+			b[i] -= 'a' - 'A'
+		}
+	}
+	return string(b)
+}
+
+// Notifier delivers one alert to one destination. Implementations must be safe
+// for concurrent use and respect ctx cancellation.
+type Notifier interface {
+	Send(ctx context.Context, a *Alert) error
+}
+
+// httpClient is the shared default for the HTTP-based senders; tests inject
+// their own via each sender's Client field.
+var httpClient = &http.Client{Timeout: 10 * time.Second}

--- a/src/pkg/notify/notify_test.go
+++ b/src/pkg/notify/notify_test.go
@@ -1,0 +1,187 @@
+package notify
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/smtp"
+	"strings"
+	"testing"
+	"time"
+)
+
+func testAlert() *Alert {
+	return &Alert{
+		Name:        "PipelineDown",
+		Status:      "firing",
+		Severity:    "critical",
+		Summary:     "no messages published for 10m",
+		Description: "tenant t1 pipeline stopped producing",
+		TenantID:    "t1",
+		Labels:      map[string]string{"tenant_id": "t1"},
+		StartsAt:    time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC),
+	}
+}
+
+func TestAlertTitle(t *testing.T) {
+	a := testAlert()
+	want := "[FIRING:critical] PipelineDown — no messages published for 10m"
+	if got := a.Title(); got != want {
+		t.Errorf("Title() = %q, want %q", got, want)
+	}
+	a.Status = "resolved"
+	if got := a.Title(); !strings.HasPrefix(got, "[RESOLVED:critical]") {
+		t.Errorf("resolved Title() = %q, want [RESOLVED:critical] prefix", got)
+	}
+}
+
+func TestSlack_Send(t *testing.T) {
+	var got map[string]interface{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &got)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	s := &Slack{WebhookURL: srv.URL, Client: srv.Client()}
+	if err := s.Send(context.Background(), testAlert()); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	atts, ok := got["attachments"].([]interface{})
+	if !ok || len(atts) != 1 {
+		t.Fatalf("attachments = %v, want 1", got["attachments"])
+	}
+	att := atts[0].(map[string]interface{})
+	if att["color"] != "#cc0000" {
+		t.Errorf("color = %v, want #cc0000 (critical)", att["color"])
+	}
+	if !strings.Contains(att["text"].(string), "PipelineDown") {
+		t.Errorf("text missing alert name: %v", att["text"])
+	}
+}
+
+func TestSlack_SendErrorStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "no_service", http.StatusNotFound)
+	}))
+	defer srv.Close()
+	s := &Slack{WebhookURL: srv.URL, Client: srv.Client()}
+	if err := s.Send(context.Background(), testAlert()); err == nil {
+		t.Fatal("expected error on 404, got nil")
+	}
+}
+
+func TestEmail_Send(t *testing.T) {
+	var gotAddr, gotFrom string
+	var gotTo []string
+	var gotMsg []byte
+	e := &Email{
+		SMTP: SMTPConfig{Host: "mail.local", Port: "1025", From: "alerts@vrsky.local"},
+		To:   "ops@example.com",
+		sendMail: func(addr string, a smtp.Auth, from string, to []string, msg []byte) error {
+			gotAddr, gotFrom, gotTo, gotMsg = addr, from, to, msg
+			return nil
+		},
+	}
+	if err := e.Send(context.Background(), testAlert()); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if gotAddr != "mail.local:1025" || gotFrom != "alerts@vrsky.local" {
+		t.Errorf("addr/from = %q/%q", gotAddr, gotFrom)
+	}
+	if len(gotTo) != 1 || gotTo[0] != "ops@example.com" {
+		t.Errorf("to = %v", gotTo)
+	}
+	if !strings.Contains(string(gotMsg), "Subject: [FIRING:critical] PipelineDown") {
+		t.Errorf("message missing subject: %s", gotMsg)
+	}
+}
+
+func TestEmail_RequiresConfig(t *testing.T) {
+	e := &Email{To: "ops@example.com"}
+	if err := e.Send(context.Background(), testAlert()); err == nil {
+		t.Fatal("expected error without SMTP config")
+	}
+	e = &Email{SMTP: SMTPConfig{Host: "h", Port: "25", From: "f@x"}}
+	if err := e.Send(context.Background(), testAlert()); err == nil {
+		t.Fatal("expected error without recipient")
+	}
+}
+
+func TestPagerDuty_Send(t *testing.T) {
+	var got map[string]interface{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &got)
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+
+	p := &PagerDuty{RoutingKey: "rk-123", Endpoint: srv.URL, Client: srv.Client()}
+	if err := p.Send(context.Background(), testAlert()); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if got["routing_key"] != "rk-123" || got["event_action"] != "trigger" {
+		t.Errorf("routing_key/event_action = %v/%v", got["routing_key"], got["event_action"])
+	}
+	if got["dedup_key"] != "PipelineDown:t1" {
+		t.Errorf("dedup_key = %v", got["dedup_key"])
+	}
+
+	// Resolved alerts resolve the same dedup key.
+	a := testAlert()
+	a.Status = "resolved"
+	if err := p.Send(context.Background(), a); err != nil {
+		t.Fatalf("Send resolved: %v", err)
+	}
+	if got["event_action"] != "resolve" {
+		t.Errorf("event_action = %v, want resolve", got["event_action"])
+	}
+}
+
+func TestWebhook_SendWithHMAC(t *testing.T) {
+	var gotSig string
+	var gotBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotSig = r.Header.Get("X-VRSky-Signature")
+		gotBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	wh := &Webhook{URL: srv.URL, Secret: "s3cret", Client: srv.Client()}
+	if err := wh.Send(context.Background(), testAlert()); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	mac := hmac.New(sha256.New, []byte("s3cret"))
+	mac.Write(gotBody)
+	if want := hex.EncodeToString(mac.Sum(nil)); gotSig != want {
+		t.Errorf("signature = %q, want %q", gotSig, want)
+	}
+	var a Alert
+	if err := json.Unmarshal(gotBody, &a); err != nil || a.Name != "PipelineDown" {
+		t.Errorf("body did not round-trip an Alert: %v %v", err, a.Name)
+	}
+}
+
+func TestWebhook_NoSecretNoHeader(t *testing.T) {
+	var hasSig bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, hasSig = r.Header["X-Vrsky-Signature"]
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+	wh := &Webhook{URL: srv.URL, Client: srv.Client()}
+	if err := wh.Send(context.Background(), testAlert()); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if hasSig {
+		t.Error("signature header set without a secret")
+	}
+}

--- a/src/pkg/notify/pagerduty.go
+++ b/src/pkg/notify/pagerduty.go
@@ -1,0 +1,84 @@
+package notify
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+// defaultPagerDutyURL is the PagerDuty Events API v2 enqueue endpoint.
+const defaultPagerDutyURL = "https://events.pagerduty.com/v2/enqueue"
+
+// PagerDuty triggers/resolves incidents via the Events API v2. RoutingKey is
+// the integration key (a secret, resolved by the caller).
+type PagerDuty struct {
+	RoutingKey string
+	Endpoint   string       // empty -> the real Events API; tests point at httptest
+	Client     *http.Client // nil -> shared default
+}
+
+func pdSeverity(severity string) string {
+	switch severity {
+	case "critical", "warning", "info", "error":
+		return severity
+	default:
+		return "warning"
+	}
+}
+
+func (p *PagerDuty) Send(ctx context.Context, a *Alert) error {
+	if p.RoutingKey == "" {
+		return fmt.Errorf("pagerduty: routing key is empty")
+	}
+	action := "trigger"
+	if a.Status == "resolved" {
+		action = "resolve"
+	}
+	// dedup_key ties resolve events to the original trigger.
+	dedup := a.Name
+	if a.TenantID != "" {
+		dedup += ":" + a.TenantID
+	}
+	payload := map[string]interface{}{
+		"routing_key":  p.RoutingKey,
+		"event_action": action,
+		"dedup_key":    dedup,
+		"payload": map[string]interface{}{
+			"summary":        a.Title(),
+			"severity":       pdSeverity(a.Severity),
+			"source":         "vrsky",
+			"custom_details": a.Labels,
+		},
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("pagerduty: marshal: %w", err)
+	}
+	url := p.Endpoint
+	if url == "" {
+		url = defaultPagerDutyURL
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("pagerduty: request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	client := p.Client
+	if client == nil {
+		client = httpClient
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("pagerduty: post: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		b, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return fmt.Errorf("pagerduty: events API returned %d: %s", resp.StatusCode, b)
+	}
+	return nil
+}

--- a/src/pkg/notify/slack.go
+++ b/src/pkg/notify/slack.go
@@ -1,0 +1,74 @@
+package notify
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+// Slack posts alerts to a Slack incoming webhook
+// (https://api.slack.com/messaging/webhooks). The webhook URL is a secret —
+// it is resolved from the secrets vault by the caller, never stored here.
+type Slack struct {
+	WebhookURL string
+	Client     *http.Client // nil -> shared default
+}
+
+// slack message colors by severity (attachment bar).
+func slackColor(severity, status string) string {
+	if status == "resolved" {
+		return "#2eb886" // green
+	}
+	switch severity {
+	case "critical":
+		return "#cc0000"
+	case "warning":
+		return "#daa038"
+	default:
+		return "#439fe0"
+	}
+}
+
+func (s *Slack) Send(ctx context.Context, a *Alert) error {
+	if s.WebhookURL == "" {
+		return fmt.Errorf("slack: webhook URL is empty")
+	}
+	text := a.Title()
+	if a.Description != "" {
+		text += "\n" + a.Description
+	}
+	payload := map[string]interface{}{
+		"attachments": []map[string]interface{}{{
+			"color":    slackColor(a.Severity, a.Status),
+			"fallback": a.Title(),
+			"text":     text,
+		}},
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("slack: marshal: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.WebhookURL, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("slack: request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	client := s.Client
+	if client == nil {
+		client = httpClient
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("slack: post: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		b, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return fmt.Errorf("slack: webhook returned %d: %s", resp.StatusCode, b)
+	}
+	return nil
+}

--- a/src/pkg/notify/webhook.go
+++ b/src/pkg/notify/webhook.go
@@ -1,0 +1,57 @@
+package notify
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+// Webhook POSTs the alert as JSON to an arbitrary URL. When Secret is set the
+// request carries X-VRSky-Signature: hex(HMAC-SHA256(body)) so the receiver can
+// verify authenticity — the same scheme VRSky's own webhook-consumer verifies.
+type Webhook struct {
+	URL    string
+	Secret string       // optional HMAC key (a secret, resolved by the caller)
+	Client *http.Client // nil -> shared default
+}
+
+func (w *Webhook) Send(ctx context.Context, a *Alert) error {
+	if w.URL == "" {
+		return fmt.Errorf("webhook: URL is empty")
+	}
+	body, err := json.Marshal(a)
+	if err != nil {
+		return fmt.Errorf("webhook: marshal: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, w.URL, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("webhook: request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if w.Secret != "" {
+		mac := hmac.New(sha256.New, []byte(w.Secret))
+		mac.Write(body)
+		req.Header.Set("X-VRSky-Signature", hex.EncodeToString(mac.Sum(nil)))
+	}
+
+	client := w.Client
+	if client == nil {
+		client = httpClient
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("webhook: post: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		b, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return fmt.Errorf("webhook: %s returned %d: %s", w.URL, resp.StatusCode, b)
+	}
+	return nil
+}

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -23,6 +23,7 @@ import AuditPage from './pages/AuditPage'
 import UsersPage from './pages/UsersPage'
 import UsagePage from './pages/UsagePage'
 import OAuthProvidersPage from './pages/OAuthProvidersPage'
+import NotificationsPage from './pages/NotificationsPage'
 
 function App() {
   const { confirmDialog, hideConfirmDialog } = useUIStore()
@@ -81,6 +82,7 @@ function App() {
             <Route path="/settings/tenant-connections" element={<ProtectedRoute><TenantConnectionsPage /></ProtectedRoute>} />
             <Route path="/settings/api-key" element={<ProtectedRoute><ApiKeyPage /></ProtectedRoute>} />
             <Route path="/settings/oauth" element={<ProtectedRoute><OAuthProvidersPage /></ProtectedRoute>} />
+            <Route path="/settings/notifications" element={<ProtectedRoute><NotificationsPage /></ProtectedRoute>} />
             <Route path="/settings/audit" element={<ProtectedRoute><AuditPage /></ProtectedRoute>} />
             <Route path="/settings/users" element={<ProtectedRoute><UsersPage /></ProtectedRoute>} />
             <Route path="/settings/usage" element={<ProtectedRoute><UsagePage /></ProtectedRoute>} />

--- a/ui/src/components/Layout/Sidebar.tsx
+++ b/ui/src/components/Layout/Sidebar.tsx
@@ -101,6 +101,16 @@ export default function Sidebar() {
           </Link>
           )}
           <Link
+            to="/settings/notifications"
+            className={`flex items-center gap-3 px-4 py-2 rounded-lg text-sm transition-all duration-fast ${
+              isActive('/settings/notifications')
+                ? 'bg-primary-100 dark:bg-primary-900/30 text-primary-700 dark:text-primary-300 font-semibold'
+                : 'text-neutral-700 dark:text-neutral-300 hover:bg-neutral-100 dark:hover:bg-neutral-700/50'
+            }`}
+          >
+            Notifications
+          </Link>
+          <Link
             to="/settings/audit"
             className={`flex items-center gap-3 px-4 py-2 rounded-lg text-sm transition-all duration-fast ${
               isActive('/settings/audit')

--- a/ui/src/components/Pipeline/PropertyEditor.tsx
+++ b/ui/src/components/Pipeline/PropertyEditor.tsx
@@ -2468,7 +2468,7 @@ function ConverterConfig({
           setPreviewInput('// Set the Salesforce instance URL, account and a SOQL query first')
           return
         }
-        const resp = await fetch('http://localhost:9700/sample-data/', {
+        const resp = await fetch('http://localhost:9250/sample-data/', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({

--- a/ui/src/components/Pipeline/schemaDiscovery.ts
+++ b/ui/src/components/Pipeline/schemaDiscovery.ts
@@ -100,7 +100,7 @@ export async function discoverSchema(
       if (!sf.instance_url || !sf.oauth_grant_id) throw new Error('Set the Salesforce instance URL and connect an account first')
       if (!sf.soql) throw new Error('Enter a SOQL query (its FROM clause names the object to describe)')
       if (!opts?.tenantId) throw new Error('No active tenant')
-      const data = await postJSON('http://localhost:9700/schema/', {
+      const data = await postJSON('http://localhost:9250/schema/', {
         tenant_id: opts.tenantId,
         instance_url: sf.instance_url, oauth_grant_id: sf.oauth_grant_id,
         api_version: sf.api_version, soql: sf.soql,

--- a/ui/src/pages/NotificationsPage.tsx
+++ b/ui/src/pages/NotificationsPage.tsx
@@ -270,8 +270,9 @@ export default function NotificationsPage() {
                 <div className="ml-4 shrink-0 flex items-center gap-2">
                   <button
                     onClick={() => handleTest(t)}
-                    disabled={testing === t.id}
-                    className="px-3 py-1.5 text-xs font-medium text-blue-700 bg-blue-50 border border-blue-200 rounded-md hover:bg-blue-100 disabled:opacity-50"
+                    disabled={testing === t.id || !t.enabled}
+                    title={!t.enabled ? 'Enable the target to send a test' : undefined}
+                    className="px-3 py-1.5 text-xs font-medium text-blue-700 bg-blue-50 border border-blue-200 rounded-md hover:bg-blue-100 disabled:opacity-50 disabled:cursor-not-allowed"
                   >
                     {testing === t.id ? 'Sending…' : 'Test'}
                   </button>

--- a/ui/src/pages/NotificationsPage.tsx
+++ b/ui/src/pages/NotificationsPage.tsx
@@ -1,0 +1,298 @@
+import { useState, useEffect, useCallback } from 'react'
+import { useUIStore } from '@/store/uiStore'
+import { useAuthStore } from '@/store/authStore'
+import * as notificationService from '@/services/notificationService'
+import type { NotificationTarget, NotificationTargetType } from '@/services/notificationService'
+
+const TARGET_TYPES: { value: NotificationTargetType; label: string }[] = [
+  { value: 'slack', label: 'Slack (incoming webhook)' },
+  { value: 'email', label: 'Email' },
+  { value: 'pagerduty', label: 'PagerDuty (Events API v2)' },
+  { value: 'webhook', label: 'Webhook (POST JSON)' },
+]
+
+const SEVERITIES = ['', 'info', 'warning', 'critical']
+
+const inputClass =
+  'w-full px-3 py-2 border border-neutral-300 rounded-md text-sm text-neutral-900 bg-white focus:outline-none focus:ring-2 focus:ring-blue-500'
+const labelClass = 'block text-xs font-medium text-neutral-600 mb-1'
+
+const typeBadgeColor: Record<string, string> = {
+  slack: 'bg-purple-50 text-purple-700 border-purple-200',
+  email: 'bg-blue-50 text-blue-700 border-blue-200',
+  pagerduty: 'bg-green-50 text-green-700 border-green-200',
+  webhook: 'bg-amber-50 text-amber-700 border-amber-200',
+}
+
+/**
+ * Settings → Notifications (#84). Per-tenant alert delivery targets. Alerts
+ * fired by Prometheus route via Alertmanager into the management-api, which
+ * fans out to these targets. Write endpoints are admin-gated server-side.
+ */
+export default function NotificationsPage() {
+  const { addNotification, showConfirmDialog, hideConfirmDialog } = useUIStore()
+
+  const role = useAuthStore((s) => s.currentTenant?.user_role)
+  const canManage = role === 'owner' || role === 'admin'
+
+  const [targets, setTargets] = useState<NotificationTarget[]>([])
+  const [loading, setLoading] = useState(true)
+
+  const [name, setName] = useState('')
+  const [type, setType] = useState<NotificationTargetType>('slack')
+  const [secret, setSecret] = useState('')
+  const [email, setEmail] = useState('')
+  const [url, setUrl] = useState('')
+  const [platform, setPlatform] = useState(false)
+  const [minSeverity, setMinSeverity] = useState('')
+  const [saving, setSaving] = useState(false)
+  const [testing, setTesting] = useState<string | null>(null) // target id being tested
+
+  const refresh = useCallback(async () => {
+    setLoading(true)
+    try {
+      setTargets(await notificationService.listTargets())
+    } catch (e) {
+      addNotification({ type: 'error', title: 'Error', message: e instanceof Error ? e.message : 'Failed to load targets' })
+    } finally {
+      setLoading(false)
+    }
+  }, [addNotification])
+
+  useEffect(() => {
+    void refresh()
+  }, [refresh])
+
+  const resetForm = () => {
+    setName(''); setSecret(''); setEmail(''); setUrl(''); setPlatform(false); setMinSeverity('')
+  }
+
+  const handleCreate = async () => {
+    if (!name.trim()) {
+      addNotification({ type: 'error', title: 'Missing name', message: 'Give the target a name.' })
+      return
+    }
+    if (type === 'slack' && !secret.trim()) {
+      addNotification({ type: 'error', title: 'Missing webhook URL', message: 'Slack targets need the incoming-webhook URL.' })
+      return
+    }
+    if (type === 'email' && !email.trim()) {
+      addNotification({ type: 'error', title: 'Missing address', message: 'Email targets need a recipient address.' })
+      return
+    }
+    if (type === 'pagerduty' && !secret.trim()) {
+      addNotification({ type: 'error', title: 'Missing routing key', message: 'PagerDuty targets need the Events API routing key.' })
+      return
+    }
+    if (type === 'webhook' && !url.trim()) {
+      addNotification({ type: 'error', title: 'Missing URL', message: 'Webhook targets need a destination URL.' })
+      return
+    }
+    setSaving(true)
+    try {
+      await notificationService.createTarget({
+        name: name.trim(),
+        type,
+        ...(secret.trim() ? { secret: secret.trim() } : {}),
+        ...(type === 'email' ? { email: email.trim() } : {}),
+        ...(type === 'webhook' ? { url: url.trim() } : {}),
+        platform,
+        ...(minSeverity ? { min_severity: minSeverity } : {}),
+      })
+      addNotification({ type: 'success', title: 'Target added', message: `${name.trim()} will receive alerts.` })
+      resetForm()
+      await refresh()
+    } catch (e) {
+      addNotification({ type: 'error', title: 'Error', message: e instanceof Error ? e.message : 'Failed to create target' })
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const handleTest = async (t: NotificationTarget) => {
+    setTesting(t.id)
+    try {
+      const res = await notificationService.testTarget(t.id)
+      if (res.ok) {
+        addNotification({ type: 'success', title: 'Test sent', message: `Check ${t.type === 'email' ? t.email : t.name} for the test notification.` })
+      } else {
+        addNotification({ type: 'error', title: 'Test failed', message: res.error || 'Delivery failed' })
+      }
+    } catch (e) {
+      addNotification({ type: 'error', title: 'Test failed', message: e instanceof Error ? e.message : 'Delivery failed' })
+    } finally {
+      setTesting(null)
+    }
+  }
+
+  const handleToggle = async (t: NotificationTarget) => {
+    try {
+      await notificationService.updateTarget(t.id, {
+        name: t.name,
+        type: t.type,
+        email: t.email,
+        url: t.url,
+        platform: t.platform,
+        min_severity: t.min_severity,
+        enabled: !t.enabled,
+      })
+      await refresh()
+    } catch (e) {
+      addNotification({ type: 'error', title: 'Error', message: e instanceof Error ? e.message : 'Failed to update target' })
+    }
+  }
+
+  const handleDelete = (t: NotificationTarget) => {
+    showConfirmDialog({
+      title: 'Delete target',
+      message: `Delete "${t.name}"? Alerts will no longer be delivered there.`,
+      confirmLabel: 'Delete',
+      destructive: true,
+      onConfirm: async () => {
+        hideConfirmDialog()
+        try {
+          await notificationService.deleteTarget(t.id)
+          addNotification({ type: 'success', title: 'Deleted', message: `${t.name} removed.` })
+          await refresh()
+        } catch (e) {
+          addNotification({ type: 'error', title: 'Error', message: e instanceof Error ? e.message : 'Failed to delete target' })
+        }
+      },
+    })
+  }
+
+  return (
+    <div className="p-6 max-w-3xl mx-auto">
+      <h1 className="text-2xl font-bold text-neutral-900 mb-2">Notifications</h1>
+      <p className="text-sm text-neutral-600 mb-6">
+        Where this workspace's alerts are delivered (pipeline down, DLQ growth, …). Targets marked
+        “platform” also receive platform-level alerts (disk, brokers, API health).
+      </p>
+
+      {!canManage && (
+        <div className="bg-amber-50 border border-amber-200 text-amber-800 rounded-lg p-4 mb-6 text-sm">
+          Only workspace <strong>owners</strong> and <strong>admins</strong> can manage notification
+          targets. You can view the configured targets below.
+        </div>
+      )}
+
+      {/* Add target — owners/admins only */}
+      {canManage && (
+        <div className="bg-white border border-neutral-200 rounded-lg p-5 mb-6">
+          <h2 className="text-sm font-semibold text-neutral-800 mb-3">Add a target</h2>
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className={labelClass}>Name</label>
+              <input className={inputClass} placeholder="Ops Slack #alerts" value={name} onChange={(e) => setName(e.target.value)} />
+            </div>
+            <div>
+              <label className={labelClass}>Type</label>
+              <select className={inputClass} value={type} onChange={(e) => setType(e.target.value as NotificationTargetType)}>
+                {TARGET_TYPES.map((t) => <option key={t.value} value={t.value}>{t.label}</option>)}
+              </select>
+            </div>
+            {type === 'slack' && (
+              <div className="col-span-2">
+                <label className={labelClass}>Incoming webhook URL</label>
+                <input className={inputClass} type="password" autoComplete="new-password" placeholder="https://hooks.slack.com/services/…" value={secret} onChange={(e) => setSecret(e.target.value)} />
+              </div>
+            )}
+            {type === 'email' && (
+              <div className="col-span-2">
+                <label className={labelClass}>Recipient address</label>
+                <input className={inputClass} placeholder="ops@example.com" value={email} onChange={(e) => setEmail(e.target.value)} />
+              </div>
+            )}
+            {type === 'pagerduty' && (
+              <div className="col-span-2">
+                <label className={labelClass}>Events API v2 routing key</label>
+                <input className={inputClass} type="password" autoComplete="new-password" value={secret} onChange={(e) => setSecret(e.target.value)} />
+              </div>
+            )}
+            {type === 'webhook' && (
+              <>
+                <div className="col-span-2">
+                  <label className={labelClass}>Destination URL</label>
+                  <input className={inputClass} placeholder="https://example.com/alerts" value={url} onChange={(e) => setUrl(e.target.value)} />
+                </div>
+                <div className="col-span-2">
+                  <label className={labelClass}>HMAC signing secret (optional)</label>
+                  <input className={inputClass} type="password" autoComplete="new-password" placeholder="adds X-VRSky-Signature" value={secret} onChange={(e) => setSecret(e.target.value)} />
+                </div>
+              </>
+            )}
+            <div>
+              <label className={labelClass}>Minimum severity</label>
+              <select className={inputClass} value={minSeverity} onChange={(e) => setMinSeverity(e.target.value)}>
+                {SEVERITIES.map((s) => <option key={s} value={s}>{s === '' ? 'all' : s}</option>)}
+              </select>
+            </div>
+            <div className="flex items-end pb-2">
+              <label className="flex items-center gap-2 text-sm text-neutral-700">
+                <input type="checkbox" checked={platform} onChange={(e) => setPlatform(e.target.checked)} />
+                Also receive platform alerts
+              </label>
+            </div>
+          </div>
+          <button
+            disabled={saving}
+            onClick={handleCreate}
+            className="mt-3 px-4 py-2 bg-blue-600 hover:bg-blue-700 disabled:opacity-50 text-white text-sm font-semibold rounded-md"
+          >
+            {saving ? 'Saving…' : 'Add target'}
+          </button>
+        </div>
+      )}
+
+      {/* List */}
+      <h2 className="text-sm font-semibold text-neutral-800 mb-2">Configured targets</h2>
+      {loading ? (
+        <p className="text-neutral-500">Loading…</p>
+      ) : targets.length === 0 ? (
+        <p className="text-sm text-neutral-500">No notification targets yet — alerts have nowhere to go.</p>
+      ) : (
+        <div className="space-y-2">
+          {targets.map((t) => (
+            <div key={t.id} className="bg-white border border-neutral-200 rounded-lg p-4 flex items-center justify-between">
+              <div className="min-w-0">
+                <p className="font-medium text-neutral-900 truncate">
+                  {t.name}{' '}
+                  <span className={`inline-block px-1.5 py-0.5 text-xs border rounded ${typeBadgeColor[t.type] || ''}`}>{t.type}</span>
+                  {t.platform && <span className="ml-1 inline-block px-1.5 py-0.5 text-xs border rounded bg-neutral-100 text-neutral-600 border-neutral-200">platform</span>}
+                  {!t.enabled && <span className="ml-1 inline-block px-1.5 py-0.5 text-xs border rounded bg-neutral-100 text-neutral-500 border-neutral-200">disabled</span>}
+                </p>
+                <p className="text-xs text-neutral-500 truncate">
+                  {t.type === 'email' ? t.email : t.type === 'webhook' ? t.url : 'secret configured'}
+                  {t.min_severity ? ` · min severity: ${t.min_severity}` : ''}
+                </p>
+              </div>
+              {canManage && (
+                <div className="ml-4 shrink-0 flex items-center gap-2">
+                  <button
+                    onClick={() => handleTest(t)}
+                    disabled={testing === t.id}
+                    className="px-3 py-1.5 text-xs font-medium text-blue-700 bg-blue-50 border border-blue-200 rounded-md hover:bg-blue-100 disabled:opacity-50"
+                  >
+                    {testing === t.id ? 'Sending…' : 'Test'}
+                  </button>
+                  <button
+                    onClick={() => handleToggle(t)}
+                    className="px-3 py-1.5 text-xs font-medium text-neutral-700 bg-neutral-50 border border-neutral-200 rounded-md hover:bg-neutral-100"
+                  >
+                    {t.enabled ? 'Disable' : 'Enable'}
+                  </button>
+                  <button
+                    onClick={() => handleDelete(t)}
+                    className="px-3 py-1.5 text-xs font-medium text-red-600 bg-red-50 border border-red-200 rounded-md hover:bg-red-100"
+                  >
+                    Delete
+                  </button>
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/ui/src/services/notificationService.ts
+++ b/ui/src/services/notificationService.ts
@@ -1,0 +1,63 @@
+/**
+ * Notification targets service (Phase 3A — #84)
+ *
+ * Talks to the management-api /api/v1/notifications/* endpoints. Uses the
+ * shared apiClient so the X-Tenant-ID header + session cookie are attached by
+ * its interceptors and requests stay same-origin via the Vite proxy.
+ */
+
+import apiClient from './api'
+
+export type NotificationTargetType = 'slack' | 'email' | 'pagerduty' | 'webhook'
+
+export interface NotificationTarget {
+  id: string
+  name: string
+  type: NotificationTargetType
+  email?: string
+  url?: string
+  platform: boolean
+  min_severity?: string
+  enabled: boolean
+  has_secret: boolean
+  created_at: string
+  updated_at: string
+}
+
+export interface NotificationTargetInput {
+  name: string
+  type: NotificationTargetType
+  secret?: string // Slack webhook URL / PagerDuty routing key / webhook HMAC key
+  email?: string
+  url?: string
+  platform?: boolean
+  min_severity?: string
+  enabled?: boolean
+}
+
+export async function listTargets(): Promise<NotificationTarget[]> {
+  const res = await apiClient.get<{ targets: NotificationTarget[] }>('/api/v1/notifications/targets')
+  return res.data.targets ?? []
+}
+
+export async function createTarget(input: NotificationTargetInput): Promise<NotificationTarget> {
+  const res = await apiClient.post<NotificationTarget>('/api/v1/notifications/targets', input)
+  return res.data
+}
+
+export async function updateTarget(id: string, input: NotificationTargetInput): Promise<NotificationTarget> {
+  const res = await apiClient.put<NotificationTarget>(`/api/v1/notifications/targets/${id}`, input)
+  return res.data
+}
+
+export async function deleteTarget(id: string): Promise<void> {
+  await apiClient.delete(`/api/v1/notifications/targets/${id}`)
+}
+
+export async function testTarget(id: string): Promise<{ ok: boolean; error?: string }> {
+  const res = await apiClient.post<{ ok: boolean; error?: string }>(
+    `/api/v1/notifications/targets/${id}/test`,
+    {}
+  )
+  return res.data
+}


### PR DESCRIPTION
Closes #84 — Phase 3A: default Prometheus alert ruleset + pluggable notifiers with per-tenant routing and a `/settings/notifications` UI.

## Architecture
Alertmanager does static routing only, so it has **one** receiver: `POST /api/v1/alerts/webhook` on the management-api (bearer `ALERTS_WEBHOOK_TOKEN`). The mgmt-api then dispatches each alert to the owning tenant's **notification targets** from the DB (`tenant_id` label → that tenant's targets; platform alerts → targets flagged `platform`), honouring per-target `min_severity`. Per-tenant routing lives in the database — no alertmanager.yml regeneration.

## The 6 default rules (`infrastructure/prometheus-rules.yml`)
| Rule | Signal |
|---|---|
| PipelineDown (critical) | tenant publish rate = 0 after activity in the previous hour, 10m |
| DLQGrowing (warning) | `increase(vrsky_dlq_messages_total[10m]) > 0`, 10m |
| JetStreamLagHigh (warning) | `jetstream_consumer_num_pending > 1000`, 10m |
| CertExpirySoon (warning) | cert NotAfter − now < 14d (new mgmt-api gauge from `TLS_CERT_PATHS`) |
| MgmtAPIErrorRate (critical) | 5xx ratio > 5% over 5m (new mgmt-api HTTP metrics) |
| DiskUsageHigh (warning) | node-exporter filesystem > 80%, 10m |

**`prometheus-rules-test.yml` drives all 6 to FIRING via promtool** — the deterministic “staged test” for acceptance box 1.

## What's new
- **`pkg/notify`**: Slack incoming webhook, email (SMTP env identity), PagerDuty Events v2, generic webhook (+`X-VRSky-Signature` HMAC) — all httptest-covered.
- **Migration 000015 `notification_targets`** (secrets encrypted via the existing OAuth pattern, table in the tenant-lint allowlist) + tenant-scoped repo + CRUD/test endpoints (admin-gated writes) + the Alertmanager webhook receiver + dispatch fan-out.
- **mgmt-api instrumentation**: `/metrics`, request counter + duration histogram (ID-normalized path label), TLS cert-expiry gauge.
- **Compose**: alertmanager, prometheus-nats-exporter, node-exporter, **mailpit** (dev SMTP catcher — see mail at http://localhost:8025); Prometheus now scrapes mgmt-api + all SDK workers + exporters.
- **UI**: Settings → Notifications — add Slack/email/PagerDuty/webhook targets, min-severity + platform flag, per-target **Test** button, enable/disable, delete.

## Verification
- Go build/vet/test (notify senders; handler tests: validation, secret never leaked, tenant isolation, secret kept on PUT, webhook auth, dispatch fan-out, platform routing + severity filter), tenant/connector lint, gofmt — all green. UI build + lint clean.
- `promtool test rules` → **all 6 rules SUCCESS**; `promtool check config` + `amtool check-config` pass.
- **Live staged chain**: stack up (prometheus + alertmanager + exporters + mailpit + mgmt-api), migration applied, email target seeded → injected an alert via `amtool` → Alertmanager → mgmt-api webhook → **email delivered to mailpit**: `[FIRING:critical] StagedChainTest — end-to-end alert chain test`. All 6 rules confirmed loaded in live Prometheus; `vrsky_mgmtapi_http_requests_total` live on /metrics; `jetstream_consumer_num_pending` + `node_filesystem_*` confirmed present with exactly the names the rules use.

## Acceptance
- [x] All 6 default rules fire correctly in a staged test (promtool, all 6 FIRING + live chain test)
- [x] Email notifier confirmed working (mailpit, live); Slack sender unit-verified — paste a real Slack webhook into the UI + hit Test to confirm against Slack itself
- [x] Per-tenant notification routing (tenant_id label → tenant targets; platform flag for the rest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)