### PR TITLE
Phase 3H (#91): centralized logging with Loki

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -156,11 +156,44 @@ services:
       - "127.0.0.1:3001:3000"
     volumes:
       - ./infrastructure/grafana/datasources:/etc/grafana/provisioning/datasources:ro
+      - ./infrastructure/grafana/dashboards-provider.yaml:/etc/grafana/provisioning/dashboards/provider.yaml:ro
+      - ./infrastructure/grafana/dashboards:/var/lib/grafana/dashboards:ro
     networks:
       - vrsky-network
     depends_on:
       - tempo
       - prometheus
+      - loki
+    restart: unless-stopped
+
+  # --- Centralized logging (#91) -----------------------------------------
+  # Services log JSON to stdout; Promtail tails the containers, parses the JSON,
+  # promotes service/tenant_id/pipeline_id/connection_id/level to labels, and
+  # ships to Loki (7-day retention). Queryable in Grafana → Explore → Loki.
+  loki:
+    image: grafana/loki:3.1.0
+    container_name: vrsky-loki
+    command: ["-config.file=/etc/loki/loki-config.yaml"]
+    volumes:
+      - ./infrastructure/loki-config.yaml:/etc/loki/loki-config.yaml:ro
+      - loki-data:/loki
+    ports:
+      - "127.0.0.1:3100:3100"
+    networks:
+      - vrsky-network
+    restart: unless-stopped
+
+  promtail:
+    image: grafana/promtail:3.1.0
+    container_name: vrsky-promtail
+    command: ["-config.file=/etc/promtail/promtail-config.yaml"]
+    volumes:
+      - ./infrastructure/promtail-config.yaml:/etc/promtail/promtail-config.yaml:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    networks:
+      - vrsky-network
+    depends_on:
+      - loki
     restart: unless-stopped
 
   # Alertmanager (#84) — routes every alert to the management-api's webhook
@@ -1091,6 +1124,8 @@ volumes:
   prometheus-data:
     driver: local
   tempo-data:
+    driver: local
+  loki-data:
     driver: local
   nats-jetstream:
     driver: local

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -1,0 +1,67 @@
+# Observability (metrics + traces + logs)
+
+VRSky's three observability signals share one Grafana, and correlate:
+
+| Signal | Backend | Source | Issue |
+|--------|---------|--------|-------|
+| **Metrics** | Prometheus | `/metrics` on each worker + management-api | #84 |
+| **Traces** | Tempo (via otel-collector tail-sampling) | OpenTelemetry spans | #87 |
+| **Logs** | Loki (via Promtail) | structured JSON on stdout | #91 |
+
+A request carries one `trace_id` end to end: logs link to their trace (Loki
+`trace_id` → Tempo), traces link to metrics and logs, so you can pivot between
+"how slow" (metrics), "where" (traces), and "why" (logs) without leaving Grafana.
+
+## Centralized logging (#91)
+
+### Structured logs everywhere
+Every long-running service builds its logger with **`pkg/logging`** (`logging.New(service)`),
+emitting **JSON to stdout**. A context-aware handler stamps each record with the platform's
+standard fields:
+
+| Field | Always? | Source |
+|-------|---------|--------|
+| `service`, `level`, `msg`, `time` | yes | the logger / slog |
+| `trace_id` | when in a trace | active OTel span (#87) |
+| `tenant_id`, `pipeline_id`, `connection_id` | when handling a pipeline message | `logging.ContextWith` (the SDK sets these per message) |
+
+Workers inherit this for free via the SDK runner (`pkg/sdk` `newLogger` →
+`logging.New`, and `subscribeDispatch` enriches the per-message context).
+management-api logs JSON the same way; its HTTP access log is fully structured.
+A unit test (`pkg/logging/logging_test.go`) is the lint gate that fails if a log
+line loses the mandatory fields.
+
+### Shipping & storage
+Promtail (compose) / a Promtail DaemonSet (K3s) tails container/pod stdout,
+parses the JSON, and promotes `service` / `tenant_id` / `pipeline_id` /
+`connection_id` / `level` to **Loki labels** (`trace_id` stays a field — high
+cardinality — and powers the trace link). Loki keeps **7 days**
+(`retention_period: 168h`, compactor deletes older chunks).
+
+> Promtail is in upstream maintenance mode; **Grafana Alloy** is the
+> forward-looking replacement and a drop-in for this pipeline when we migrate.
+
+### Using it
+```sh
+docker compose up -d ... loki promtail grafana   # + the app stack
+open http://localhost:3001          # Grafana → Explore → Loki
+```
+- All logs touching a pipeline, across every service: `{pipeline_id="abc-123"}`
+- Errors for a tenant: `{tenant_id="t1", level="error"}`
+- From a log line, click `trace_id` to jump to the full trace in Tempo.
+
+A starter dashboard (**VRSky — Logs**) ships with panels for logs-by-pipeline,
+errors-per-tenant-per-hour, and recent errors.
+
+### Don't log secrets
+Log **identifiers/references**, never secret values (tokens, passwords, keys,
+decrypted payloads). `pkg/logging` only emits the explicit fields you pass — it
+never reflects whole structs — but the rule is on the caller: e.g. log
+`grant_id`, not the access token; log `email`, not the password. Login and
+secret-access paths follow this.
+
+## Kubernetes
+- Metrics: kube-prometheus stack.
+- Traces: `infrastructure/kubernetes/monitoring/otel-tracing.yaml`.
+- Logs: `infrastructure/kubernetes/monitoring/loki-promtail.yaml`.
+- All three datasources are provisioned in `grafana-values.yaml`.

--- a/infrastructure/grafana/dashboards-provider.yaml
+++ b/infrastructure/grafana/dashboards-provider.yaml
@@ -1,0 +1,12 @@
+# Grafana dashboard provisioning (#91): load JSON dashboards from disk.
+apiVersion: 1
+providers:
+  - name: vrsky
+    orgId: 1
+    folder: VRSky
+    type: file
+    disableDeletion: false
+    allowUiUpdates: true
+    options:
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: false

--- a/infrastructure/grafana/dashboards/vrsky-logs.json
+++ b/infrastructure/grafana/dashboards/vrsky-logs.json
@@ -1,0 +1,56 @@
+{
+  "uid": "vrsky-logs",
+  "title": "VRSky — Logs",
+  "tags": ["vrsky", "logs", "loki"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "time": { "from": "now-1h", "to": "now" },
+  "templating": {
+    "list": [
+      {
+        "name": "pipeline_id",
+        "label": "Pipeline",
+        "type": "query",
+        "datasource": { "type": "loki", "uid": "loki" },
+        "query": { "label": "pipeline_id", "stream": "{service=~\".+\"}", "type": 1 },
+        "refresh": 2,
+        "includeAll": false
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "title": "Logs for pipeline $pipeline_id (all services)",
+      "type": "logs",
+      "datasource": { "type": "loki", "uid": "loki" },
+      "gridPos": { "h": 11, "w": 24, "x": 0, "y": 0 },
+      "options": { "showTime": true, "wrapLogMessage": true, "dedupStrategy": "none" },
+      "targets": [
+        { "refId": "A", "expr": "{pipeline_id=\"$pipeline_id\"}" }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "Errors per tenant per hour",
+      "type": "timeseries",
+      "datasource": { "type": "loki", "uid": "loki" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 11 },
+      "targets": [
+        { "refId": "A", "expr": "sum by (tenant_id) (count_over_time({level=\"error\"}[1h]))" }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "Recent errors (all services)",
+      "type": "logs",
+      "datasource": { "type": "loki", "uid": "loki" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 11 },
+      "options": { "showTime": true, "wrapLogMessage": true },
+      "targets": [
+        { "refId": "A", "expr": "{level=\"error\"}" }
+      ]
+    }
+  ]
+}

--- a/infrastructure/grafana/datasources/datasources.yaml
+++ b/infrastructure/grafana/datasources/datasources.yaml
@@ -1,5 +1,5 @@
-# Grafana datasource provisioning for the local VRSky observability stack
-# (Phase 3D, #87): Tempo for traces + the existing Prometheus for metrics.
+# Grafana datasource provisioning for the local VRSky observability stack:
+# Tempo for traces (#87), Prometheus for metrics (#84), Loki for logs (#91).
 apiVersion: 1
 datasources:
   - name: Tempo
@@ -9,11 +9,27 @@ datasources:
     url: http://tempo:3200
     isDefault: true
     jsonData:
-      # Let trace spans link out to the matching Prometheus metrics.
+      # Let trace spans link out to the matching Prometheus metrics + Loki logs.
       tracesToMetrics:
         datasourceUid: prometheus
+      tracesToLogsV2:
+        datasourceUid: loki
   - name: Prometheus
     type: prometheus
     access: proxy
     uid: prometheus
     url: http://prometheus:9090
+  - name: Loki
+    type: loki
+    access: proxy
+    uid: loki
+    url: http://loki:3100
+    jsonData:
+      # trace_id is a log field (not a label); surface it as a clickable link
+      # into Tempo so logs ↔ traces correlate both ways (#91 + #87).
+      derivedFields:
+        - name: trace_id
+          matcherType: label
+          matcherRegex: trace_id
+          datasourceUid: tempo
+          url: "$${__value.raw}"

--- a/infrastructure/grafana/datasources/datasources.yaml
+++ b/infrastructure/grafana/datasources/datasources.yaml
@@ -28,8 +28,11 @@ datasources:
       # trace_id is a log field (not a label); surface it as a clickable link
       # into Tempo so logs ↔ traces correlate both ways (#91 + #87).
       derivedFields:
+        # trace_id is a JSON field in the log line (not a Loki label — it's
+        # high-cardinality), so match it with a regex against the line and link
+        # the captured value to Tempo.
         - name: trace_id
-          matcherType: label
-          matcherRegex: trace_id
+          matcherType: regex
+          matcherRegex: '"trace_id":"(\w+)"'
           datasourceUid: tempo
           url: "$${__value.raw}"

--- a/infrastructure/kubernetes/monitoring/grafana-values.yaml
+++ b/infrastructure/kubernetes/monitoring/grafana-values.yaml
@@ -56,9 +56,11 @@ datasources:
         access: proxy
         jsonData:
           derivedFields:
+            # trace_id is a JSON log field (not a Loki label), so match it with
+            # a regex against the line and link the captured value to Tempo.
             - name: trace_id
-              matcherType: label
-              matcherRegex: trace_id
+              matcherType: regex
+              matcherRegex: '"trace_id":"(\w+)"'
               datasourceUid: tempo
               url: "$${__value.raw}"
 

--- a/infrastructure/kubernetes/monitoring/grafana-values.yaml
+++ b/infrastructure/kubernetes/monitoring/grafana-values.yaml
@@ -45,6 +45,22 @@ datasources:
         jsonData:
           tracesToMetrics:
             datasourceUid: prometheus
+          tracesToLogsV2:
+            datasourceUid: loki
+      # Centralized logging (#91) — Loki, fed by the Promtail DaemonSet.
+      # See infrastructure/kubernetes/monitoring/loki-promtail.yaml.
+      - name: Loki
+        type: loki
+        uid: loki
+        url: http://loki.vrsky-monitoring.svc.cluster.local:3100
+        access: proxy
+        jsonData:
+          derivedFields:
+            - name: trace_id
+              matcherType: label
+              matcherRegex: trace_id
+              datasourceUid: tempo
+              url: "$${__value.raw}"
 
 # Dashboard providers
 dashboardProviders:

--- a/infrastructure/kubernetes/monitoring/loki-promtail.yaml
+++ b/infrastructure/kubernetes/monitoring/loki-promtail.yaml
@@ -199,6 +199,6 @@ spec:
         - name: config
           configMap: { name: promtail-config }
         - name: run
-          hostPath: { path: /run/promtail }
+          hostPath: { path: /run/promtail, type: DirectoryOrCreate }
         - name: pods
           hostPath: { path: /var/log/pods }

--- a/infrastructure/kubernetes/monitoring/loki-promtail.yaml
+++ b/infrastructure/kubernetes/monitoring/loki-promtail.yaml
@@ -1,0 +1,204 @@
+# Centralized logging (#91): Loki + Promtail DaemonSet for K3s.
+# Services log JSON to stdout; Promtail (one pod per node) tails pod logs,
+# parses the JSON, promotes the standard fields to labels, and ships to Loki
+# (7-day retention). Grafana reads Loki via the datasource in grafana-values.yaml.
+#
+# NOTE: Loki here is single-binary with a PVC for simplicity. For higher scale,
+# use the Loki Helm chart in microservices/SSD mode backed by object storage
+# (the issue's deployments/k8s/loki/ sizing: ~50 GB for 7 days at ~100 msg/s).
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: loki-config
+  namespace: vrsky-monitoring
+data:
+  loki.yaml: |
+    auth_enabled: false
+    server:
+      http_listen_port: 3100
+    common:
+      path_prefix: /loki
+      storage:
+        filesystem:
+          chunks_directory: /loki/chunks
+          rules_directory: /loki/rules
+      replication_factor: 1
+      ring:
+        kvstore:
+          store: inmemory
+    schema_config:
+      configs:
+        - from: 2024-01-01
+          store: tsdb
+          object_store: filesystem
+          schema: v13
+          index:
+            prefix: index_
+            period: 24h
+    limits_config:
+      retention_period: 168h
+      reject_old_samples: true
+      reject_old_samples_max_age: 168h
+    compactor:
+      working_directory: /loki/compactor
+      retention_enabled: true
+      delete_request_store: filesystem
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: loki
+  namespace: vrsky-monitoring
+  labels: { app: loki }
+spec:
+  serviceName: loki
+  replicas: 1
+  selector:
+    matchLabels: { app: loki }
+  template:
+    metadata:
+      labels: { app: loki }
+    spec:
+      containers:
+        - name: loki
+          image: grafana/loki:3.1.0
+          args: ["-config.file=/etc/loki/loki.yaml"]
+          ports:
+            - { containerPort: 3100, name: http }
+          volumeMounts:
+            - { name: config, mountPath: /etc/loki }
+            - { name: data, mountPath: /loki }
+          resources:
+            requests: { cpu: "250m", memory: "512Mi" }
+            limits: { cpu: "1", memory: "2Gi" }
+      volumes:
+        - name: config
+          configMap: { name: loki-config }
+  volumeClaimTemplates:
+    - metadata: { name: data }
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 60Gi # ~50 GB of logs at 7-day retention + headroom
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: loki
+  namespace: vrsky-monitoring
+spec:
+  selector: { app: loki }
+  ports:
+    - { name: http, port: 3100, targetPort: 3100 }
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: promtail
+  namespace: vrsky-monitoring
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: promtail
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "nodes"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: promtail
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: promtail
+subjects:
+  - kind: ServiceAccount
+    name: promtail
+    namespace: vrsky-monitoring
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: promtail-config
+  namespace: vrsky-monitoring
+data:
+  promtail.yaml: |
+    server:
+      http_listen_port: 9080
+    positions:
+      filename: /run/promtail/positions.yaml
+    clients:
+      - url: http://loki.vrsky-monitoring.svc.cluster.local:3100/loki/api/v1/push
+    scrape_configs:
+      - job_name: kubernetes-pods
+        kubernetes_sd_configs:
+          - role: pod
+        relabel_configs:
+          - source_labels: [__meta_kubernetes_pod_node_name]
+            target_label: __host__
+          - source_labels: [__meta_kubernetes_namespace]
+            target_label: namespace
+          - source_labels: [__meta_kubernetes_pod_label_app]
+            target_label: app
+          - source_labels: [__meta_kubernetes_pod_uid, __meta_kubernetes_pod_container_name]
+            target_label: __path__
+            separator: /
+            replacement: /var/log/pods/*$1/*.log
+        pipeline_stages:
+          - cri: {}
+          - json:
+              expressions:
+                service: service
+                level: level
+                tenant_id: tenant_id
+                pipeline_id: pipeline_id
+                connection_id: connection_id
+                trace_id: trace_id
+          # connection IS the pipeline — backfill pipeline_id from connection_id
+          # so {pipeline_id="…"} matches every service touching that pipeline.
+          - template:
+              source: pipeline_id
+              template: '{{ if .pipeline_id }}{{ .pipeline_id }}{{ else }}{{ .connection_id }}{{ end }}'
+          - labels:
+              service:
+              level:
+              tenant_id:
+              pipeline_id:
+              connection_id:
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: promtail
+  namespace: vrsky-monitoring
+  labels: { app: promtail }
+spec:
+  selector:
+    matchLabels: { app: promtail }
+  template:
+    metadata:
+      labels: { app: promtail }
+    spec:
+      serviceAccountName: promtail
+      containers:
+        - name: promtail
+          image: grafana/promtail:3.1.0
+          args: ["-config.file=/etc/promtail/promtail.yaml"]
+          volumeMounts:
+            - { name: config, mountPath: /etc/promtail }
+            - { name: run, mountPath: /run/promtail }
+            - { name: pods, mountPath: /var/log/pods, readOnly: true }
+          resources:
+            requests: { cpu: "50m", memory: "128Mi" }
+            limits: { cpu: "500m", memory: "512Mi" }
+      volumes:
+        - name: config
+          configMap: { name: promtail-config }
+        - name: run
+          hostPath: { path: /run/promtail }
+        - name: pods
+          hostPath: { path: /var/log/pods }

--- a/infrastructure/loki-config.yaml
+++ b/infrastructure/loki-config.yaml
@@ -1,0 +1,49 @@
+# Single-binary Grafana Loki config for the local VRSky stack (Phase 3H, #91).
+# Filesystem storage with a 7-day retention enforced by the compactor. This is
+# the dev/compose setup; production Loki uses object storage (see
+# deployments/k8s/loki/).
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+  grpc_listen_port: 9096
+  log_level: warn
+
+common:
+  instance_addr: 127.0.0.1
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+schema_config:
+  configs:
+    - from: 2024-01-01
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+limits_config:
+  retention_period: 168h # 7 days
+  reject_old_samples: true
+  reject_old_samples_max_age: 168h
+  max_label_names_per_series: 30
+
+compactor:
+  working_directory: /loki/compactor
+  retention_enabled: true # actually delete chunks older than retention_period
+  delete_request_store: filesystem
+
+query_range:
+  results_cache:
+    cache:
+      embedded_cache:
+        enabled: true

--- a/infrastructure/promtail-config.yaml
+++ b/infrastructure/promtail-config.yaml
@@ -1,0 +1,53 @@
+# Promtail config for the local VRSky stack (Phase 3H, #91): discover compose
+# containers via the Docker socket, parse our JSON log lines, and promote the
+# standard fields to Loki labels so {pipeline_id="abc-123"} works across
+# services. (Promtail is in maintenance mode upstream; Grafana Alloy is the
+# longer-term replacement — see docs/OBSERVABILITY.md.)
+server:
+  http_listen_port: 9080
+  log_level: warn
+
+positions:
+  filename: /tmp/positions.yaml
+
+clients:
+  - url: http://loki:3100/loki/api/v1/push
+
+scrape_configs:
+  - job_name: vrsky-containers
+    docker_sd_configs:
+      - host: unix:///var/run/docker.sock
+        refresh_interval: 10s
+    relabel_configs:
+      # Keep only our containers (compose names are vrsky-*).
+      - source_labels: [__meta_docker_container_name]
+        regex: "/?(vrsky-.*)"
+        target_label: container
+        replacement: "$1"
+      - source_labels: [__meta_docker_container_name]
+        regex: "/?vrsky-.*"
+        action: keep
+    pipeline_stages:
+      # App logs are JSON (pkg/logging); pull the standard fields out...
+      - json:
+          expressions:
+            service: service
+            level: level
+            tenant_id: tenant_id
+            pipeline_id: pipeline_id
+            connection_id: connection_id
+            trace_id: trace_id
+      # In VRSky the connection IS the pipeline. Workers log connection_id on
+      # every pipeline line; backfill pipeline_id from it when not set explicitly
+      # so {pipeline_id="…"} matches every service touching that pipeline.
+      - template:
+          source: pipeline_id
+          template: '{{ if .pipeline_id }}{{ .pipeline_id }}{{ else }}{{ .connection_id }}{{ end }}'
+      # Promote the low-cardinality fields to labels. trace_id is high-cardinality
+      # so it stays a field (Grafana derivedFields → Tempo), not a label.
+      - labels:
+          service:
+          level:
+          tenant_id:
+          pipeline_id:
+          connection_id:

--- a/src/cmd/management-api/logging.go
+++ b/src/cmd/management-api/logging.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"log"
+	"log/slog"
 	"net/http"
 	"time"
 )
@@ -29,8 +29,10 @@ func (rw *responseWriter) Write(b []byte) (int, error) {
 	return rw.ResponseWriter.Write(b)
 }
 
-// LoggingMiddleware logs HTTP requests and responses
-func LoggingMiddleware(logger *log.Logger) func(http.Handler) http.Handler {
+// LoggingMiddleware logs HTTP requests as structured records. Using the
+// request context means each access log carries trace_id (from the otelhttp
+// span, #87) automatically; fields are promoted to Loki labels (#91).
+func LoggingMiddleware(logger *slog.Logger) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			start := time.Now()
@@ -41,15 +43,12 @@ func LoggingMiddleware(logger *log.Logger) func(http.Handler) http.Handler {
 			// Call next handler
 			next.ServeHTTP(rw, r)
 
-			// Log request details
-			duration := time.Since(start)
-			logger.Printf(
-				"%s %s %s %d %v",
-				r.Method,
-				r.RequestURI,
-				r.RemoteAddr,
-				rw.statusCode,
-				duration,
+			logger.InfoContext(r.Context(), "http request",
+				"method", r.Method,
+				"path", r.URL.Path,
+				"remote_addr", r.RemoteAddr,
+				"status", rw.statusCode,
+				"duration_ms", time.Since(start).Milliseconds(),
 			)
 		})
 	}

--- a/src/cmd/management-api/main.go
+++ b/src/cmd/management-api/main.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"log/slog"
 	"net/http"
 	"os"
 	"os/signal"
@@ -24,14 +25,20 @@ import (
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 
 	"github.com/ValueRetail/vrsky/pkg/crypto"
+	"github.com/ValueRetail/vrsky/pkg/logging"
 	"github.com/ValueRetail/vrsky/pkg/managementapi"
 	"github.com/ValueRetail/vrsky/pkg/oauth"
 	"github.com/ValueRetail/vrsky/pkg/tracing"
 )
 
 func main() {
-	// Setup logging
-	logger := log.New(os.Stdout, "[MGMT-API] ", log.LstdFlags|log.Lshortfile)
+	// Structured JSON logging (#91): back the existing *log.Logger threading
+	// with a slog JSON handler so every log.Printf/Fatalf call site emits
+	// JSON tagged service=management-api (and trace_id via the context handler
+	// where a ctx is available), shippable to Loki. The HTTP access log is
+	// fully structured separately in LoggingMiddleware.
+	appLog := logging.New("management-api")
+	logger := slog.NewLogLogger(appLog.Handler(), slog.LevelInfo)
 
 	// Load configuration
 	config := LoadConfig()
@@ -344,7 +351,7 @@ func setupServer(config *Config, db *sql.DB, nc *nats.Conn, logger *log.Logger, 
 	handler = TenantIDMiddleware(config.TenantHeader)(handler)
 	handler = CORSMiddleware(config.CORSOrigins, config.TenantHeader)(handler)
 	handler = MetricsMiddleware(handler)
-	handler = LoggingMiddleware(logger)(handler)
+	handler = LoggingMiddleware(logging.New("management-api"))(handler)
 	// Outermost: start/continue the trace for every inbound API request (no-op
 	// when tracing is disabled).
 	handler = otelhttp.NewHandler(handler, "management-api")

--- a/src/cmd/management-api/main.go
+++ b/src/cmd/management-api/main.go
@@ -31,6 +31,14 @@ import (
 	"github.com/ValueRetail/vrsky/pkg/tracing"
 )
 
+// fatal logs a fatal startup error at ERROR level (so {level="error"} queries
+// and panels catch it) and exits. Used instead of log.Fatalf, whose records
+// would otherwise be tagged level=info by the slog-backed adapter.
+func fatal(log *slog.Logger, msg string, err error) {
+	log.Error(msg, "error", err)
+	os.Exit(1)
+}
+
 func main() {
 	// Structured JSON logging (#91): back the existing *log.Logger threading
 	// with a slog JSON handler so every log.Printf/Fatalf call site emits
@@ -43,21 +51,20 @@ func main() {
 	// Load configuration
 	config := LoadConfig()
 	if err := config.Validate(); err != nil {
-		logger.Fatalf("Invalid configuration: %v", err)
+		fatal(appLog, "invalid configuration", err)
 	}
 
 	// Fail fast if the secrets master key is missing or malformed.
 	// All credential encrypt/decrypt operations require ENCRYPTION_KEY.
 	keyHex, err := crypto.Key()
 	if err != nil {
-		logger.Fatalf("ENCRYPTION_KEY is not configured: %v", err)
+		fatal(appLog, "ENCRYPTION_KEY is not configured", err)
 	}
 	// Warn loudly when the dev key is in use — easy to miss in a real
 	// deployment that copied docker-compose.yml as a starting point. The
 	// canonical dev key is the literal repeated nibbles "0123456789abcdef".
 	if keyHex == "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef" {
-		logger.Printf("WARNING: ENCRYPTION_KEY is the documented dev value. " +
-			"Generate a real key for any environment other than local development: openssl rand -hex 32")
+		appLog.Warn("ENCRYPTION_KEY is the documented dev value; generate a real key for any non-local environment (openssl rand -hex 32)")
 	}
 
 	logger.Printf("Starting %s v%s", config.ServiceName, config.Version)
@@ -65,7 +72,7 @@ func main() {
 
 	// Distributed tracing (no-op unless OTEL_EXPORTER_OTLP_ENDPOINT is set).
 	if shutdownTracing, terr := tracing.Init(context.Background(), config.ServiceName); terr != nil {
-		logger.Printf("WARNING: tracing init failed; continuing without tracing: %v", terr)
+		appLog.Warn("tracing init failed; continuing without tracing", "error", terr)
 	} else {
 		defer func() {
 			sctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -77,14 +84,14 @@ func main() {
 	// Initialize database connection
 	db, err := initDatabase(config.DatabaseURL, logger)
 	if err != nil {
-		logger.Fatalf("Failed to initialize database: %v", err)
+		fatal(appLog, "failed to initialize database", err)
 	}
 	defer db.Close()
 
 	// Initialize NATS connection
 	nc, err := initNATS(config.NATSUrl, logger)
 	if err != nil {
-		logger.Fatalf("Failed to initialize NATS: %v", err)
+		fatal(appLog, "failed to initialize NATS", err)
 	}
 	defer nc.Close()
 
@@ -110,7 +117,7 @@ func main() {
 	select {
 	case err := <-serverErrs:
 		if err != nil && err != http.ErrServerClosed {
-			logger.Fatalf("Server error: %v", err)
+			fatal(appLog, "server error", err)
 		}
 	case sig := <-sigChan:
 		logger.Printf("Received signal: %v, shutting down...", sig)
@@ -130,7 +137,7 @@ func main() {
 		defer cancel()
 
 		if err := server.Shutdown(ctx); err != nil {
-			logger.Printf("Error during shutdown: %v", err)
+			appLog.Error("error during shutdown", "error", err)
 		}
 
 		// Stop the tenant provisioner after the HTTP server has drained, so no

--- a/src/pkg/logging/context.go
+++ b/src/pkg/logging/context.go
@@ -1,0 +1,36 @@
+package logging
+
+import "context"
+
+// ctxKey is a private context key type so these values can't collide with keys
+// set by other packages.
+type ctxKey int
+
+const (
+	tenantKey ctxKey = iota
+	pipelineKey
+	connectionKey
+)
+
+// ContextWith returns a context carrying the tenant and connection (pipeline)
+// identity so that any log emitted with it via the *Context slog methods
+// (InfoContext, ErrorContext, …) automatically includes tenant_id, pipeline_id
+// and connection_id. In VRSky the connection IS the pipeline, so pipeline_id and
+// connection_id are the same value. Empty values are not attached.
+func ContextWith(ctx context.Context, tenantID, connectionID string) context.Context {
+	if tenantID != "" {
+		ctx = context.WithValue(ctx, tenantKey, tenantID)
+	}
+	if connectionID != "" {
+		ctx = context.WithValue(ctx, connectionKey, connectionID)
+		ctx = context.WithValue(ctx, pipelineKey, connectionID)
+	}
+	return ctx
+}
+
+func strFromCtx(ctx context.Context, k ctxKey) string {
+	if v, ok := ctx.Value(k).(string); ok {
+		return v
+	}
+	return ""
+}

--- a/src/pkg/logging/logging.go
+++ b/src/pkg/logging/logging.go
@@ -1,0 +1,79 @@
+// Package logging is VRSky's shared structured-logging setup (Phase 3H, #91).
+// Every long-running service builds its logger with New, which emits JSON to
+// stdout (12-factor: the platform's Promtail/Alloy DaemonSet ships stdout to
+// Loki — the app never logs over the network itself) and, via a context-aware
+// handler, stamps every record with the platform's standard fields:
+//
+//	service       — the service name (baked in by New)
+//	level, msg, time — slog JSON defaults
+//	trace_id      — from the active OTel span (#87), when present
+//	tenant_id, pipeline_id, connection_id — from the context (see ContextWith)
+//
+// Loki promotes these to labels so a support engineer can run
+// {pipeline_id="abc-123"} and get every log touching that pipeline across
+// services. NEVER log secret values — log identifiers/references instead.
+package logging
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"strings"
+
+	"go.opentelemetry.io/otel/trace"
+)
+
+// New returns a JSON structured logger for service. Level is driven by LOG_LEVEL
+// (debug|info|warn|error, default info). The logger is context-aware: use the
+// *Context methods (InfoContext, ErrorContext, …) with a ctx from ContextWith
+// (and/or carrying an OTel span) to get tenant_id/pipeline_id/connection_id/
+// trace_id stamped automatically.
+func New(service string) *slog.Logger {
+	base := slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: Level()})
+	return slog.New(&contextHandler{Handler: base}).With("service", service)
+}
+
+// Level parses LOG_LEVEL into an slog.Level (default info).
+func Level() slog.Level {
+	switch strings.ToLower(os.Getenv("LOG_LEVEL")) {
+	case "debug":
+		return slog.LevelDebug
+	case "warn", "warning":
+		return slog.LevelWarn
+	case "error":
+		return slog.LevelError
+	default:
+		return slog.LevelInfo
+	}
+}
+
+// contextHandler enriches every record with the standard context fields before
+// delegating to the wrapped JSON handler.
+type contextHandler struct{ slog.Handler }
+
+func (h *contextHandler) Handle(ctx context.Context, r slog.Record) error {
+	if ctx != nil {
+		if sc := trace.SpanContextFromContext(ctx); sc.HasTraceID() {
+			r.AddAttrs(slog.String("trace_id", sc.TraceID().String()))
+		}
+		if v := strFromCtx(ctx, tenantKey); v != "" {
+			r.AddAttrs(slog.String("tenant_id", v))
+		}
+		if v := strFromCtx(ctx, pipelineKey); v != "" {
+			r.AddAttrs(slog.String("pipeline_id", v))
+		}
+		if v := strFromCtx(ctx, connectionKey); v != "" {
+			r.AddAttrs(slog.String("connection_id", v))
+		}
+	}
+	return h.Handler.Handle(ctx, r)
+}
+
+// WithAttrs / WithGroup re-wrap so the context enrichment survives logger.With.
+func (h *contextHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &contextHandler{Handler: h.Handler.WithAttrs(attrs)}
+}
+
+func (h *contextHandler) WithGroup(name string) slog.Handler {
+	return &contextHandler{Handler: h.Handler.WithGroup(name)}
+}

--- a/src/pkg/logging/logging_test.go
+++ b/src/pkg/logging/logging_test.go
@@ -1,0 +1,88 @@
+package logging
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"go.opentelemetry.io/otel/trace"
+)
+
+// bufLogger builds a logger with the same context-aware handler New uses, but
+// writing JSON to buf so a test can inspect the emitted record.
+func bufLogger(buf *bytes.Buffer) *slog.Logger {
+	h := &contextHandler{Handler: slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug})}
+	return slog.New(h).With("service", "test-svc")
+}
+
+func lastLine(t *testing.T, buf *bytes.Buffer) map[string]any {
+	t.Helper()
+	line := strings.TrimSpace(buf.String())
+	if line == "" {
+		t.Fatal("no log output")
+	}
+	var m map[string]any
+	if err := json.Unmarshal([]byte(line), &m); err != nil {
+		t.Fatalf("log line is not valid JSON: %v (%q)", err, line)
+	}
+	return m
+}
+
+// TestMandatoryFields is the acceptance guard (#91): with a fully-populated
+// context, a log line carries all of the platform's mandatory fields.
+func TestMandatoryFields(t *testing.T) {
+	var buf bytes.Buffer
+	log := bufLogger(&buf)
+
+	traceID, _ := trace.TraceIDFromHex("0123456789abcdef0123456789abcdef")
+	spanID, _ := trace.SpanIDFromHex("0123456789abcdef")
+	sc := trace.NewSpanContext(trace.SpanContextConfig{TraceID: traceID, SpanID: spanID, TraceFlags: trace.FlagsSampled})
+	ctx := trace.ContextWithSpanContext(context.Background(), sc)
+	ctx = ContextWith(ctx, "tenant-1", "conn-9")
+
+	log.InfoContext(ctx, "pipeline event")
+
+	m := lastLine(t, &buf)
+	for _, k := range []string{"service", "level", "msg", "time", "trace_id", "tenant_id", "pipeline_id", "connection_id"} {
+		if _, ok := m[k]; !ok {
+			t.Errorf("missing mandatory field %q in %v", k, m)
+		}
+	}
+	if m["service"] != "test-svc" || m["tenant_id"] != "tenant-1" ||
+		m["pipeline_id"] != "conn-9" || m["connection_id"] != "conn-9" {
+		t.Errorf("unexpected field values: %v", m)
+	}
+	if m["trace_id"] != "0123456789abcdef0123456789abcdef" {
+		t.Errorf("trace_id = %v, want the span's trace id", m["trace_id"])
+	}
+}
+
+// TestBaseFieldsWithoutContext: a context-less / bare log still always has the
+// always-on fields (service/level/msg/time); the tenant/pipeline/trace fields
+// are simply absent when not in context.
+func TestBaseFieldsWithoutContext(t *testing.T) {
+	var buf bytes.Buffer
+	bufLogger(&buf).Info("startup")
+
+	m := lastLine(t, &buf)
+	for _, k := range []string{"service", "level", "msg", "time"} {
+		if _, ok := m[k]; !ok {
+			t.Errorf("missing always-on field %q in %v", k, m)
+		}
+	}
+	for _, k := range []string{"tenant_id", "pipeline_id", "connection_id", "trace_id"} {
+		if _, ok := m[k]; ok {
+			t.Errorf("field %q should be absent without context, got %v", k, m[k])
+		}
+	}
+}
+
+func TestContextWithIgnoresEmpty(t *testing.T) {
+	ctx := ContextWith(context.Background(), "", "")
+	if strFromCtx(ctx, tenantKey) != "" || strFromCtx(ctx, connectionKey) != "" || strFromCtx(ctx, pipelineKey) != "" {
+		t.Error("ContextWith attached empty values")
+	}
+}

--- a/src/pkg/sdk/lifecycle.go
+++ b/src/pkg/sdk/lifecycle.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"os/signal"
 	"strconv"
-	"strings"
 	"syscall"
 	"time"
 
@@ -23,6 +22,7 @@ import (
 
 	"github.com/ValueRetail/vrsky/pkg/envelope"
 	"github.com/ValueRetail/vrsky/pkg/health"
+	"github.com/ValueRetail/vrsky/pkg/logging"
 	"github.com/ValueRetail/vrsky/pkg/messaging"
 	"github.com/ValueRetail/vrsky/pkg/tracing"
 )
@@ -338,6 +338,9 @@ func subscribeDispatch(js nats.JetStreamContext, durable string, logger *slog.Lo
 		// Continue the trace from the producer that published this message; the
 		// per-stage span both links the chain and times this worker's handling.
 		ctx = tracing.ExtractNATS(ctx, msg.Header)
+		// Enrich the context so every log emitted while handling this message
+		// carries tenant_id / pipeline_id / connection_id (+ trace_id) (#91).
+		ctx = logging.ContextWith(ctx, env.TenantID, env.IntegrationID)
 		ctx, span := tracing.Tracer("sdk").Start(ctx, "consume "+durable,
 			trace.WithSpanKind(trace.SpanKindConsumer),
 			trace.WithAttributes(
@@ -383,19 +386,10 @@ func republish(ctx context.Context, pub *messaging.Publisher, env *envelope.Enve
 // --- env / wiring helpers ---
 
 func newLogger(name string) *slog.Logger {
-	var level slog.Level
-	switch strings.ToLower(os.Getenv("LOG_LEVEL")) {
-	case "debug":
-		level = slog.LevelDebug
-	case "warn", "warning":
-		level = slog.LevelWarn
-	case "error":
-		level = slog.LevelError
-	default:
-		level = slog.LevelInfo
-	}
-	return slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: level})).
-		With("service", name)
+	// Structured JSON to stdout with the platform's standard fields (#91); the
+	// context-aware handler stamps trace_id/tenant_id/pipeline_id/connection_id
+	// when the call uses a ctx from logging.ContextWith / carrying a span.
+	return logging.New(name)
 }
 
 func connectNATS(logger *slog.Logger) (*nats.Conn, error) {


### PR DESCRIPTION
Closes #91. The logging pane that completes the observability trifecta — metrics (#84) + traces (#87) + **logs** — all in one Grafana, correlated by `trace_id`.

## Live proof (all acceptance criteria)
- **`{pipeline_id="<conn>"}` returns logs from every service touching that pipeline** — verified: both `webhook-consumer` and `http-producer`. ✅
- **Structured JSON everywhere** with the mandatory fields (`service`, `level`, `msg`, `time`, + `tenant_id`/`pipeline_id`/`connection_id`/`trace_id` when in context); a unit test is the lint gate. ✅
- **7-day retention** enforced in Loki config (`retention_period: 168h` + compactor). ✅ (config-level; not wall-clock testable in a session)
- **No secrets in logs**: a login with a test password left **0 occurrences** of that value in container logs and in Loki. ✅
- Bonus: the management-api access log carries `trace_id` (e.g. `9183…`) → click-through to the Tempo trace.

## How it works (central, low-boilerplate)
- **`pkg/logging`** — `New(service)` → JSON to stdout + a context-aware handler that stamps `trace_id` (from the #87 span) and `tenant_id`/`pipeline_id`/`connection_id` (from `ContextWith`). 
- **`pkg/sdk`** — `newLogger` → `logging.New`, so all ~25 workers log JSON with no per-worker change; `subscribeDispatch` enriches the per-message context.
- **management-api** — keeps its `*log.Logger` threading but backs it with slog JSON (`slog.NewLogLogger`); `LoggingMiddleware` is fully structured with the request context.

## Infra
- **docker-compose**: `loki` (7-day) + `promtail` (Docker SD → parses JSON, promotes `service`/`tenant_id`/`pipeline_id`/`connection_id`/`level` to labels) + Loki Grafana datasource (`trace_id`→Tempo derived field) + a starter **VRSky — Logs** dashboard. The connection *is* the pipeline, so Promtail backfills `pipeline_id` from `connection_id` — that's why `{pipeline_id="…"}` matches services that log `connection_id`.
- **k8s**: `infrastructure/kubernetes/monitoring/loki-promtail.yaml` (Loki StatefulSet + Promtail DaemonSet) + Loki datasource in `grafana-values.yaml`.
- **docs/OBSERVABILITY.md** — the unified metrics+traces+logs picture, label model, retention, and the no-secrets rule.

## Verification
- `go build`/`vet`/`test` + `golangci-lint` v1.64.8 + `gofmt` clean; `pkg/logging` test is the mandatory-field gate; compose config + all YAML/JSON validated.
- Live trace above on the docker-compose stack (Loki/Promtail/Grafana + the webhook→http chain).

## Notes
- Promtail (not Alloy) for shipper simplicity; Alloy noted as the forward path (Promtail is in upstream maintenance mode).
- Pragmatic scope (as agreed): all long-running services structured + full infra; the non-service CLI/tool binaries (vrsky-cli, migrate-secrets, lint-*) keep stdlib log — they aren't part of the aggregated runtime.
- Remaining Phase 3 after this: **#89 (mTLS)** and **#90 (API gateway rate-limiting + the #88 latency ceiling)** — the last two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)