### PR TITLE
fix: bound VRSKY_DATA retention + load-harness cleanup + file-producer disk-fill guard

### DIFF
--- a/src/cmd/file-producer/main.go
+++ b/src/cmd/file-producer/main.go
@@ -184,9 +184,10 @@ func (p *fileProducer) getConnectionConfigs(ctx context.Context, connectionID st
 	err := p.db.QueryRowContext(ctx, `SELECT name, nodes, edges FROM connections WHERE id = $1`, connectionID).Scan(&connName, &nodesJSON, &edgesJSON)
 	if err != nil {
 		if err == sql.ErrNoRows {
-			configs := []*ConnectionConfig{{ID: connectionID, OutputPath: p.defaultOutputDir, PredIsConsumer: true}}
-			p.cacheConfigs(connectionID, configs)
-			return configs, nil
+			// Unknown connection — not ours to write. Cache empty so we don't
+			// re-query (and don't write a file) for every message of it.
+			p.cacheConfigs(connectionID, nil)
+			return nil, nil
 		}
 		return nil, fmt.Errorf("query connection config: %w", err)
 	}
@@ -197,9 +198,10 @@ func (p *fileProducer) getConnectionConfigs(ctx context.Context, connectionID st
 		Config json.RawMessage `json:"config"`
 	}
 	if err := json.Unmarshal(nodesJSON, &nodes); err != nil {
-		configs := []*ConnectionConfig{{ID: connectionID, OutputPath: p.defaultOutputDir, PredIsConsumer: true}}
-		p.cacheConfigs(connectionID, configs)
-		return configs, nil
+		// Unparseable nodes — can't identify a file output; skip rather than
+		// dump every message into the default dir.
+		p.cacheConfigs(connectionID, nil)
+		return nil, nil
 	}
 
 	var edges []struct {
@@ -263,10 +265,10 @@ func (p *fileProducer) getConnectionConfigs(ctx context.Context, connectionID st
 		})
 	}
 
-	if len(configs) == 0 {
-		configs = []*ConnectionConfig{{ID: connectionID, OutputPath: p.defaultOutputDir, PredIsConsumer: true}}
-	}
-
+	// No file-producer node on this connection → nothing for us to write. (This
+	// is the common case for non-file pipelines, e.g. webhook→http; the
+	// file-producer subscribes to ALL pipeline data, so it must no-op here
+	// rather than write a file per message to the default dir.)
 	p.cacheConfigs(connectionID, configs)
 	return configs, nil
 }

--- a/src/cmd/file-producer/producer_test.go
+++ b/src/cmd/file-producer/producer_test.go
@@ -50,6 +50,11 @@ func TestGetConnectionConfigs_NoFileNode(t *testing.T) {
 	if len(configs) != 0 {
 		t.Errorf("expected 0 file configs for a non-file pipeline, got %d (%+v)", len(configs), configs)
 	}
+	// Guard the guard: ensure it actually queried the DB (didn't short-circuit
+	// or serve stale cache) — otherwise this test could pass for the wrong reason.
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet sqlmock expectations: %v", err)
+	}
 }
 
 // TestFileProducer_RoundTrip proves the SDK refactor end-to-end with zero

--- a/src/cmd/file-producer/producer_test.go
+++ b/src/cmd/file-producer/producer_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -12,6 +13,44 @@ import (
 	"github.com/ValueRetail/vrsky/pkg/envelope"
 	"github.com/ValueRetail/vrsky/pkg/sdk/harness"
 )
+
+// TestGetConnectionConfigs_NoFileNode is the regression guard for the disk-fill
+// bug: the file-producer subscribes to ALL pipeline data, so for a connection
+// with no file-output node (e.g. webhook→http) it must return zero configs and
+// write nothing — not fall back to dumping every message into the default dir.
+func TestGetConnectionConfigs_NoFileNode(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	const connID = "conn-webhook-http"
+	// A webhook→http pipeline: a consumer + an http producer, no file node.
+	nodes := `[{"id":"wh","type":"consumer","config":{"type":"http"}},` +
+		`{"id":"hp","type":"producer","config":{"type":"http","http":{"url":"http://x/post"}}}]`
+	mock.MatchExpectationsInOrder(false)
+	mock.ExpectQuery("FROM connections WHERE id").
+		WithArgs(connID).
+		WillReturnRows(sqlmock.NewRows([]string{"name", "nodes", "edges"}).
+			AddRow("Webhook HTTP", []byte(nodes), []byte(`[]`)))
+
+	p := &fileProducer{
+		db:               db,
+		defaultOutputDir: "/data/output",
+		configCache:      make(map[string][]*ConnectionConfig),
+		configCacheTime:  make(map[string]time.Time),
+		configCacheTTL:   time.Minute,
+	}
+
+	configs, err := p.getConnectionConfigs(context.Background(), connID)
+	if err != nil {
+		t.Fatalf("getConnectionConfigs: %v", err)
+	}
+	if len(configs) != 0 {
+		t.Errorf("expected 0 file configs for a non-file pipeline, got %d (%+v)", len(configs), configs)
+	}
+}
 
 // TestFileProducer_RoundTrip proves the SDK refactor end-to-end with zero
 // Docker: an envelope published into embedded JetStream flows through the SDK

