### PR TITLE
feat(#89): mTLS for high-security HTTP connectors (Phase 3F)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -552,6 +552,14 @@ services:
       # Aux HTTP port the SDK serves /webhook, /sample-data + /tunnel/* on (UI
       # connects here; the cloudflared tunnel forwards to it). Health is on 8080.
       WORKER_HTTP_PORT: "9100"
+      # mTLS listener for high-security connections (#89). A dedicated TLS port
+      # that demands a client certificate; per-connection client-CA verification
+      # happens in the handler. Connections with a tls.client_ca block are
+      # reachable here over https. Server identity defaults to a generated
+      # self-signed cert (dev); set WEBHOOK_TLS_CERT_FILE/_KEY_FILE for a real one.
+      WORKER_MTLS_PORT: "9101"
+      # WEBHOOK_TLS_CERT_FILE: "/certs/server.crt"
+      # WEBHOOK_TLS_KEY_FILE: "/certs/server.key"
       # Must match management-api's ENCRYPTION_KEY — the resolver decrypts
       # secrets (e.g. HMAC signing key from #67) at connection-start time.
       ENCRYPTION_KEY: "${ENCRYPTION_KEY:-0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef}"
@@ -560,6 +568,7 @@ services:
       OTEL_SERVICE_NAME: "webhook-consumer"
     ports:
       - "127.0.0.1:9100:9100"
+      - "127.0.0.1:9101:9101"
     depends_on:
       nats:
         condition: service_healthy

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -336,11 +336,12 @@ self-signed cert (dev only) — mTLS security here comes from verifying the
 
 - **Consumer:** when `WORKER_MTLS_PORT` is set (9101 in compose) the worker runs
   a dedicated TLS listener that demands *a* client cert at the handshake
-  (`RequireAnyClientCert`). For a connection with `tls.client_ca`, the handler
-  then verifies the presented cert chains to that per-connection CA and rejects
-  with **401** if it is missing or untrusted. The same check also runs on the
-  plain aux port (9100), where `r.TLS == nil` counts as "no cert" — so an mTLS
-  connection cannot be reached unauthenticated over plain HTTP.
+  (`RequireAnyClientCert`) — a caller that presents none is refused at the TLS
+  layer (no HTTP response). For a connection with `tls.client_ca`, the handler
+  then verifies the presented cert chains to that per-connection CA (client-auth
+  EKU only) and rejects with **401** if it does not. The same check also runs on
+  the plain aux port (9100), where `r.TLS == nil` counts as "no cert" → **401** —
+  so an mTLS connection cannot be reached unauthenticated over plain HTTP.
 - **Producer:** when a node has a `tls` block with a resolved `cert`/`key`, the
   worker builds a dedicated `http.Client` that presents that client cert (and
   trusts `client_ca` as the server root if supplied), reused for every send.
@@ -361,8 +362,11 @@ openssl x509 -req -in client.csr -CA ca.crt -CAkey ca.key -CAcreateserial -days 
 # 2. Store ca.crt as a tenant secret and put its id in the consumer node's
 #    tls.client_ca_secret_id, then start a webhook→http connection.
 
-# 3. No client cert → rejected; valid client cert → 202.
-curl -k https://localhost:9101/webhook/<conn-id> -d '{"x":1}'                       # TLS/401
+# 3. No client cert → TLS handshake refused (RequireAnyClientCert, no HTTP
+#    response — curl exits 35/56); valid client cert → 202.
+curl -k https://localhost:9101/webhook/<conn-id> -d '{"x":1}'                       # handshake refused
 curl -k --cert client.crt --key client.key https://localhost:9101/webhook/<conn-id> -d '{"x":1}'  # 202
-# A cert signed by a different CA → 401.
+# A cert signed by a different CA completes the handshake but fails app-layer
+# verification → 401. (macOS system curl uses LibreSSL, which mishandles EC
+# client keys with "bad decrypt"; use an OpenSSL-based curl to test.)
 ```

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -297,3 +297,72 @@ done            # expect a run of 200s then 429s
 # A 429 response carries Retry-After and Server: traefik. A different
 # X-Tenant-ID (tenant-B) is unaffected — independent buckets.
 ```
+
+## Mutual TLS for HTTP connectors (Phase 3F, #89)
+
+High-security integrations (banking, public sector) require mutual TLS: the
+inbound **webhook consumer** must reject callers that do not present a valid
+client certificate, and the outbound **http producer** must present a client
+certificate to mTLS-required endpoints. mTLS is opt-in per connection, keyed off
+cert material stored as tenant secrets — no new secret plumbing (it reuses the
+`*_secret_id` resolution from #66).
+
+### Config surface
+
+Add a `tls` block to the connector node's `config` (alongside `http`). Each
+field is a reference to a secret holding PEM text; the worker resolves it to
+plaintext at connection-start / send time (the resolver replaces a `*_secret_id`
+key with the de-suffixed key, e.g. `cert_secret_id` → `cert`):
+
+| Field                 | Consumer (webhook)                          | Producer (http)                                   |
+|-----------------------|---------------------------------------------|---------------------------------------------------|
+| `client_ca_secret_id` | **required** — CA that signs accepted client certs | optional — server CA to trust (empty → system roots) |
+| `cert_secret_id`      | n/a (listener cert comes from env)          | **required** — client cert presented to the endpoint |
+| `key_secret_id`       | n/a                                         | **required** — private key for `cert`             |
+
+Example consumer node config (after the CA secret is stored):
+
+```json
+{ "type": "http", "tls": { "client_ca_secret_id": "<secret-uuid>" } }
+```
+
+The `tls` block is settable today via the connections API; UI cert pickers are a
+follow-up. The webhook consumer's own server identity comes from
+`WEBHOOK_TLS_CERT_FILE` / `WEBHOOK_TLS_KEY_FILE`; if unset it generates a
+self-signed cert (dev only) — mTLS security here comes from verifying the
+**client** cert, not from the client trusting the server cert.
+
+### Behaviour
+
+- **Consumer:** when `WORKER_MTLS_PORT` is set (9101 in compose) the worker runs
+  a dedicated TLS listener that demands *a* client cert at the handshake
+  (`RequireAnyClientCert`). For a connection with `tls.client_ca`, the handler
+  then verifies the presented cert chains to that per-connection CA and rejects
+  with **401** if it is missing or untrusted. The same check also runs on the
+  plain aux port (9100), where `r.TLS == nil` counts as "no cert" — so an mTLS
+  connection cannot be reached unauthenticated over plain HTTP.
+- **Producer:** when a node has a `tls` block with a resolved `cert`/`key`, the
+  worker builds a dedicated `http.Client` that presents that client cert (and
+  trusts `client_ca` as the server root if supplied), reused for every send.
+- A connection with no `tls` block behaves exactly as before.
+- Rejections increment `webhook_client_cert_failures_total{connection_id,reason}`
+  (`reason` = `missing_cert` | `untrusted_cert`).
+
+### Verify (compose)
+
+```bash
+# 1. Throwaway CA + server + client certs.
+openssl ecparam -genkey -name prime256v1 -out ca.key
+openssl req -x509 -new -key ca.key -sha256 -days 1 -subj "/CN=test-ca" -out ca.crt
+openssl ecparam -genkey -name prime256v1 -out client.key
+openssl req -new -key client.key -subj "/CN=client" -out client.csr
+openssl x509 -req -in client.csr -CA ca.crt -CAkey ca.key -CAcreateserial -days 1 -out client.crt
+
+# 2. Store ca.crt as a tenant secret and put its id in the consumer node's
+#    tls.client_ca_secret_id, then start a webhook→http connection.
+
+# 3. No client cert → rejected; valid client cert → 202.
+curl -k https://localhost:9101/webhook/<conn-id> -d '{"x":1}'                       # TLS/401
+curl -k --cert client.crt --key client.key https://localhost:9101/webhook/<conn-id> -d '{"x":1}'  # 202
+# A cert signed by a different CA → 401.
+```

--- a/src/cmd/http-producer/main.go
+++ b/src/cmd/http-producer/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/ValueRetail/vrsky/pkg/envelope"
 	"github.com/ValueRetail/vrsky/pkg/oauthtoken"
 	"github.com/ValueRetail/vrsky/pkg/sdk"
+	"github.com/ValueRetail/vrsky/pkg/tlsconfig"
 )
 
 // httpProducer delivers pipeline envelopes to external HTTP endpoints. It is a
@@ -71,6 +72,11 @@ type HTTPConfig struct {
 	OAuthGrantID   string            `json:"oauth_grant_id"` // grant id when auth_type=oauth
 	PredecessorID  string
 	PredIsConsumer bool
+
+	// mTLS (#89): when the node carries a "tls" block with a resolved client
+	// cert/key, client is a pre-built *http.Client presenting that cert to the
+	// endpoint. nil means use the default (non-mTLS) client.
+	client *http.Client
 }
 
 func main() {
@@ -196,10 +202,14 @@ func (p *httpProducer) sendHTTPRequest(ctx context.Context, connectionID string,
 
 	// otelhttp transport makes the outbound call a child span of the pipeline
 	// trace and injects traceparent into the external request. No-op when
-	// tracing is disabled.
-	client := &http.Client{
-		Timeout:   30 * time.Second,
-		Transport: otelhttp.NewTransport(http.DefaultTransport),
+	// tracing is disabled. When the node configured mTLS, httpCfg.client is a
+	// pre-built client that presents the client cert; otherwise use the default.
+	client := httpCfg.client
+	if client == nil {
+		client = &http.Client{
+			Timeout:   30 * time.Second,
+			Transport: otelhttp.NewTransport(http.DefaultTransport),
+		}
 	}
 	// buildAndSend creates a fresh request (re-readable body) per attempt and,
 	// for auth_type=oauth, attaches a Bearer token. force=true refreshes it.
@@ -341,6 +351,10 @@ func (p *httpProducer) getHTTPConfigs(ctx context.Context, connectionID, tenantI
 				AuthType     string            `json:"auth_type"`
 				OAuthGrantID string            `json:"oauth_grant_id"`
 			} `json:"http"`
+			// mTLS material (#89). In the stored config these are *_secret_id
+			// refs; crypto.ResolveSecretsInJSON has already replaced them with
+			// plaintext PEM by the time we parse here.
+			TLS tlsconfig.NodeConfig `json:"tls"`
 		}
 		if err := json.Unmarshal(node.Config, &nodeConfig); err != nil {
 			continue
@@ -364,7 +378,7 @@ func (p *httpProducer) getHTTPConfigs(ctx context.Context, connectionID, tenantI
 			}
 		}
 
-		configs = append(configs, &HTTPConfig{
+		cfg := &HTTPConfig{
 			URL:            nodeConfig.HTTP.URL,
 			Method:         nodeConfig.HTTP.Method,
 			Headers:        nodeConfig.HTTP.Headers,
@@ -372,7 +386,29 @@ func (p *httpProducer) getHTTPConfigs(ctx context.Context, connectionID, tenantI
 			OAuthGrantID:   nodeConfig.HTTP.OAuthGrantID,
 			PredecessorID:  predID,
 			PredIsConsumer: predIsConsumer,
-		})
+		}
+
+		// mTLS: when the node presents a client cert, pre-build a dedicated
+		// http.Client that presents it (and trusts the configured server CA, if
+		// any). Built once here and reused for every send to this node.
+		if nodeConfig.TLS.Enabled() {
+			tlsCfg, err := tlsconfig.ClientConfig(
+				[]byte(nodeConfig.TLS.Cert),
+				[]byte(nodeConfig.TLS.Key),
+				[]byte(nodeConfig.TLS.ClientCA),
+			)
+			if err != nil {
+				return nil, fmt.Errorf("node %s: build mTLS client: %w", node.ID, err)
+			}
+			cfg.client = &http.Client{
+				Timeout: 30 * time.Second,
+				Transport: otelhttp.NewTransport(&http.Transport{
+					TLSClientConfig: tlsCfg,
+				}),
+			}
+		}
+
+		configs = append(configs, cfg)
 	}
 
 	if len(configs) == 0 {

--- a/src/cmd/http-producer/main.go
+++ b/src/cmd/http-producer/main.go
@@ -400,11 +400,13 @@ func (p *httpProducer) getHTTPConfigs(ctx context.Context, connectionID, tenantI
 			if err != nil {
 				return nil, fmt.Errorf("node %s: build mTLS client: %w", node.ID, err)
 			}
+			// Clone DefaultTransport so proxy support, dial/idle timeouts and
+			// HTTP/2 settings are preserved; only swap in the mTLS config.
+			transport := http.DefaultTransport.(*http.Transport).Clone()
+			transport.TLSClientConfig = tlsCfg
 			cfg.client = &http.Client{
-				Timeout: 30 * time.Second,
-				Transport: otelhttp.NewTransport(&http.Transport{
-					TLSClientConfig: tlsCfg,
-				}),
+				Timeout:   30 * time.Second,
+				Transport: otelhttp.NewTransport(transport),
 			}
 		}
 

--- a/src/cmd/webhook-consumer/metrics.go
+++ b/src/cmd/webhook-consumer/metrics.go
@@ -26,6 +26,26 @@ func incSignatureFailure(connectionID, reason string) {
 	webhookSignatureFailures.WithLabelValues(connectionID, reason).Inc()
 }
 
+// webhookClientCertFailures counts every webhook request rejected because the
+// caller's mTLS client certificate was missing or did not chain to the
+// connection's configured client CA (#89 / Phase 3F).
+//
+// Labels:
+//   - connection_id: routes failures back to the specific pipeline
+//   - reason:        "missing_cert" (none presented / non-TLS) or
+//     "untrusted_cert" (presented but not signed by the configured CA)
+var webhookClientCertFailures = promauto.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "webhook_client_cert_failures_total",
+		Help: "Number of webhook requests rejected for failing mTLS client-certificate verification.",
+	},
+	[]string{"connection_id", "reason"},
+)
+
+func incClientCertFailure(connectionID, reason string) {
+	webhookClientCertFailures.WithLabelValues(connectionID, reason).Inc()
+}
+
 // classifySigErr buckets the errors from verifyHMAC into a small set of
 // Prometheus label values. Anything we cannot categorise lands in
 // "mismatch" so genuine attacks are not hidden by an unknown-reason label.

--- a/src/cmd/webhook-consumer/mtls_test.go
+++ b/src/cmd/webhook-consumer/mtls_test.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/json"
+	"encoding/pem"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+
+	"github.com/ValueRetail/vrsky/pkg/sdk/harness"
+)
+
+// mtlsCA generates a throwaway CA and returns its PEM plus the signing material.
+func mtlsCA(t *testing.T) (caPEM []byte, ca *x509.Certificate, caKey *ecdsa.PrivateKey) {
+	t.Helper()
+	caKey, _ = ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &caKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("create CA: %v", err)
+	}
+	ca, _ = x509.ParseCertificate(der)
+	caPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	return caPEM, ca, caKey
+}
+
+// mtlsClientCert returns a parsed client leaf certificate signed by ca.
+func mtlsClientCert(t *testing.T, ca *x509.Certificate, caKey *ecdsa.PrivateKey) *x509.Certificate {
+	t.Helper()
+	key, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(time.Now().UnixNano()),
+		Subject:      pkix.Name{CommonName: "client"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, ca, &key.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("create client leaf: %v", err)
+	}
+	leaf, _ := x509.ParseCertificate(der)
+	return leaf
+}
+
+// TestWebhookConsumer_MTLS verifies the #89 client-cert path: a connection with
+// a tls.client_ca block rejects requests that present no client cert (401) or a
+// cert signed by a different CA (401), and accepts one signed by the configured
+// CA (202, published). Plain-HTTP requests (r.TLS == nil) are treated as
+// "no cert presented", which closes the SDK plain-port bypass.
+func TestWebhookConsumer_MTLS(t *testing.T) {
+	const (
+		connID = "conn-wh-3"
+		tenant = "tenant-x"
+	)
+
+	caPEM, ca, caKey := mtlsCA(t)
+	validCert := mtlsClientCert(t, ca, caKey)
+	_, otherCA, otherKey := mtlsCA(t)
+	foreignCert := mtlsClientCert(t, otherCA, otherKey)
+
+	mgmtDB, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer mgmtDB.Close()
+	mock.MatchExpectationsInOrder(false)
+
+	nodesObj := []map[string]any{{
+		"id":   "c1",
+		"type": "consumer",
+		"config": map[string]any{
+			"type": "http",
+			"tls":  map[string]any{"client_ca": string(caPEM)},
+		},
+	}}
+	nodes, _ := json.Marshal(nodesObj)
+	mock.ExpectQuery("SELECT id, tenant_id, name, nodes, edges FROM connections").
+		WithArgs(connID, tenant).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "tenant_id", "name", "nodes", "edges"}).
+			AddRow(connID, tenant, "WH Conn", nodes, []byte(`[]`)))
+	mock.ExpectExec("UPDATE connections SET status").WillReturnResult(sqlmock.NewResult(0, 1))
+	// Only the valid request publishes → exactly one last_payload write.
+	mock.ExpectExec("UPDATE connections SET last_payload").WillReturnResult(sqlmock.NewResult(0, 1))
+
+	c := &webhookConsumer{}
+	h := harness.NewConsumerHarness(t, c, harness.Options{Name: "webhook-consumer", DB: mgmtDB})
+	startConn(t, h, c, connID, tenant)
+
+	body := `{"secure":true}`
+
+	// No client cert (plain HTTP) → 401.
+	noCert := httptest.NewRequest("POST", "/webhook/"+connID, strings.NewReader(body))
+	noRec := httptest.NewRecorder()
+	c.handleWebhook()(noRec, noCert)
+	if noRec.Code != http.StatusUnauthorized {
+		t.Fatalf("no-cert status = %d, want 401", noRec.Code)
+	}
+
+	// Cert signed by a different CA → 401.
+	wrong := httptest.NewRequest("POST", "/webhook/"+connID, strings.NewReader(body))
+	wrong.TLS = &tls.ConnectionState{PeerCertificates: []*x509.Certificate{foreignCert}}
+	wrongRec := httptest.NewRecorder()
+	c.handleWebhook()(wrongRec, wrong)
+	if wrongRec.Code != http.StatusUnauthorized {
+		t.Fatalf("foreign-cert status = %d, want 401", wrongRec.Code)
+	}
+
+	// Cert signed by the configured CA → 202, published.
+	good := httptest.NewRequest("POST", "/webhook/"+connID, strings.NewReader(body))
+	good.TLS = &tls.ConnectionState{PeerCertificates: []*x509.Certificate{validCert}}
+	goodRec := httptest.NewRecorder()
+	c.handleWebhook()(goodRec, good)
+	if goodRec.Code != http.StatusAccepted {
+		t.Fatalf("valid-cert status = %d, want 202; body=%s", goodRec.Code, goodRec.Body.String())
+	}
+
+	got := h.ExpectEnvelope(t, harness.MatchTenant(tenant), 5*time.Second)
+	if string(got.Payload) != body {
+		t.Errorf("payload = %q, want %q", got.Payload, body)
+	}
+}

