### PR TITLE
fix(#116): unblock postgres-consumer CDC capture after first batch

### DIFF
--- a/src/pkg/io/postgres_input.go
+++ b/src/pkg/io/postgres_input.go
@@ -807,10 +807,12 @@ func (pi *PostgresInput) flushBatch() {
 		pi.batchStartTime = time.Time{} // Reset
 	}
 
+	published := 0
 	for _, env := range pi.pendingBatch {
-		// Honor shutdown promptly.
+		// Stop publishing promptly on shutdown — but break (not return) so the
+		// cleanup below still runs and we don't leave stale buffers/timers/gauge.
 		if pi.ctx.Err() != nil {
-			return
+			break
 		}
 
 		// NATS is this worker's durable output path — publish unconditionally.
@@ -833,12 +835,17 @@ func (pi *PostgresInput) flushBatch() {
 		case pi.messages <- env:
 		default:
 		}
+		published++
 	}
 
-	// Record batch published metric
-	pi.metrics.BatchesPublishedTotal.Inc()
+	// Only count a batch as published when we emitted all of it (a shutdown
+	// break leaves a partial batch — don't report that as a full publish).
+	if published == len(pi.pendingBatch) {
+		pi.metrics.BatchesPublishedTotal.Inc()
+	}
 
-	// Update pending batch size gauge
+	// Always clear pending state — even when interrupted by shutdown — so we
+	// don't leak buffered envelopes/timers or leave the gauge reading stale.
 	pi.metrics.PendingBatchSizeGauge.Set(0)
 
 	pi.pendingBatch = nil

--- a/src/pkg/io/postgres_input.go
+++ b/src/pkg/io/postgres_input.go
@@ -808,18 +808,30 @@ func (pi *PostgresInput) flushBatch() {
 	}
 
 	for _, env := range pi.pendingBatch {
-		select {
-		case pi.messages <- env:
-			// Published to channel, attempt NATS publish
-			if pi.natsConn != nil {
-				if payload, err := json.Marshal(env); err == nil {
-					if err := pi.natsConn.Publish(pi.natsSubject, payload); err != nil {
-						pi.logger.Error("Failed to publish to NATS", "error", err)
-					}
+		// Honor shutdown promptly.
+		if pi.ctx.Err() != nil {
+			return
+		}
+
+		// NATS is this worker's durable output path — publish unconditionally.
+		if pi.natsConn != nil {
+			if payload, err := json.Marshal(env); err == nil {
+				if err := pi.natsConn.Publish(pi.natsSubject, payload); err != nil {
+					pi.logger.Error("Failed to publish to NATS", "error", err)
 				}
 			}
-		case <-pi.ctx.Done():
-			return
+		}
+
+		// Best-effort hand-off to the in-process Read() channel. This is a
+		// NON-BLOCKING offer on purpose: nothing drains pi.messages in the
+		// standalone consumer (main.go never calls Read), so a blocking send
+		// here wedged the whole poll goroutine the moment the buffer filled —
+		// the bug that froze CDC capture after the first batch (#116). A reader,
+		// when wired, still receives envelopes; without one we skip the channel
+		// (NATS already has the data) rather than deadlock capture.
+		select {
+		case pi.messages <- env:
+		default:
 		}
 	}
 

--- a/src/pkg/io/postgres_input_test.go
+++ b/src/pkg/io/postgres_input_test.go
@@ -901,6 +901,45 @@ func TestFlushBatch_DoesNotBlockWithoutReader(t *testing.T) {
 	}
 }
 
+// TestFlushBatch_ClearsStateOnShutdown verifies that when the context is already
+// cancelled, flushBatch still clears the pending batch and timer instead of
+// returning early and leaking stale state (Copilot review on #117).
+func TestFlushBatch_ClearsStateOnShutdown(t *testing.T) {
+	os.Setenv("POSTGRES_INPUT_PASSWORD", "password")
+	os.Setenv("POSTGRES_INPUT_DATABASE", "source_db")
+	defer os.Unsetenv("POSTGRES_INPUT_PASSWORD")
+	defer os.Unsetenv("POSTGRES_INPUT_DATABASE")
+
+	pi, err := NewPostgresInput(slog.Default(), prometheus.NewRegistry())
+	if err != nil {
+		t.Fatalf("NewPostgresInput() error = %v", err)
+	}
+	pi.ctx, pi.cancel = context.WithCancel(context.Background())
+	pi.natsConn = nil
+	pi.cancel() // already shutting down
+
+	for i := 0; i < 10; i++ {
+		e := envelope.New()
+		e.ID = fmt.Sprintf("e-%d", i)
+		pi.pendingBatch = append(pi.pendingBatch, e)
+	}
+	// A pending batch timer should also be stopped/cleared by flush.
+	pi.batchTimer = time.AfterFunc(time.Hour, func() {})
+
+	pi.mu.Lock()
+	pi.flushBatch()
+	pendingLeft := len(pi.pendingBatch)
+	timer := pi.batchTimer
+	pi.mu.Unlock()
+
+	if pendingLeft != 0 {
+		t.Errorf("pendingBatch not cleared on shutdown flush: %d remaining", pendingLeft)
+	}
+	if timer != nil {
+		t.Error("batchTimer not cleared on shutdown flush")
+	}
+}
+
 // TestCreateEnvelopeFromWAL_EnvelopeID tests envelope ID generation
 func TestCreateEnvelopeFromWAL_EnvelopeID(t *testing.T) {
 	os.Setenv("POSTGRES_INPUT_PASSWORD", "password")

--- a/src/pkg/io/postgres_input_test.go
+++ b/src/pkg/io/postgres_input_test.go
@@ -852,6 +852,55 @@ func TestRead_ConsumerClosed(t *testing.T) {
 	}
 }
 
+// TestFlushBatch_DoesNotBlockWithoutReader is the regression test for #116:
+// flushBatch must not wedge when more than cap(pi.messages) envelopes are
+// flushed and nothing is draining the channel (the standalone consumer never
+// calls Read). Before the fix the channel send blocked once the buffer filled,
+// freezing the poll goroutine after the first batch.
+func TestFlushBatch_DoesNotBlockWithoutReader(t *testing.T) {
+	os.Setenv("POSTGRES_INPUT_PASSWORD", "password")
+	os.Setenv("POSTGRES_INPUT_DATABASE", "source_db")
+	defer os.Unsetenv("POSTGRES_INPUT_PASSWORD")
+	defer os.Unsetenv("POSTGRES_INPUT_DATABASE")
+
+	pi, err := NewPostgresInput(slog.Default(), prometheus.NewRegistry())
+	if err != nil {
+		t.Fatalf("NewPostgresInput() error = %v", err)
+	}
+	pi.ctx, pi.cancel = context.WithCancel(context.Background())
+	pi.natsConn = nil // no NATS in this unit test; exercise only the channel path
+
+	// Far more envelopes than the channel buffer (cap 100), with NO reader.
+	const n = 250
+	for i := 0; i < n; i++ {
+		e := envelope.New()
+		e.ID = fmt.Sprintf("e-%d", i)
+		pi.pendingBatch = append(pi.pendingBatch, e)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		pi.mu.Lock()
+		pi.flushBatch()
+		pi.mu.Unlock()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// good — returned without blocking
+	case <-time.After(5 * time.Second):
+		t.Fatal("flushBatch blocked with no channel reader (regression #116)")
+	}
+
+	pi.mu.Lock()
+	remaining := len(pi.pendingBatch)
+	pi.mu.Unlock()
+	if remaining != 0 {
+		t.Errorf("pendingBatch not cleared after flush: %d remaining", remaining)
+	}
+}
+
 // TestCreateEnvelopeFromWAL_EnvelopeID tests envelope ID generation
 func TestCreateEnvelopeFromWAL_EnvelopeID(t *testing.T) {
 	os.Setenv("POSTGRES_INPUT_PASSWORD", "password")


### PR DESCRIPTION
Closes #116.

## Bug
The env-driven `postgres-consumer` captured only the **first batch** of CDC changes after startup, then stalled permanently — counters frozen at `changes_captured_total=200`, `batches_published_total=1`, no errors, no panic. Found while building the #88 load harness.

## Root cause
`flushBatch()` sent every envelope onto the internal `pi.messages` channel (buffer **100**) and did the actual NATS publish *as a side effect inside that blocking send*:

```go
case pi.messages <- env:          // blocks once the buffer is full
    ...natsConn.Publish...        // the real output path, gated behind the send
```

`pi.messages` is only consumed by `Read()`, and the standalone consumer's `main.go` **never calls `Read()`**. So the first batch fills the 100-slot buffer (NATS-publishes each, `batches_published`→1) and the second batch's first send blocks forever — wedging the synchronous `pollChanges → fetchChanges → addToPendingBatch → flushBatch` goroutine. The freeze point is exactly **200 = 2 × `POSTGRES_INPUT_BATCH_SIZE`(100)**. The capture counter was never wrong; it just never advanced past the deadlock.

## Fix
Publish to NATS (the durable output) unconditionally, and make the in-process channel hand-off **non-blocking** (`select { case pi.messages <- env: default: }`) so a missing `Read()` consumer can never deadlock capture.

## Verification
- **Live (docker-compose):** before — frozen at `200 / 1`; after the rebuild — capture runs continuously: `changes_captured_total=51000`, `batches_published_total=510` and climbing across multiple inserts, no panic, `Detected changes` logs flowing.
- **Unit:** new `TestFlushBatch_DoesNotBlockWithoutReader` flushes 250 envelopes (> buffer) with no reader and asserts `flushBatch` returns + clears the batch (hangs without the fix). `go build` + `go vet` clean; all `pkg/io` postgres_input tests pass.
- Pre-existing unrelated `TestFileProducer_PermissionRespect` fails locally on macOS only (temp dirs under `/var/folders` resolve through `/private` symlinks, tripping the path-traversal guard) — not touched here, passes on Linux CI.

## Scope
Minimal deadlock fix. This is the polling-POC CDC path (not true logical replication — see the `fetchChanges` NOTE); replacing the POC poller with real `pglogrepl` streaming is a separate, larger item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)