--- a/src/pkg/messaging/messaging.go
+++ b/src/pkg/messaging/messaging.go
@@ -43,6 +43,17 @@ const (
 	// is the backstop in case a consumer is offline for a long time.
 	MainRetention = 72 * time.Hour
 
+	// MainMaxBytes / MainMaxMsgs bound the *size* of the main stream. The data
+	// stream is an ephemeral transport (docs/NATS_ARCHITECTURE.md) — messages
+	// should be consumed in seconds. Age alone (72h) doesn't stop a runaway
+	// producer or a stuck/absent consumer from piling up gigabytes within the
+	// window and OOM-killing NATS. With DiscardOld these caps shed the oldest
+	// (already-stale) messages instead, keeping the broker alive — the right
+	// trade-off for a transit stream. ~512 MiB sits well under the ~830 MiB
+	// that OOM-killed the dev broker.
+	MainMaxBytes = 512 * 1024 * 1024 // 512 MiB
+	MainMaxMsgs  = 1_000_000
+
 	// MainStreamName is the singleton data-flow stream.
 	MainStreamName = "VRSKY_DATA"
 
@@ -81,11 +92,16 @@ func DLQSubject(tenantID, connectionID string) string {
 // consumer maintains its own ack state.
 func EnsureStreams(js nats.JetStreamContext) error {
 	if err := ensure(js, &nats.StreamConfig{
-		Name:       MainStreamName,
-		Subjects:   []string{MainSubjectAll},
-		Retention:  nats.LimitsPolicy,
-		Storage:    nats.FileStorage,
-		MaxAge:     MainRetention,
+		Name:      MainStreamName,
+		Subjects:  []string{MainSubjectAll},
+		Retention: nats.LimitsPolicy,
+		Storage:   nats.FileStorage,
+		MaxAge:    MainRetention,
+		// Size caps + DiscardOld: shed the oldest stale messages rather than
+		// grow unbounded and OOM NATS (see MainMaxBytes).
+		MaxBytes:   MainMaxBytes,
+		MaxMsgs:    MainMaxMsgs,
+		Discard:    nats.DiscardOld,
 		Duplicates: 5 * time.Minute,
 	}); err != nil {
 		return fmt.Errorf("ensure %s: %w", MainStreamName, err)

--- a/src/pkg/messaging/messaging_test.go
+++ b/src/pkg/messaging/messaging_test.go
@@ -71,6 +71,22 @@ func TestEnsureStreams(t *testing.T) {
 		}
 	}
 
+	// The data stream must be size-bounded with DiscardOld so a runaway producer
+	// or stuck consumer sheds stale messages instead of OOM-killing NATS.
+	main, err := js.StreamInfo(MainStreamName)
+	if err != nil {
+		t.Fatalf("StreamInfo %s: %v", MainStreamName, err)
+	}
+	if main.Config.MaxBytes != MainMaxBytes {
+		t.Errorf("MaxBytes = %d, want %d", main.Config.MaxBytes, MainMaxBytes)
+	}
+	if main.Config.MaxMsgs != MainMaxMsgs {
+		t.Errorf("MaxMsgs = %d, want %d", main.Config.MaxMsgs, MainMaxMsgs)
+	}
+	if main.Config.Discard != nats.DiscardOld {
+		t.Errorf("Discard = %v, want DiscardOld", main.Config.Discard)
+	}
+
 	// Idempotent.
 	if err := EnsureStreams(js); err != nil {
 		t.Fatalf("second EnsureStreams: %v", err)

--- a/tests/load/lib.sh
+++ b/tests/load/lib.sh
@@ -18,6 +18,10 @@ DOCKER_NETWORK="${DOCKER_NETWORK:-vrsky-network}"
 K6_IMAGE="${K6_IMAGE:-grafana/k6:latest}"
 # Container-internal URL k6 uses to reach the webhook ingress.
 WEBHOOK_INGRESS_INTERNAL="${WEBHOOK_INGRESS_INTERNAL:-http://webhook-consumer:9100}"
+# NATS (for the post-run stream purge — see purge_data_stream).
+NATS_INTERNAL="${NATS_INTERNAL:-nats://nats:4222}"
+NATS_BOX_IMAGE="${NATS_BOX_IMAGE:-natsio/nats-box:latest}"
+DATA_STREAM="${DATA_STREAM:-VRSKY_DATA}"
 
 # --- load-test account ---
 # Auto-provisioned on first run. The minimal load stack has no mail server, so
@@ -123,4 +127,18 @@ stop_pipeline() {
 result_row() {
   printf '%s  %-16s p99=%-9s sustained=%-11s delivered=%-8s errors=%s%s\n' \
     "$GRN" "$1" "${2}ms" "${3}/s" "$4" "$5" "$NC"
+}
+
+# purge_data_stream clears the NATS data stream so a load run doesn't leave a
+# durable backlog behind. A high-rate run can publish hundreds of thousands of
+# messages; left un-purged they accumulate (across runs) and have OOM-killed the
+# NATS broker. Best-effort + non-fatal: skips quietly if NATS isn't reachable so
+# it never changes the harness's exit code (which CI gates on).
+purge_data_stream() {
+  if docker run --rm --network "$DOCKER_NETWORK" "$NATS_BOX_IMAGE" \
+       nats --server "$NATS_INTERNAL" stream purge "$DATA_STREAM" -f >/dev/null 2>&1; then
+    log "purged $DATA_STREAM (load-test teardown)"
+  else
+    warn "could not purge $DATA_STREAM (NATS reachable? purge manually if a backlog remains)"
+  fi
 }

--- a/tests/load/lib.sh
+++ b/tests/load/lib.sh
@@ -132,8 +132,8 @@ result_row() {
 # purge_data_stream clears the NATS data stream so a load run doesn't leave a
 # durable backlog behind. A high-rate run can publish hundreds of thousands of
 # messages; left un-purged they accumulate (across runs) and have OOM-killed the
-# NATS broker. Best-effort + non-fatal: skips quietly if NATS isn't reachable so
-# it never changes the harness's exit code (which CI gates on).
+# NATS broker. Best-effort + non-fatal: logs on success, warns (never errors) on
+# failure, so it can't change the harness's exit code (which CI gates on).
 purge_data_stream() {
   if docker run --rm --network "$DOCKER_NETWORK" "$NATS_BOX_IMAGE" \
        nats --server "$NATS_INTERNAL" stream purge "$DATA_STREAM" -f >/dev/null 2>&1; then

--- a/tests/load/run.sh
+++ b/tests/load/run.sh
@@ -123,6 +123,11 @@ run_db_cdc()          { "$HERE/generators/cdc_insert.sh"   --rate "$RATE" --dura
 run_file_to_db()      { "$HERE/generators/file_drop.sh"    --rate "$RATE" --duration "$DURATION"; }
 run_tenant_to_tenant(){ "$HERE/generators/tenant_publish.sh" --rate "$RATE" --duration "$DURATION"; }
 
+# Always purge the data stream on the way out so a run never leaves a durable
+# backlog behind (which has OOM-killed NATS). Set after arg parsing so --help
+# doesn't trigger it; best-effort, preserves the scenario's exit code.
+trap purge_data_stream EXIT
+
 case "$SCENARIO" in
   webhook-to-http)  run_webhook_to_http;;
   db-cdc)           run_db_cdc;;


### PR DESCRIPTION
Follow-up to a real incident: the #88 load tests left **~1.2M messages (828 MiB)** in the `VRSKY_DATA` JetStream stream, which **OOM-killed the NATS broker** (exit 137) on the local stack and took the whole pipeline down until the stream was manually purged. Three independent fixes so it can't recur.

## 1. Bound the data stream (the OOM guard)
`pkg/messaging` `EnsureStreams`: `VRSKY_DATA` now has **MaxBytes 512 MiB + MaxMsgs 1,000,000 + Discard=Old** (it only had `MaxAge=72h`, which doesn't stop gigabytes piling up *within* the window). The data stream is an ephemeral transport (docs/NATS_ARCHITECTURE.md), so shedding the oldest already-stale messages beats OOM-ing the broker. `ensure()` already calls `UpdateStream`, so the caps reconcile onto the **existing** stream on next worker boot — **verified live**: the pre-existing stream now reports `Discard Old / 512 MiB / 1,000,000`.

## 2. Load harness cleans up after itself
`tests/load/`: a `purge_data_stream()` helper + a `trap … EXIT` in `run.sh` so every run clears `VRSKY_DATA` on the way out (best-effort, preserves the scenario's exit code that CI gates on). No more durable backlog left behind.

## 3. file-producer no longer disk-fills on unrelated pipelines
The file-producer subscribes to **all** pipeline data. For a connection with **no file-output node** (e.g. webhook→http), three fallbacks (unknown connection / unparseable nodes / no file node) used to dump *every* envelope into the default dir — during the incident it wrote tens of thousands of junk files for a webhook→http connection. Now those cases return **zero configs and write nothing**.

## Tests
- `TestEnsureStreams` asserts the caps + `DiscardOld`.
- `TestGetConnectionConfigs_NoFileNode` asserts a webhook→http connection yields no file configs (writes nothing).
- `go build`/`vet`/`test` + `golangci-lint` v1.64.8 + gofmt + `bash -n` (harness) all clean; stream-cap reconciliation confirmed live.

Discovered while debugging why a met.no API→file pipeline produced no output on the local stack — root cause was the NATS OOM from the leftover load-test backlog, not the pipeline config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)