--- a/src/cmd/webhook-consumer/server.go
+++ b/src/cmd/webhook-consumer/server.go
@@ -73,7 +73,7 @@ func (s *webhookConsumer) handleWebhook() http.HandlerFunc {
 				http.Error(w, "Client certificate required", http.StatusUnauthorized)
 				return
 			}
-			if err := tlsconfig.VerifyClientCert(r.TLS.PeerCertificates[0], ac.ClientCA); err != nil {
+			if err := tlsconfig.VerifyClientCert(r.TLS.PeerCertificates, ac.ClientCA); err != nil {
 				incClientCertFailure(ac.ConnectionID, "untrusted_cert")
 				s.logger.Warn("Webhook client certificate verification failed",
 					"connection_id", ac.ConnectionID, "reason", err.Error())

--- a/src/cmd/webhook-consumer/server.go
+++ b/src/cmd/webhook-consumer/server.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/ValueRetail/vrsky/pkg/envelope"
+	"github.com/ValueRetail/vrsky/pkg/tlsconfig"
 	"github.com/google/uuid"
 )
 
@@ -58,6 +59,27 @@ func (s *webhookConsumer) handleWebhook() http.HandlerFunc {
 		if ac == nil {
 			http.Error(w, "Connection not found or not running", http.StatusNotFound)
 			return
+		}
+
+		// mTLS client-cert verification (#89 / Phase 3F). When the connection
+		// configured a client CA, the caller must present a client cert that
+		// chains to it. This also closes the plain-port bypass: a request over
+		// the SDK aux HTTP port (no TLS) to an mTLS connection is rejected.
+		if len(ac.ClientCA) > 0 {
+			if r.TLS == nil || len(r.TLS.PeerCertificates) == 0 {
+				incClientCertFailure(ac.ConnectionID, "missing_cert")
+				s.logger.Warn("Webhook requires mTLS but no client certificate presented",
+					"connection_id", ac.ConnectionID)
+				http.Error(w, "Client certificate required", http.StatusUnauthorized)
+				return
+			}
+			if err := tlsconfig.VerifyClientCert(r.TLS.PeerCertificates[0], ac.ClientCA); err != nil {
+				incClientCertFailure(ac.ConnectionID, "untrusted_cert")
+				s.logger.Warn("Webhook client certificate verification failed",
+					"connection_id", ac.ConnectionID, "reason", err.Error())
+				http.Error(w, "Client certificate verification failed", http.StatusUnauthorized)
+				return
+			}
 		}
 
 		body, err := io.ReadAll(io.LimitReader(r.Body, 10*1024*1024)) // 10MB limit

--- a/src/cmd/webhook-consumer/service.go
+++ b/src/cmd/webhook-consumer/service.go
@@ -262,7 +262,7 @@ func (s *webhookConsumer) handleStartCommand(msg *nats.Msg) {
 	// requires an inbound client cert that chains to it.
 	clientCA := s.extractClientCA(conn)
 	if len(clientCA) > 0 && s.mtlsPort == "" {
-		s.logger.Warn("Connection requires mTLS but WORKER_MTLS_PORT is unset; client-cert checks only apply to TLS-port requests",
+		s.logger.Warn("Connection requires mTLS (tls.client_ca) but WORKER_MTLS_PORT is unset; the connection is unreachable — there is no TLS listener and plain-port requests are rejected as missing a client cert. Set WORKER_MTLS_PORT.",
 			"connection_id", cmd.ConnectionID)
 	}
 

--- a/src/cmd/webhook-consumer/service.go
+++ b/src/cmd/webhook-consumer/service.go
@@ -2,17 +2,20 @@ package main
 
 import (
 	"context"
+	"crypto/tls"
 	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"os"
 	"sync"
 	"time"
 
 	"github.com/ValueRetail/vrsky/pkg/crypto"
 	"github.com/ValueRetail/vrsky/pkg/sdk"
+	"github.com/ValueRetail/vrsky/pkg/tlsconfig"
 	"github.com/nats-io/nats.go"
 )
 
@@ -32,6 +35,13 @@ type webhookConsumer struct {
 	// auxPort is the SDK auxiliary HTTP port (WORKER_HTTP_PORT) that /webhook is
 	// served on; the cloudflared tunnel forwards to it.
 	auxPort string
+
+	// mTLS (#89): a dedicated TLS listener for high-security connections that
+	// require an inbound client certificate. Empty mtlsPort disables it. The
+	// listener demands *a* client cert at the handshake (RequireAnyClientCert);
+	// handleWebhook then verifies the cert chains to the per-connection client CA.
+	mtlsPort   string
+	mtlsServer *http.Server
 
 	// Active connections: connectionId → connection info
 	activeConnections map[string]*ActiveConnection
@@ -54,6 +64,12 @@ type ActiveConnection struct {
 	// HMAC signature header does not match cfg.Secret. Populated at start
 	// time from the connection's http.signature config (#67 / Phase 1B).
 	Signature *signatureConfig
+
+	// ClientCA, when non-empty, makes the webhook require a client certificate
+	// that chains to this CA (PEM). Populated at start time from the
+	// connection's tls.client_ca config (#89 / Phase 3F). Requests that present
+	// no client cert — or one signed by a different CA — are rejected 401.
+	ClientCA []byte
 }
 
 // Configure wires dependencies and registers the HTTP endpoints the UI uses
@@ -68,6 +84,7 @@ func (s *webhookConsumer) Configure(ctx context.Context, res *sdk.Resources) err
 	s.logger = res.Logger
 	s.activeConnections = make(map[string]*ActiveConnection)
 	s.auxPort = envOr("WORKER_HTTP_PORT", "9100")
+	s.mtlsPort = os.Getenv("WORKER_MTLS_PORT") // empty → mTLS listener disabled
 
 	s.RegisterHTTPHandler("/webhook/", s.handleWebhook())
 	s.RegisterHTTPHandler("/sample-data/", s.handleSampleData())
@@ -85,6 +102,10 @@ func (s *webhookConsumer) Configure(ctx context.Context, res *sdk.Resources) err
 func (s *webhookConsumer) Run(ctx context.Context, publish sdk.PublishFunc) error {
 	s.publish = publish
 	s.logger.Info("Starting Webhook Consumer Service")
+
+	if err := s.startMTLSListener(); err != nil {
+		return fmt.Errorf("failed to start mTLS listener: %w", err)
+	}
 
 	startSub, err := s.nc.Subscribe("vrsky.commands.*.connection.start", s.handleStartCommand)
 	if err != nil {
@@ -125,12 +146,74 @@ func (s *webhookConsumer) Stop(ctx context.Context) error {
 
 	s.stopTunnel()
 
+	if s.mtlsServer != nil {
+		_ = s.mtlsServer.Shutdown(ctx)
+	}
+
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
 	case <-time.After(2 * time.Second):
 		return nil
 	}
+}
+
+// startMTLSListener brings up a dedicated TLS listener on WORKER_MTLS_PORT that
+// serves /webhook and demands a client certificate at the handshake
+// (RequireAnyClientCert). Per-connection client-CA enforcement happens in
+// handleWebhook. No-op when WORKER_MTLS_PORT is unset. The server identity comes
+// from WEBHOOK_TLS_CERT_FILE/_KEY_FILE, or a generated self-signed cert (dev).
+func (s *webhookConsumer) startMTLSListener() error {
+	if s.mtlsPort == "" {
+		return nil
+	}
+
+	certPEM, keyPEM, err := s.loadServerCert()
+	if err != nil {
+		return fmt.Errorf("load mTLS server cert: %w", err)
+	}
+	tlsCfg, err := tlsconfig.ServerConfig(certPEM, keyPEM)
+	if err != nil {
+		return fmt.Errorf("build mTLS server config: %w", err)
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/webhook/", s.handleWebhook())
+	s.mtlsServer = &http.Server{Addr: ":" + s.mtlsPort, Handler: mux, TLSConfig: tlsCfg}
+
+	ln, err := tls.Listen("tcp", s.mtlsServer.Addr, tlsCfg)
+	if err != nil {
+		return fmt.Errorf("listen on mTLS port %s: %w", s.mtlsPort, err)
+	}
+	go func() {
+		s.logger.Info("mTLS webhook listener started", "port", s.mtlsPort)
+		if serr := s.mtlsServer.Serve(ln); serr != nil && serr != http.ErrServerClosed {
+			s.logger.Error("mTLS listener stopped", "error", serr)
+		}
+	}()
+	return nil
+}
+
+// loadServerCert returns the mTLS listener's server cert/key as PEM. It reads
+// WEBHOOK_TLS_CERT_FILE/_KEY_FILE when both are set; otherwise it generates a
+// throwaway self-signed cert (dev fallback). mTLS security comes from verifying
+// the inbound *client* cert, not from the client trusting this server cert.
+func (s *webhookConsumer) loadServerCert() ([]byte, []byte, error) {
+	certFile := os.Getenv("WEBHOOK_TLS_CERT_FILE")
+	keyFile := os.Getenv("WEBHOOK_TLS_KEY_FILE")
+	if certFile != "" && keyFile != "" {
+		cert, err := os.ReadFile(certFile)
+		if err != nil {
+			return nil, nil, fmt.Errorf("read cert file: %w", err)
+		}
+		key, err := os.ReadFile(keyFile)
+		if err != nil {
+			return nil, nil, fmt.Errorf("read key file: %w", err)
+		}
+		return cert, key, nil
+	}
+	s.logger.Warn("WEBHOOK_TLS_CERT_FILE/_KEY_FILE not set; generating self-signed mTLS server cert (dev only)")
+	return tlsconfig.SelfSignedServer("webhook-consumer")
 }
 
 // CommandMessage represents a start/stop command from NATS
@@ -175,12 +258,21 @@ func (s *webhookConsumer) handleStartCommand(msg *nats.Msg) {
 	// node.config.http.signature.secret.
 	sig := s.extractSignature(conn)
 
+	// Extract optional per-connection mTLS client CA (#89). When set, the webhook
+	// requires an inbound client cert that chains to it.
+	clientCA := s.extractClientCA(conn)
+	if len(clientCA) > 0 && s.mtlsPort == "" {
+		s.logger.Warn("Connection requires mTLS but WORKER_MTLS_PORT is unset; client-cert checks only apply to TLS-port requests",
+			"connection_id", cmd.ConnectionID)
+	}
+
 	s.mu.Lock()
 	s.activeConnections[cmd.ConnectionID] = &ActiveConnection{
 		ConnectionID: cmd.ConnectionID,
 		TenantID:     cmd.TenantID,
 		Cancel:       cancel,
 		Signature:    sig,
+		ClientCA:     clientCA,
 	}
 	s.mu.Unlock()
 
@@ -339,6 +431,37 @@ func (s *webhookConsumer) extractSignature(conn *Connection) *signatureConfig {
 			Prefix:    sig.Prefix,
 			Secret:    sig.Secret,
 		}
+	}
+	return nil
+}
+
+// extractClientCA returns the per-connection mTLS client CA (PEM) for a webhook
+// connection, or nil if the connection has no tls.client_ca configured. The CA
+// has already been resolved to plaintext by resolveSecretsInNodes (#66). When
+// set, handleWebhook requires inbound requests to present a client cert that
+// chains to this CA.
+func (s *webhookConsumer) extractClientCA(conn *Connection) []byte {
+	var nodes []Node
+	if err := json.Unmarshal(conn.Nodes, &nodes); err != nil {
+		return nil
+	}
+	for _, node := range nodes {
+		if node.Type != "consumer" {
+			continue
+		}
+		var cfg struct {
+			Type string `json:"type"`
+			TLS  struct {
+				ClientCA string `json:"client_ca"` // resolved by ResolveSecrets
+			} `json:"tls"`
+		}
+		if err := json.Unmarshal(node.Config, &cfg); err != nil {
+			continue
+		}
+		if cfg.Type != "http" || cfg.TLS.ClientCA == "" {
+			continue
+		}
+		return []byte(cfg.TLS.ClientCA)
 	}
 	return nil
 }

--- a/src/pkg/tlsconfig/tlsconfig.go
+++ b/src/pkg/tlsconfig/tlsconfig.go
@@ -1,0 +1,123 @@
+// Package tlsconfig builds *tls.Config values for the HTTP connectors' mutual-TLS
+// support (Phase 3F, #89). Cert material is supplied as PEM bytes — the workers
+// resolve the connector's tls.*_secret_id references to plaintext via
+// crypto.ResolveSecrets before calling in here, so this package never touches
+// the secrets vault.
+package tlsconfig
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"time"
+)
+
+// NodeConfig is the resolved (plaintext PEM) mTLS material a connector node
+// carries under its "tls" block. In the stored config these are *_secret_id
+// references; crypto.ResolveSecrets replaces them with the PEM values below.
+//
+//	consumer (webhook): ClientCA verifies inbound client certs;
+//	                    Cert/Key are the listener's server identity.
+//	producer (http):    Cert/Key are the client cert presented to the endpoint;
+//	                    ClientCA (optional) is the server CA to trust.
+type NodeConfig struct {
+	ClientCA string `json:"client_ca"`
+	Cert     string `json:"cert"`
+	Key      string `json:"key"`
+}
+
+// Enabled reports whether the block carries any mTLS material.
+func (c *NodeConfig) Enabled() bool {
+	return c != nil && (c.ClientCA != "" || c.Cert != "" || c.Key != "")
+}
+
+// ServerConfig builds a server-side *tls.Config that presents serverCert/Key and
+// requires the client to present *a* certificate (RequireAnyClientCert). The
+// per-connection trust decision is made at the application layer with
+// VerifyClientCert, because a single shared listener can't bind one CA pool per
+// connection at handshake time.
+func ServerConfig(serverCert, serverKey []byte) (*tls.Config, error) {
+	cert, err := tls.X509KeyPair(serverCert, serverKey)
+	if err != nil {
+		return nil, fmt.Errorf("server keypair: %w", err)
+	}
+	return &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		ClientAuth:   tls.RequireAnyClientCert,
+		MinVersion:   tls.VersionTLS12,
+	}, nil
+}
+
+// VerifyClientCert reports whether peer chains to clientCA. Used by the consumer
+// to enforce the per-connection client CA after the handshake captured the cert.
+func VerifyClientCert(peer *x509.Certificate, clientCA []byte) error {
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(clientCA) {
+		return fmt.Errorf("client CA: no certificates parsed")
+	}
+	_, err := peer.Verify(x509.VerifyOptions{
+		Roots:     pool,
+		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageAny},
+	})
+	return err
+}
+
+// ClientConfig builds a client-side *tls.Config presenting clientCert/Key. When
+// rootCA is non-empty it is the only trusted server CA; empty → system roots.
+func ClientConfig(clientCert, clientKey, rootCA []byte) (*tls.Config, error) {
+	cert, err := tls.X509KeyPair(clientCert, clientKey)
+	if err != nil {
+		return nil, fmt.Errorf("client keypair: %w", err)
+	}
+	cfg := &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		MinVersion:   tls.VersionTLS12,
+	}
+	if len(rootCA) > 0 {
+		pool := x509.NewCertPool()
+		if !pool.AppendCertsFromPEM(rootCA) {
+			return nil, fmt.Errorf("root CA: no certificates parsed")
+		}
+		cfg.RootCAs = pool
+	}
+	return cfg, nil
+}
+
+// SelfSignedServer generates a throwaway self-signed server certificate for host.
+// The webhook consumer's mTLS listener uses this as a dev fallback when no server
+// cert (WEBHOOK_TLS_CERT_FILE/_KEY_FILE) is configured: mTLS security here comes
+// from verifying the *client* cert (see VerifyClientCert), not from the client
+// trusting this server cert, so a self-signed identity is acceptable for dev.
+func SelfSignedServer(host string) (certPEM, keyPEM []byte, err error) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, nil, fmt.Errorf("generate key: %w", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: host},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(10 * 365 * 24 * time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		DNSNames:              []string{host},
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		return nil, nil, fmt.Errorf("create cert: %w", err)
+	}
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		return nil, nil, fmt.Errorf("marshal key: %w", err)
+	}
+	certPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyPEM = pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+	return certPEM, keyPEM, nil
+}

--- a/src/pkg/tlsconfig/tlsconfig.go
+++ b/src/pkg/tlsconfig/tlsconfig.go
@@ -54,30 +54,48 @@ func ServerConfig(serverCert, serverKey []byte) (*tls.Config, error) {
 	}, nil
 }
 
-// VerifyClientCert reports whether peer chains to clientCA. Used by the consumer
-// to enforce the per-connection client CA after the handshake captured the cert.
-func VerifyClientCert(peer *x509.Certificate, clientCA []byte) error {
-	pool := x509.NewCertPool()
-	if !pool.AppendCertsFromPEM(clientCA) {
+// VerifyClientCert reports whether the presented chain (leaf first, any
+// intermediates following — i.e. tls.ConnectionState.PeerCertificates) chains to
+// clientCA. Used by the consumer to enforce the per-connection client CA after
+// the handshake captured the cert. Intermediates from the chain are added to a
+// pool so a leaf signed by an intermediate under a configured root still
+// verifies. EKU is restricted to client-auth: a server-auth-only leaf signed by
+// the same CA is rejected (a leaf with no EKU still validates, per x509).
+func VerifyClientCert(chain []*x509.Certificate, clientCA []byte) error {
+	if len(chain) == 0 {
+		return fmt.Errorf("no client certificate presented")
+	}
+	roots := x509.NewCertPool()
+	if !roots.AppendCertsFromPEM(clientCA) {
 		return fmt.Errorf("client CA: no certificates parsed")
 	}
-	_, err := peer.Verify(x509.VerifyOptions{
-		Roots:     pool,
-		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageAny},
+	intermediates := x509.NewCertPool()
+	for _, c := range chain[1:] {
+		intermediates.AddCert(c)
+	}
+	_, err := chain[0].Verify(x509.VerifyOptions{
+		Roots:         roots,
+		Intermediates: intermediates,
+		KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
 	})
 	return err
 }
 
-// ClientConfig builds a client-side *tls.Config presenting clientCert/Key. When
-// rootCA is non-empty it is the only trusted server CA; empty → system roots.
+// ClientConfig builds a client-side *tls.Config. When clientCert/Key are both
+// supplied it presents that client cert (mTLS); supplying only one is a config
+// error. When rootCA is non-empty it is the only trusted server CA; empty →
+// system roots. A rootCA-only config (no client cert) just pins the server CA.
 func ClientConfig(clientCert, clientKey, rootCA []byte) (*tls.Config, error) {
-	cert, err := tls.X509KeyPair(clientCert, clientKey)
-	if err != nil {
-		return nil, fmt.Errorf("client keypair: %w", err)
-	}
-	cfg := &tls.Config{
-		Certificates: []tls.Certificate{cert},
-		MinVersion:   tls.VersionTLS12,
+	cfg := &tls.Config{MinVersion: tls.VersionTLS12}
+	switch {
+	case len(clientCert) > 0 && len(clientKey) > 0:
+		cert, err := tls.X509KeyPair(clientCert, clientKey)
+		if err != nil {
+			return nil, fmt.Errorf("client keypair: %w", err)
+		}
+		cfg.Certificates = []tls.Certificate{cert}
+	case len(clientCert) > 0 || len(clientKey) > 0:
+		return nil, fmt.Errorf("client cert and key must both be set (got cert=%t key=%t)", len(clientCert) > 0, len(clientKey) > 0)
 	}
 	if len(rootCA) > 0 {
 		pool := x509.NewCertPool()

--- a/src/pkg/tlsconfig/tlsconfig_test.go
+++ b/src/pkg/tlsconfig/tlsconfig_test.go
@@ -118,14 +118,26 @@ func TestVerifyClientCert(t *testing.T) {
 	leaf := parseLeaf(t, cliCert)
 
 	// Signed by the configured CA → accepted.
-	if err := VerifyClientCert(leaf, caPEM); err != nil {
+	if err := VerifyClientCert([]*x509.Certificate{leaf}, caPEM); err != nil {
 		t.Errorf("VerifyClientCert should accept a cert signed by the configured CA: %v", err)
 	}
 
 	// A different CA → rejected.
 	otherCAPEM, _, _ := genCA(t)
-	if err := VerifyClientCert(leaf, otherCAPEM); err == nil {
+	if err := VerifyClientCert([]*x509.Certificate{leaf}, otherCAPEM); err == nil {
 		t.Error("VerifyClientCert should reject a cert signed by a different CA")
+	}
+
+	// Empty chain → rejected.
+	if err := VerifyClientCert(nil, caPEM); err == nil {
+		t.Error("VerifyClientCert should reject an empty chain")
+	}
+
+	// A server-auth-only leaf signed by the configured CA → rejected (EKU is
+	// restricted to client-auth).
+	srvCert, _ := genLeaf(t, ca, caKey, "server-leaf", []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth})
+	if err := VerifyClientCert([]*x509.Certificate{parseLeaf(t, srvCert)}, caPEM); err == nil {
+		t.Error("VerifyClientCert should reject a server-auth-only leaf")
 	}
 }
 

--- a/src/pkg/tlsconfig/tlsconfig_test.go
+++ b/src/pkg/tlsconfig/tlsconfig_test.go
@@ -1,0 +1,162 @@
+package tlsconfig
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"testing"
+	"time"
+)
+
+func genCA(t *testing.T) (caPEM []byte, ca *x509.Certificate, caKey *ecdsa.PrivateKey) {
+	t.Helper()
+	caKey, _ = ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &caKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("create CA: %v", err)
+	}
+	ca, _ = x509.ParseCertificate(der)
+	caPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	return caPEM, ca, caKey
+}
+
+func genLeaf(t *testing.T, ca *x509.Certificate, caKey *ecdsa.PrivateKey, cn string, eku []x509.ExtKeyUsage) (certPEM, keyPEM []byte) {
+	t.Helper()
+	key, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(time.Now().UnixNano()),
+		Subject:      pkix.Name{CommonName: cn},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  eku,
+		DNSNames:     []string{cn},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, ca, &key.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("create leaf: %v", err)
+	}
+	certPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyDER, _ := x509.MarshalECPrivateKey(key)
+	keyPEM = pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+	return certPEM, keyPEM
+}
+
+func parseLeaf(t *testing.T, certPEM []byte) *x509.Certificate {
+	t.Helper()
+	block, _ := pem.Decode(certPEM)
+	c, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		t.Fatalf("parse leaf: %v", err)
+	}
+	return c
+}
+
+func TestServerConfig(t *testing.T) {
+	caPEM, ca, caKey := genCA(t)
+	srvCert, srvKey := genLeaf(t, ca, caKey, "webhook-consumer", []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth})
+
+	cfg, err := ServerConfig(srvCert, srvKey)
+	if err != nil {
+		t.Fatalf("ServerConfig: %v", err)
+	}
+	if cfg.ClientAuth != tls.RequireAnyClientCert {
+		t.Errorf("ClientAuth = %v, want RequireAnyClientCert", cfg.ClientAuth)
+	}
+	if len(cfg.Certificates) != 1 {
+		t.Errorf("expected 1 server cert, got %d", len(cfg.Certificates))
+	}
+	_ = caPEM
+
+	if _, err := ServerConfig([]byte("not a cert"), srvKey); err == nil {
+		t.Error("ServerConfig should reject bad cert material")
+	}
+}
+
+func TestClientConfig(t *testing.T) {
+	caPEM, ca, caKey := genCA(t)
+	cliCert, cliKey := genLeaf(t, ca, caKey, "client", []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth})
+
+	cfg, err := ClientConfig(cliCert, cliKey, caPEM)
+	if err != nil {
+		t.Fatalf("ClientConfig: %v", err)
+	}
+	if cfg.RootCAs == nil {
+		t.Error("RootCAs should be set when a CA is supplied")
+	}
+	if len(cfg.Certificates) != 1 {
+		t.Errorf("expected 1 client cert, got %d", len(cfg.Certificates))
+	}
+
+	// Empty CA → system roots (nil RootCAs), no error.
+	cfg2, err := ClientConfig(cliCert, cliKey, nil)
+	if err != nil {
+		t.Fatalf("ClientConfig (no CA): %v", err)
+	}
+	if cfg2.RootCAs != nil {
+		t.Error("RootCAs should be nil (system roots) when no CA supplied")
+	}
+}
+
+func TestVerifyClientCert(t *testing.T) {
+	caPEM, ca, caKey := genCA(t)
+	cliCert, _ := genLeaf(t, ca, caKey, "client", []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth})
+	leaf := parseLeaf(t, cliCert)
+
+	// Signed by the configured CA → accepted.
+	if err := VerifyClientCert(leaf, caPEM); err != nil {
+		t.Errorf("VerifyClientCert should accept a cert signed by the configured CA: %v", err)
+	}
+
+	// A different CA → rejected.
+	otherCAPEM, _, _ := genCA(t)
+	if err := VerifyClientCert(leaf, otherCAPEM); err == nil {
+		t.Error("VerifyClientCert should reject a cert signed by a different CA")
+	}
+}
+
+func TestSelfSignedServer(t *testing.T) {
+	certPEM, keyPEM, err := SelfSignedServer("webhook-consumer")
+	if err != nil {
+		t.Fatalf("SelfSignedServer: %v", err)
+	}
+	// Must be usable as a server keypair.
+	if _, err := tls.X509KeyPair(certPEM, keyPEM); err != nil {
+		t.Fatalf("self-signed material is not a valid keypair: %v", err)
+	}
+	// And feed straight into ServerConfig.
+	cfg, err := ServerConfig(certPEM, keyPEM)
+	if err != nil {
+		t.Fatalf("ServerConfig with self-signed cert: %v", err)
+	}
+	if cfg.ClientAuth != tls.RequireAnyClientCert {
+		t.Errorf("ClientAuth = %v, want RequireAnyClientCert", cfg.ClientAuth)
+	}
+}
+
+func TestNodeConfigEnabled(t *testing.T) {
+	if (&NodeConfig{}).Enabled() {
+		t.Error("empty NodeConfig should be disabled")
+	}
+	if !(&NodeConfig{Cert: "x", Key: "y"}).Enabled() {
+		t.Error("NodeConfig with cert/key should be enabled")
+	}
+	var nilCfg *NodeConfig
+	if nilCfg.Enabled() {
+		t.Error("nil NodeConfig should be disabled")
+	}
+}


### PR DESCRIPTION
Worker-terminated mutual TLS for the HTTP connectors — the **last Phase-3 item** (completes Phase 3, 8/8). Opt-in per connection, keyed off cert material stored as tenant secrets, reusing the #66 `*_secret_id` resolution (no new secret plumbing).

## What it does
- **Consumer (webhook):** rejects callers that don't present a client cert chaining to the connection's configured CA.
- **Producer (http):** presents a client cert to mTLS-required endpoints.

## Changes
- **`pkg/tlsconfig`** (new): shared `*tls.Config` builders — `ServerConfig` (`RequireAnyClientCert`), `VerifyClientCert` (per-connection client-CA x509 verify), `ClientConfig` (client cert + optional root CA), `SelfSignedServer` (dev-fallback server identity).
- **webhook-consumer:** dedicated TLS listener on `WORKER_MTLS_PORT` (9101) that demands a client cert at the handshake. `handleWebhook` verifies the presented cert chains to the connection's `tls.client_ca` (resolved from `tls.client_ca_secret_id`), else **401**. The same check runs on the plain aux port (`r.TLS == nil` ⇒ no cert), **closing the plain-port bypass**. New `webhook_client_cert_failures_total{connection_id,reason}` metric.
- **http-producer:** when a node has a `tls` block with resolved `cert`/`key`, builds a dedicated `http.Client` presenting that client cert (trusting `client_ca` as the server root if supplied), cached per config.
- **docker-compose:** `WORKER_MTLS_PORT=9101` + `127.0.0.1:9101` mapping for webhook-consumer; documented optional `WEBHOOK_TLS_CERT_FILE`/`_KEY_FILE`.
- **docs/SECURITY.md:** mTLS section — config surface, behaviour, verify steps.

## Config surface
A `tls` block on the connector node `config` (sibling of `http`); each field references a secret holding PEM:
- Consumer: `tls.client_ca_secret_id` (required).
- Producer: `tls.cert_secret_id` + `tls.key_secret_id` (required), `tls.client_ca_secret_id` (optional server CA).

UI cert pickers are a follow-up; the `tls` block is settable via the connections API today.

## Verification
- **Unit/race:** `pkg/tlsconfig` round-trips CA→server/client configs and rejects a foreign CA; webhook handler test asserts 401 on missing / foreign-CA client certs and 202 on a valid one. `go build/vet ./...`, gofmt, golangci-lint v1.64.8 all clean.
- **Live (compose):** generated a throwaway CA + client cert, stored the CA as a tenant secret, deployed a webhook→http connection with `tls.client_ca_secret_id`:
  - no client cert → **handshake refused** (curl exit 56)
  - cert from a different CA → **401** (`untrusted_cert`)
  - valid cert signed by the configured CA → **202**, published
  - plain port 9100, no cert → **401** (bypass closed)
  - both `webhook_client_cert_failures_total` reasons incremented.

Closes #89.

🤖 Generated with [Claude Code](https://claude.com/claude-code)