### PR TITLE
feat(#92): per-tenant usage metering (Phase 4A)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -435,6 +435,10 @@ services:
       # dynamic config (shared, read-only, with the traefik service). On a plan
       # change the API rewrites tenants.yml here and Traefik hot-reloads.
       TRAEFIK_DYNAMIC_DIR: "/etc/traefik/dynamic"
+      # Usage metering (#92): the hourly rollup queries Prometheus for per-tenant
+      # message + deploy counts and snapshots them (with storage) into
+      # usage_daily. Unset → storage-only rollup.
+      PROMETHEUS_URL: "${PROMETHEUS_URL:-http://prometheus:9090}"
     depends_on:
       nats:
         condition: service_healthy

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -65,3 +65,33 @@ secret-access paths follow this.
 - Traces: `infrastructure/kubernetes/monitoring/otel-tracing.yaml`.
 - Logs: `infrastructure/kubernetes/monitoring/loki-promtail.yaml`.
 - All three datasources are provisioned in `grafana-values.yaml`.
+
+## Per-tenant usage metering (#92)
+
+Phase 4A turns the per-tenant metrics into a billable record. Three axes are
+tracked per tenant per UTC day in the `usage_daily` table (migration `000016`):
+
+| Axis                 | Source                                                              |
+|----------------------|---------------------------------------------------------------------|
+| `messages_published` | `increase(vrsky_messages_published_total[24h])` (Prometheus)        |
+| `deploys`            | `increase(vrsky_connection_deploys_total[24h])` (Prometheus)        |
+| `storage_bytes`      | `tenant_quotas.storage_bytes` snapshot                              |
+
+`vrsky_messages_published_total` is incremented by the publisher on every
+successful JetStream publish; `vrsky_connection_deploys_total` is incremented by
+the management-api on every successful connection start. Prometheus scrapes both
+(jobs `vrsky-workers` + `management-api`).
+
+**Rollup.** The management-api runs an hourly `UsageRollup` (`PROMETHEUS_URL`,
+default `http://prometheus:9090`) that queries the two counters by `tenant_id`
+and upserts the current day's row (idempotent `ON CONFLICT`). Running hourly
+keeps the live day's totals fresh and re-derives the current day after a restart;
+prior days persist in `usage_daily` — so the metering survives worker/API
+restarts even though Prometheus counters reset. With `PROMETHEUS_URL` unset the
+rollup records storage only.
+
+**Surfacing.** `GET /api/v1/tenants/{id}/usage[?from=&to=]` returns current-month
+(default) totals + daily rows; `…/usage/export?format=csv` streams the same as
+CSV (`day,messages_published,deploys,storage_bytes`) for handoff to a billing /
+invoice system. Both are shown on the **Usage & quotas** settings page. A live
+Stripe API integration is out of scope — CSV export is the billing handoff.

--- a/infrastructure/migrations/000016_usage_daily.down.sql
+++ b/infrastructure/migrations/000016_usage_daily.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS usage_daily;

--- a/infrastructure/migrations/000016_usage_daily.up.sql
+++ b/infrastructure/migrations/000016_usage_daily.up.sql
@@ -1,0 +1,22 @@
+-- Per-tenant usage metering (Phase 4A / #92).
+--
+-- A daily rollup job (management-api) snapshots per-tenant usage here once an
+-- hour for the current UTC day: message + deploy counts come from Prometheus
+-- (increase() over the day), storage from tenant_quotas.storage_bytes. The table
+-- is the durable record — Prometheus counters reset on worker restart and have
+-- limited retention, but these rows persist, satisfying the "counters survive
+-- restart (Prometheus + Postgres snapshot)" acceptance criterion. The UI reads
+-- current-month totals + daily rows from here; CSV export streams the same.
+
+CREATE TABLE IF NOT EXISTS usage_daily (
+    tenant_id          UUID        NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+    day                DATE        NOT NULL,
+    messages_published BIGINT      NOT NULL DEFAULT 0,
+    deploys            BIGINT      NOT NULL DEFAULT 0,
+    storage_bytes      BIGINT      NOT NULL DEFAULT 0,
+    updated_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (tenant_id, day)
+);
+
+-- Range scans over a billing period span all tenants for a day range.
+CREATE INDEX IF NOT EXISTS idx_usage_daily_day ON usage_daily (day);

--- a/src/cmd/lint-tenant-filter/main.go
+++ b/src/cmd/lint-tenant-filter/main.go
@@ -51,6 +51,7 @@ var tenantScopedTables = []string{
 	"oauth_providers",
 	"oauth_grants",
 	"notification_targets",
+	"usage_daily",
 }
 
 // sqlStmt extracts the backtick-quoted SQL string that follows a

--- a/src/cmd/management-api/main.go
+++ b/src/cmd/management-api/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/ValueRetail/vrsky/pkg/logging"
 	"github.com/ValueRetail/vrsky/pkg/managementapi"
 	"github.com/ValueRetail/vrsky/pkg/oauth"
+	"github.com/ValueRetail/vrsky/pkg/promquery"
 	"github.com/ValueRetail/vrsky/pkg/tracing"
 )
 
@@ -327,6 +328,19 @@ func setupServer(config *Config, db *sql.DB, nc *nats.Conn, logger *log.Logger, 
 	// process lifetime; its ticker + worker goroutines are reclaimed on exit.
 	oauthRefresher.Start()
 	restHandler.SetOAuthRefresher(oauthRefresher)
+
+	// Phase 4A (#92): per-tenant usage metering. An hourly rollup snapshots
+	// message + deploy counts (from Prometheus) and storage (from tenant_quotas)
+	// into usage_daily, which the /usage API + CSV export read. PROMETHEUS_URL
+	// unset → storage-only rollup (counts stay 0). Like the OAuth refresher, no
+	// deferred Stop — it runs for the process lifetime.
+	var promClient *promquery.Client
+	if promURL := os.Getenv("PROMETHEUS_URL"); promURL != "" {
+		promClient = promquery.New(promURL, nil)
+	} else {
+		slog.Warn("PROMETHEUS_URL unset; usage rollup will record storage only (no message/deploy counts)")
+	}
+	managementapi.NewUsageRollup(repo, promClient).Start()
 
 	restHandler.RegisterRoutes(mux)
 

--- a/src/pkg/managementapi/handler.go
+++ b/src/pkg/managementapi/handler.go
@@ -564,6 +564,10 @@ func (h *Handler) StartConnection(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Count the deploy for per-tenant usage metering (#92). The usage rollup
+	// snapshots increase() of this counter from Prometheus into usage_daily.
+	connectionDeploys.WithLabelValues(tenantID).Inc()
+
 	// Create connection started event
 	eventData, _ := json.Marshal(map[string]interface{}{
 		"status":    conn.Status,
@@ -1023,6 +1027,10 @@ func (h *Handler) RegisterAuthRoutes(mux *http.ServeMux) {
 	// Tenant quotas (#74). Reads = any member; writes = owner.
 	mux.HandleFunc("GET /api/v1/tenants/{tenant_id}/quotas", sessionMW(tenantMW(http.HandlerFunc(h.HandleGetQuotas))).ServeHTTP)
 	mux.HandleFunc("PUT /api/v1/tenants/{tenant_id}/quotas", sessionMW(tenantMW(ownerMW(http.HandlerFunc(h.HandleUpdateQuotas)))).ServeHTTP)
+
+	// Per-tenant usage metering (#92). Any member can read usage + export CSV.
+	mux.HandleFunc("GET /api/v1/tenants/{tenant_id}/usage", sessionMW(tenantMW(http.HandlerFunc(h.HandleGetUsage))).ServeHTTP)
+	mux.HandleFunc("GET /api/v1/tenants/{tenant_id}/usage/export", sessionMW(tenantMW(http.HandlerFunc(h.HandleExportUsage))).ServeHTTP)
 
 	// Subscription plan (#90). Owner-only; drives the gateway's per-tenant edge
 	// rate limit (free/pro/enterprise).

--- a/src/pkg/managementapi/handler_test.go
+++ b/src/pkg/managementapi/handler_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"sort"
 	"testing"
 	"time"
 )
@@ -20,6 +21,7 @@ type MockRepository struct {
 	oidcUsers    []mockOIDCUser
 	quotas       map[string]*TenantQuotas
 	tenantPlans  map[string]string
+	usage        map[string]map[string]*UsageDaily // tenantID → day → row
 }
 
 type mockOIDCUser struct {
@@ -683,6 +685,52 @@ func (m *MockRepository) CountActiveIntegrations(ctx context.Context, tenantID s
 		}
 	}
 	return n, nil
+}
+
+// ----- Usage metering (Phase 4A — #92) -----
+
+func (m *MockRepository) UpsertUsageDaily(ctx context.Context, tenantID string, day time.Time, messages, deploys, storageBytes int64) error {
+	if m.usage == nil {
+		m.usage = map[string]map[string]*UsageDaily{}
+	}
+	if m.usage[tenantID] == nil {
+		m.usage[tenantID] = map[string]*UsageDaily{}
+	}
+	d := day.UTC().Format("2006-01-02")
+	m.usage[tenantID][d] = &UsageDaily{Day: d, MessagesPublished: messages, Deploys: deploys, StorageBytes: storageBytes}
+	return nil
+}
+
+func (m *MockRepository) ListUsageDaily(ctx context.Context, tenantID string, from, to time.Time) ([]*UsageDaily, error) {
+	lo, hi := from.UTC().Format("2006-01-02"), to.UTC().Format("2006-01-02")
+	var out []*UsageDaily
+	for d, row := range m.usage[tenantID] {
+		if d >= lo && d <= hi {
+			cp := *row
+			out = append(out, &cp)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Day < out[j].Day })
+	return out, nil
+}
+
+func (m *MockRepository) SumUsage(ctx context.Context, tenantID string, from, to time.Time) (*UsageTotals, error) {
+	rows, _ := m.ListUsageDaily(ctx, tenantID, from, to)
+	t := &UsageTotals{}
+	for _, r := range rows {
+		t.MessagesPublished += r.MessagesPublished
+		t.Deploys += r.Deploys
+		t.StorageBytes = r.StorageBytes // rows are day-ascending → ends on latest
+	}
+	return t, nil
+}
+
+func (m *MockRepository) ListTenantStorage(ctx context.Context) (map[string]int64, error) {
+	out := map[string]int64{}
+	for id, q := range m.quotas {
+		out[id] = q.StorageBytes
+	}
+	return out, nil
 }
 
 // ----- Tenant members (Phase 1D — #69) -----

--- a/src/pkg/managementapi/repo_usage.go
+++ b/src/pkg/managementapi/repo_usage.go
@@ -1,0 +1,115 @@
+package managementapi
+
+import (
+	"context"
+	"time"
+)
+
+// Per-tenant usage metering (Phase 4A / #92).
+//
+// usage_daily holds one row per (tenant, UTC day) with message + deploy counts
+// and a storage snapshot. The rollup job (usage_rollup.go) upserts the current
+// day hourly; the UI/API read current-month totals + daily rows from here. See
+// the 000016_usage_daily migration.
+
+// UsageDaily is one row of the usage_daily table. Day is formatted YYYY-MM-DD.
+type UsageDaily struct {
+	Day               string `json:"day"`
+	MessagesPublished int64  `json:"messages_published"`
+	Deploys           int64  `json:"deploys"`
+	StorageBytes      int64  `json:"storage_bytes"`
+}
+
+// UsageTotals aggregates a date range for one tenant. Messages and deploys are
+// summed; StorageBytes is a point-in-time value (the most recent day in range),
+// since summing a gauge-like snapshot is meaningless.
+type UsageTotals struct {
+	MessagesPublished int64 `json:"messages_published"`
+	Deploys           int64 `json:"deploys"`
+	StorageBytes      int64 `json:"storage_bytes"`
+}
+
+// UpsertUsageDaily writes (or refreshes) a tenant's usage row for one day. Safe
+// to call repeatedly for the live day — ON CONFLICT replaces the counts.
+func (r *PostgresRepository) UpsertUsageDaily(ctx context.Context, tenantID string, day time.Time, messages, deploys, storageBytes int64) error {
+	_, err := r.db.ExecContext(ctx, `
+		INSERT INTO usage_daily (tenant_id, day, messages_published, deploys, storage_bytes, updated_at)
+		VALUES ($1, $2, $3, $4, $5, NOW())
+		ON CONFLICT (tenant_id, day) DO UPDATE
+		   SET messages_published = EXCLUDED.messages_published,
+		       deploys            = EXCLUDED.deploys,
+		       storage_bytes      = EXCLUDED.storage_bytes,
+		       updated_at         = NOW()
+	`, tenantID, day.UTC().Format("2006-01-02"), messages, deploys, storageBytes)
+	return err
+}
+
+// ListUsageDaily returns a tenant's daily usage rows in [from, to] (inclusive),
+// ordered by day ascending.
+func (r *PostgresRepository) ListUsageDaily(ctx context.Context, tenantID string, from, to time.Time) ([]*UsageDaily, error) {
+	rows, err := r.db.QueryContext(ctx, `
+		SELECT day, messages_published, deploys, storage_bytes
+		FROM usage_daily
+		WHERE tenant_id = $1 AND day >= $2 AND day <= $3
+		ORDER BY day ASC
+	`, tenantID, from.UTC().Format("2006-01-02"), to.UTC().Format("2006-01-02"))
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []*UsageDaily
+	for rows.Next() {
+		var u UsageDaily
+		var day time.Time
+		if err := rows.Scan(&day, &u.MessagesPublished, &u.Deploys, &u.StorageBytes); err != nil {
+			return nil, err
+		}
+		u.Day = day.UTC().Format("2006-01-02")
+		out = append(out, &u)
+	}
+	return out, rows.Err()
+}
+
+// SumUsage aggregates a tenant's usage over [from, to]. Messages/deploys are
+// summed; StorageBytes is the most recent day's snapshot in range.
+func (r *PostgresRepository) SumUsage(ctx context.Context, tenantID string, from, to time.Time) (*UsageTotals, error) {
+	t := &UsageTotals{}
+	err := r.db.QueryRowContext(ctx, `
+		SELECT COALESCE(SUM(messages_published), 0),
+		       COALESCE(SUM(deploys), 0),
+		       COALESCE((SELECT storage_bytes FROM usage_daily
+		                  WHERE tenant_id = $1 AND day >= $2 AND day <= $3
+		                  ORDER BY day DESC LIMIT 1), 0)
+		FROM usage_daily
+		WHERE tenant_id = $1 AND day >= $2 AND day <= $3
+	`, tenantID, from.UTC().Format("2006-01-02"), to.UTC().Format("2006-01-02")).
+		Scan(&t.MessagesPublished, &t.Deploys, &t.StorageBytes)
+	if err != nil {
+		return nil, err
+	}
+	return t, nil
+}
+
+// ListTenantStorage returns tenant_id → storage_bytes for every tenant with a
+// quota row. The rollup uses it as both the tenant set and the storage source.
+func (r *PostgresRepository) ListTenantStorage(ctx context.Context) (map[string]int64, error) {
+	// lint:tenant-ok — the usage rollup is a global background job with no
+	// request tenant; it intentionally reads every tenant's storage snapshot.
+	rows, err := r.db.QueryContext(ctx, `SELECT tenant_id, storage_bytes FROM tenant_quotas`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	out := map[string]int64{}
+	for rows.Next() {
+		var id string
+		var bytes int64
+		if err := rows.Scan(&id, &bytes); err != nil {
+			return nil, err
+		}
+		out[id] = bytes
+	}
+	return out, rows.Err()
+}

--- a/src/pkg/managementapi/repository.go
+++ b/src/pkg/managementapi/repository.go
@@ -229,6 +229,24 @@ type Repository interface {
 	CountActiveIntegrations(ctx context.Context, tenantID string) (int, error)
 
 	// ============================================
+	// Usage metering (Phase 4A — #92)
+	// ============================================
+
+	// UpsertUsageDaily writes (or refreshes) a tenant's usage row for one day.
+	UpsertUsageDaily(ctx context.Context, tenantID string, day time.Time, messages, deploys, storageBytes int64) error
+
+	// ListUsageDaily returns a tenant's daily usage rows in [from, to] inclusive.
+	ListUsageDaily(ctx context.Context, tenantID string, from, to time.Time) ([]*UsageDaily, error)
+
+	// SumUsage aggregates a tenant's usage over [from, to] (messages/deploys
+	// summed, storage = latest day in range).
+	SumUsage(ctx context.Context, tenantID string, from, to time.Time) (*UsageTotals, error)
+
+	// ListTenantStorage returns tenant_id → storage_bytes for every tenant with
+	// a quota row; the rollup uses it as the tenant set + storage source.
+	ListTenantStorage(ctx context.Context) (map[string]int64, error)
+
+	// ============================================
 	// Tenant members (Phase 1D — #69)
 	// ============================================
 

--- a/src/pkg/managementapi/usage_handler.go
+++ b/src/pkg/managementapi/usage_handler.go
@@ -1,0 +1,104 @@
+package managementapi
+
+import (
+	"encoding/csv"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+// Per-tenant usage metering API (Phase 4A / #92).
+//
+//	GET /api/v1/tenants/{tenant_id}/usage[?from=YYYY-MM-DD&to=YYYY-MM-DD]
+//	GET /api/v1/tenants/{tenant_id}/usage/export?format=csv[&from=&to=]
+//
+// Both default to the current calendar month (UTC). Membership is enforced by
+// the tenant middleware on the route; we read the tenant from the path.
+
+// UsageResponse is the GET /usage payload: a range, the range totals, and the
+// per-day rows that back a chart/table.
+type UsageResponse struct {
+	From  string        `json:"from"`
+	To    string        `json:"to"`
+	Month *UsageTotals  `json:"month"`
+	Daily []*UsageDaily `json:"daily"`
+}
+
+// usageRange resolves the from/to query params, defaulting to the current
+// calendar month (UTC): from = first of month, to = today. Invalid dates fall
+// back to the default bound. to is clamped to be >= from.
+func usageRange(r *http.Request) (from, to time.Time) {
+	now := time.Now().UTC()
+	from = time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
+	to = time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
+
+	if v := r.URL.Query().Get("from"); v != "" {
+		if d, err := time.Parse("2006-01-02", v); err == nil {
+			from = d
+		}
+	}
+	if v := r.URL.Query().Get("to"); v != "" {
+		if d, err := time.Parse("2006-01-02", v); err == nil {
+			to = d
+		}
+	}
+	if to.Before(from) {
+		to = from
+	}
+	return from, to
+}
+
+// HandleGetUsage returns range totals + daily rows for the tenant.
+func (h *Handler) HandleGetUsage(w http.ResponseWriter, r *http.Request) {
+	tenantID := r.PathValue("tenant_id")
+	from, to := usageRange(r)
+	ctx := r.Context()
+
+	totals, err := h.repo.SumUsage(ctx, tenantID, from, to)
+	if err != nil {
+		_ = writeError(w, http.StatusInternalServerError, "DatabaseError", "failed to aggregate usage", nil)
+		return
+	}
+	daily, err := h.repo.ListUsageDaily(ctx, tenantID, from, to)
+	if err != nil {
+		_ = writeError(w, http.StatusInternalServerError, "DatabaseError", "failed to load usage", nil)
+		return
+	}
+	if daily == nil {
+		daily = []*UsageDaily{}
+	}
+	_ = writeJSON(w, http.StatusOK, SuccessResponse{Data: UsageResponse{
+		From:  from.Format("2006-01-02"),
+		To:    to.Format("2006-01-02"),
+		Month: totals,
+		Daily: daily,
+	}})
+}
+
+// HandleExportUsage streams the daily rows as CSV (Stripe/invoice-ready).
+func (h *Handler) HandleExportUsage(w http.ResponseWriter, r *http.Request) {
+	tenantID := r.PathValue("tenant_id")
+	from, to := usageRange(r)
+
+	daily, err := h.repo.ListUsageDaily(r.Context(), tenantID, from, to)
+	if err != nil {
+		_ = writeError(w, http.StatusInternalServerError, "DatabaseError", "failed to load usage", nil)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/csv")
+	w.Header().Set("Content-Disposition",
+		"attachment; filename=\"vrsky-usage-"+from.Format("2006-01-02")+"_"+to.Format("2006-01-02")+".csv\"")
+
+	cw := csv.NewWriter(w)
+	_ = cw.Write([]string{"day", "messages_published", "deploys", "storage_bytes"})
+	for _, d := range daily {
+		_ = cw.Write([]string{
+			d.Day,
+			strconv.FormatInt(d.MessagesPublished, 10),
+			strconv.FormatInt(d.Deploys, 10),
+			strconv.FormatInt(d.StorageBytes, 10),
+		})
+	}
+	cw.Flush()
+}

--- a/src/pkg/managementapi/usage_handler.go
+++ b/src/pkg/managementapi/usage_handler.go
@@ -2,6 +2,7 @@ package managementapi
 
 import (
 	"encoding/csv"
+	"log"
 	"net/http"
 	"strconv"
 	"time"
@@ -101,4 +102,10 @@ func (h *Handler) HandleExportUsage(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 	cw.Flush()
+	// The 200 + headers are already committed once streaming starts, so we can't
+	// signal failure to the client — but log it (e.g. client disconnect mid-stream)
+	// so a truncated export isn't silent.
+	if err := cw.Error(); err != nil {
+		log.Printf("usage: CSV export to tenant=%s failed mid-stream: %v", tenantID, err)
+	}
 }

--- a/src/pkg/managementapi/usage_handler_test.go
+++ b/src/pkg/managementapi/usage_handler_test.go
@@ -1,0 +1,107 @@
+package managementapi
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func seedUsage(t *testing.T, repo *MockRepository, tenant string) {
+	t.Helper()
+	ctx := context.Background()
+	// Two days in June 2026.
+	d1 := time.Date(2026, 6, 10, 0, 0, 0, 0, time.UTC)
+	d2 := time.Date(2026, 6, 11, 0, 0, 0, 0, time.UTC)
+	if err := repo.UpsertUsageDaily(ctx, tenant, d1, 100, 2, 5000); err != nil {
+		t.Fatalf("seed d1: %v", err)
+	}
+	if err := repo.UpsertUsageDaily(ctx, tenant, d2, 50, 1, 6000); err != nil {
+		t.Fatalf("seed d2: %v", err)
+	}
+}
+
+func TestHandleGetUsage(t *testing.T) {
+	repo := NewMockRepository()
+	seedUsage(t, repo, "t-1")
+	// A second tenant must not leak into t-1's totals.
+	seedUsage(t, repo, "t-2")
+	h := NewHandler(repo, NewValidator())
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/tenants/t-1/usage?from=2026-06-01&to=2026-06-30", nil)
+	req.SetPathValue("tenant_id", "t-1")
+	rec := httptest.NewRecorder()
+	h.HandleGetUsage(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		Data UsageResponse `json:"data"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Data.Month.MessagesPublished != 150 {
+		t.Errorf("messages = %d, want 150", resp.Data.Month.MessagesPublished)
+	}
+	if resp.Data.Month.Deploys != 3 {
+		t.Errorf("deploys = %d, want 3", resp.Data.Month.Deploys)
+	}
+	// Storage is the latest day's snapshot, not a sum.
+	if resp.Data.Month.StorageBytes != 6000 {
+		t.Errorf("storage = %d, want 6000 (latest day)", resp.Data.Month.StorageBytes)
+	}
+	if len(resp.Data.Daily) != 2 {
+		t.Fatalf("daily rows = %d, want 2", len(resp.Data.Daily))
+	}
+	if resp.Data.Daily[0].Day != "2026-06-10" {
+		t.Errorf("first day = %q, want 2026-06-10 (ascending)", resp.Data.Daily[0].Day)
+	}
+}
+
+func TestHandleExportUsageCSV(t *testing.T) {
+	repo := NewMockRepository()
+	seedUsage(t, repo, "t-1")
+	h := NewHandler(repo, NewValidator())
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/tenants/t-1/usage/export?from=2026-06-01&to=2026-06-30", nil)
+	req.SetPathValue("tenant_id", "t-1")
+	rec := httptest.NewRecorder()
+	h.HandleExportUsage(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "text/csv" {
+		t.Errorf("content-type = %q, want text/csv", ct)
+	}
+	if cd := rec.Header().Get("Content-Disposition"); !strings.Contains(cd, "attachment") {
+		t.Errorf("content-disposition = %q, want attachment", cd)
+	}
+	lines := strings.Split(strings.TrimSpace(rec.Body.String()), "\n")
+	if len(lines) != 3 { // header + 2 days
+		t.Fatalf("csv lines = %d, want 3; body=%q", len(lines), rec.Body.String())
+	}
+	if lines[0] != "day,messages_published,deploys,storage_bytes" {
+		t.Errorf("header = %q", lines[0])
+	}
+	if !strings.HasPrefix(lines[1], "2026-06-10,100,2,5000") {
+		t.Errorf("row 1 = %q", lines[1])
+	}
+}
+
+func TestUsageRangeDefaultsToCurrentMonth(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/tenants/t-1/usage", nil)
+	from, to := usageRange(req)
+	now := time.Now().UTC()
+	if from.Day() != 1 || from.Month() != now.Month() {
+		t.Errorf("from = %v, want first of current month", from)
+	}
+	if to.Before(from) {
+		t.Errorf("to %v before from %v", to, from)
+	}
+}

--- a/src/pkg/managementapi/usage_metrics.go
+++ b/src/pkg/managementapi/usage_metrics.go
@@ -1,0 +1,14 @@
+package managementapi
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// connectionDeploys counts successful connection starts (deploys) per tenant
+// (Phase 4A / #92). It is scraped from the management-api /metrics endpoint; the
+// usage rollup reads increase() of it from Prometheus into usage_daily.deploys.
+var connectionDeploys = promauto.NewCounterVec(prometheus.CounterOpts{
+	Name: "vrsky_connection_deploys_total",
+	Help: "Successful connection starts (deploys) by tenant.",
+}, []string{"tenant_id"})

--- a/src/pkg/managementapi/usage_rollup.go
+++ b/src/pkg/managementapi/usage_rollup.go
@@ -1,0 +1,151 @@
+package managementapi
+
+import (
+	"context"
+	"log/slog"
+	"math"
+	"sync"
+	"time"
+
+	"github.com/ValueRetail/vrsky/pkg/promquery"
+)
+
+// UsageRollup snapshots per-tenant usage into usage_daily on a timer (Phase 4A /
+// #92). Each run upserts the current UTC day: message + deploy counts come from
+// Prometheus (increase() over the trailing 24h), storage from the tenant_quotas
+// snapshot. Running hourly keeps the live day's "this month" totals fresh and
+// re-derives the current day after a restart; prior days already persisted in
+// usage_daily are the durable record.
+//
+// The lifecycle (Start/Stop with WaitGroup + cancel) mirrors OAuthRefresher so
+// it slots into the standard cmd/management-api/main.go boot sequence.
+type UsageRollup struct {
+	repo   Repository
+	prom   *promquery.Client // nil → storage-only rollup (no Prometheus configured)
+	tick   time.Duration
+	logger *slog.Logger
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+}
+
+// PromQL the rollup evaluates. increase() over 24h gives the day's delta and is
+// resilient to counter resets on worker restart.
+const (
+	usageMessagesQuery = `sum by (tenant_id) (increase(vrsky_messages_published_total[24h]))`
+	usageDeploysQuery  = `sum by (tenant_id) (increase(vrsky_connection_deploys_total[24h]))`
+)
+
+// UsageRollupOption tunes the rollup at construction.
+type UsageRollupOption func(*UsageRollup)
+
+// WithRollupTick overrides the rollup interval. Default 1 hour.
+func WithRollupTick(d time.Duration) UsageRollupOption {
+	return func(u *UsageRollup) { u.tick = d }
+}
+
+// WithRollupLogger sets the logger. Default slog.Default().
+func WithRollupLogger(l *slog.Logger) UsageRollupOption {
+	return func(u *UsageRollup) { u.logger = l }
+}
+
+// NewUsageRollup builds a rollup. prom may be nil (storage-only).
+func NewUsageRollup(repo Repository, prom *promquery.Client, opts ...UsageRollupOption) *UsageRollup {
+	u := &UsageRollup{
+		repo:   repo,
+		prom:   prom,
+		tick:   time.Hour,
+		logger: slog.Default(),
+	}
+	for _, opt := range opts {
+		opt(u)
+	}
+	return u
+}
+
+// Start runs an immediate rollup then repeats every tick until Stop.
+func (u *UsageRollup) Start() {
+	ctx, cancel := context.WithCancel(context.Background())
+	u.cancel = cancel
+	u.wg.Add(1)
+	go func() {
+		defer u.wg.Done()
+		t := time.NewTicker(u.tick)
+		defer t.Stop()
+		u.runOnce(ctx) // seed immediately so the dashboard isn't empty on boot
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-t.C:
+				u.runOnce(ctx)
+			}
+		}
+	}()
+}
+
+// Stop cancels the loop and waits for the in-flight run to finish.
+func (u *UsageRollup) Stop() {
+	if u.cancel != nil {
+		u.cancel()
+	}
+	u.wg.Wait()
+}
+
+// runOnce upserts every tenant's row for the current UTC day. Errors are logged,
+// not fatal — a transient Prometheus or DB blip should not kill the loop.
+func (u *UsageRollup) runOnce(ctx context.Context) {
+	day := time.Now().UTC()
+
+	storage, err := u.repo.ListTenantStorage(ctx)
+	if err != nil {
+		u.logger.Error("usage rollup: list tenant storage", "error", err)
+		return
+	}
+
+	var messages, deploys map[string]float64
+	if u.prom != nil {
+		if messages, err = u.prom.QueryByLabel(ctx, usageMessagesQuery, "tenant_id"); err != nil {
+			u.logger.Warn("usage rollup: query messages", "error", err)
+			messages = map[string]float64{}
+		}
+		if deploys, err = u.prom.QueryByLabel(ctx, usageDeploysQuery, "tenant_id"); err != nil {
+			u.logger.Warn("usage rollup: query deploys", "error", err)
+			deploys = map[string]float64{}
+		}
+	}
+
+	// Tenant set = union of storage rows + any tenant seen in the metrics.
+	tenants := make(map[string]struct{}, len(storage))
+	for id := range storage {
+		tenants[id] = struct{}{}
+	}
+	for id := range messages {
+		tenants[id] = struct{}{}
+	}
+	for id := range deploys {
+		tenants[id] = struct{}{}
+	}
+
+	var written, failed int
+	for id := range tenants {
+		if err := u.repo.UpsertUsageDaily(ctx, id, day,
+			roundCounter(messages[id]), roundCounter(deploys[id]), storage[id]); err != nil {
+			u.logger.Error("usage rollup: upsert", "tenant_id", id, "error", err)
+			failed++
+			continue
+		}
+		written++
+	}
+	u.logger.Info("usage rollup complete", "day", day.Format("2006-01-02"),
+		"tenants", written, "failed", failed, "prometheus", u.prom != nil)
+}
+
+// roundCounter rounds a non-negative Prometheus increase() value to a count.
+// increase() can yield small fractional values from interpolation across scrape
+// boundaries; rounding gives a clean message/deploy count.
+func roundCounter(v float64) int64 {
+	if v <= 0 || math.IsNaN(v) {
+		return 0
+	}
+	return int64(math.Round(v))
+}

--- a/src/pkg/managementapi/usage_rollup.go
+++ b/src/pkg/managementapi/usage_rollup.go
@@ -2,6 +2,7 @@ package managementapi
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"math"
 	"sync"
@@ -28,12 +29,21 @@ type UsageRollup struct {
 	wg     sync.WaitGroup
 }
 
-// PromQL the rollup evaluates. increase() over 24h gives the day's delta and is
-// resilient to counter resets on worker restart.
+// Counters the rollup snapshots. increase() is reset-aware, so it survives
+// worker/API restarts that zero the counter.
 const (
-	usageMessagesQuery = `sum by (tenant_id) (increase(vrsky_messages_published_total[24h]))`
-	usageDeploysQuery  = `sum by (tenant_id) (increase(vrsky_connection_deploys_total[24h]))`
+	usageMessagesMetric = "vrsky_messages_published_total"
+	usageDeploysMetric  = "vrsky_connection_deploys_total"
 )
+
+// dayDeltaQuery builds a PromQL instant query for a counter's increase over the
+// window (windowSec) ending at endUnix, summed by tenant_id. Anchoring the
+// window to a calendar-day boundary with the @ modifier — rather than a rolling
+// [24h] — keeps each usage_daily row scoped to exactly one UTC day, which is
+// what billing needs.
+func dayDeltaQuery(metric string, windowSec, endUnix int64) string {
+	return fmt.Sprintf("sum by (tenant_id) (increase(%s[%ds] @ %d))", metric, windowSec, endUnix)
+}
 
 // UsageRollupOption tunes the rollup at construction.
 type UsageRollupOption func(*UsageRollup)
@@ -91,10 +101,15 @@ func (u *UsageRollup) Stop() {
 	u.wg.Wait()
 }
 
-// runOnce upserts every tenant's row for the current UTC day. Errors are logged,
-// not fatal — a transient Prometheus or DB blip should not kill the loop.
+// runOnce refreshes today's row (midnight → now) and finalizes yesterday's full
+// calendar day. Running hourly keeps today's totals fresh and converging to the
+// true day total; finalizing yesterday closes the midnight gap so a complete
+// day is never left as a partial rolling window. Errors are logged, not fatal —
+// a transient Prometheus or DB blip should not kill the loop.
 func (u *UsageRollup) runOnce(ctx context.Context) {
-	day := time.Now().UTC()
+	now := time.Now().UTC()
+	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
+	yesterday := today.AddDate(0, 0, -1)
 
 	storage, err := u.repo.ListTenantStorage(ctx)
 	if err != nil {
@@ -102,14 +117,33 @@ func (u *UsageRollup) runOnce(ctx context.Context) {
 		return
 	}
 
+	// Today: window [midnight, now]; storage = current snapshot.
+	todayWindow := int64(now.Sub(today).Seconds())
+	if todayWindow < 1 {
+		todayWindow = 1
+	}
+	u.rollupDay(ctx, today, todayWindow, now.Unix(), storage, true)
+
+	// Yesterday: full day [yesterday-midnight, today-midnight]. Counter deltas
+	// are a fixed past window (stable across re-runs); storage is preserved from
+	// yesterday's own last snapshot rather than overwritten with today's.
+	u.rollupDay(ctx, yesterday, 86400, today.Unix(), storage, false)
+}
+
+// rollupDay upserts one day's row for every tenant. windowSec/endUnix define the
+// counter-delta window. When setStorage is true the current storage snapshot is
+// written; otherwise the day's existing stored storage is preserved (so
+// finalizing a past day doesn't clobber it with today's value).
+func (u *UsageRollup) rollupDay(ctx context.Context, day time.Time, windowSec, endUnix int64, storage map[string]int64, setStorage bool) {
 	var messages, deploys map[string]float64
 	if u.prom != nil {
-		if messages, err = u.prom.QueryByLabel(ctx, usageMessagesQuery, "tenant_id"); err != nil {
-			u.logger.Warn("usage rollup: query messages", "error", err)
+		var err error
+		if messages, err = u.prom.QueryByLabel(ctx, dayDeltaQuery(usageMessagesMetric, windowSec, endUnix), "tenant_id"); err != nil {
+			u.logger.Warn("usage rollup: query messages", "day", day.Format("2006-01-02"), "error", err)
 			messages = map[string]float64{}
 		}
-		if deploys, err = u.prom.QueryByLabel(ctx, usageDeploysQuery, "tenant_id"); err != nil {
-			u.logger.Warn("usage rollup: query deploys", "error", err)
+		if deploys, err = u.prom.QueryByLabel(ctx, dayDeltaQuery(usageDeploysMetric, windowSec, endUnix), "tenant_id"); err != nil {
+			u.logger.Warn("usage rollup: query deploys", "day", day.Format("2006-01-02"), "error", err)
 			deploys = map[string]float64{}
 		}
 	}
@@ -128,15 +162,22 @@ func (u *UsageRollup) runOnce(ctx context.Context) {
 
 	var written, failed int
 	for id := range tenants {
+		storageVal := storage[id]
+		if !setStorage {
+			// Preserve the day's own stored storage if a row already exists.
+			if rows, err := u.repo.ListUsageDaily(ctx, id, day, day); err == nil && len(rows) == 1 {
+				storageVal = rows[0].StorageBytes
+			}
+		}
 		if err := u.repo.UpsertUsageDaily(ctx, id, day,
-			roundCounter(messages[id]), roundCounter(deploys[id]), storage[id]); err != nil {
-			u.logger.Error("usage rollup: upsert", "tenant_id", id, "error", err)
+			roundCounter(messages[id]), roundCounter(deploys[id]), storageVal); err != nil {
+			u.logger.Error("usage rollup: upsert", "tenant_id", id, "day", day.Format("2006-01-02"), "error", err)
 			failed++
 			continue
 		}
 		written++
 	}
-	u.logger.Info("usage rollup complete", "day", day.Format("2006-01-02"),
+	u.logger.Info("usage rollup day complete", "day", day.Format("2006-01-02"),
 		"tenants", written, "failed", failed, "prometheus", u.prom != nil)
 }
 

--- a/src/pkg/managementapi/usage_rollup_test.go
+++ b/src/pkg/managementapi/usage_rollup_test.go
@@ -85,6 +85,14 @@ func TestUsageRollup_RunOnce(t *testing.T) {
 	if len(rows2) != 1 || rows2[0].Deploys != 0 {
 		t.Errorf("t-2 row = %+v, want one row with deploys=0", rows2)
 	}
+
+	// The run also finalizes yesterday (closing the midnight gap), so a
+	// yesterday row exists with the day-anchored counter delta.
+	yesterday := today.AddDate(0, 0, -1)
+	yrows, _ := repo.ListUsageDaily(ctx, "t-1", yesterday, yesterday)
+	if len(yrows) != 1 {
+		t.Fatalf("t-1 yesterday rows = %d, want 1 (finalized)", len(yrows))
+	}
 }
 
 func TestUsageRollup_StorageOnlyWhenNoProm(t *testing.T) {

--- a/src/pkg/managementapi/usage_rollup_test.go
+++ b/src/pkg/managementapi/usage_rollup_test.go
@@ -1,0 +1,103 @@
+package managementapi
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ValueRetail/vrsky/pkg/promquery"
+)
+
+// fakeProm returns a Prometheus-shaped vector keyed by tenant_id, choosing the
+// payload by whether the query is for messages or deploys.
+func fakeProm(t *testing.T, messages, deploys map[string]string) *httptest.Server {
+	t.Helper()
+	vec := func(vals map[string]string) string {
+		var b strings.Builder
+		b.WriteString(`{"status":"success","data":{"resultType":"vector","result":[`)
+		first := true
+		for tid, v := range vals {
+			if !first {
+				b.WriteString(",")
+			}
+			first = false
+			b.WriteString(`{"metric":{"tenant_id":"` + tid + `"},"value":[1718000000,"` + v + `"]}`)
+		}
+		b.WriteString(`]}}`)
+		return b.String()
+	}
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query().Get("query")
+		w.Header().Set("Content-Type", "application/json")
+		if strings.Contains(q, "deploys") {
+			_, _ = w.Write([]byte(vec(deploys)))
+		} else {
+			_, _ = w.Write([]byte(vec(messages)))
+		}
+	}))
+}
+
+func quietRollup(repo Repository, prom *promquery.Client) *UsageRollup {
+	return NewUsageRollup(repo, prom,
+		WithRollupLogger(slog.New(slog.NewTextHandler(io.Discard, nil))))
+}
+
+func TestUsageRollup_RunOnce(t *testing.T) {
+	ctx := context.Background()
+	repo := NewMockRepository()
+	// Two tenants with storage rows.
+	_, _ = repo.GetTenantQuotas(ctx, "t-1")
+	_ = repo.SetTenantStorageUsage(ctx, "t-1", 4096)
+	_, _ = repo.GetTenantQuotas(ctx, "t-2")
+	_ = repo.SetTenantStorageUsage(ctx, "t-2", 0)
+
+	srv := fakeProm(t,
+		map[string]string{"t-1": "42.4", "t-2": "0"}, // messages (fractional → rounds to 42)
+		map[string]string{"t-1": "3"},                // deploys (only t-1)
+	)
+	defer srv.Close()
+
+	quietRollup(repo, promquery.New(srv.URL, srv.Client())).runOnce(ctx)
+
+	today := time.Now().UTC()
+	rows, _ := repo.ListUsageDaily(ctx, "t-1", today, today)
+	if len(rows) != 1 {
+		t.Fatalf("t-1 rows = %d, want 1", len(rows))
+	}
+	got := rows[0]
+	if got.MessagesPublished != 42 {
+		t.Errorf("messages = %d, want 42 (rounded)", got.MessagesPublished)
+	}
+	if got.Deploys != 3 {
+		t.Errorf("deploys = %d, want 3", got.Deploys)
+	}
+	if got.StorageBytes != 4096 {
+		t.Errorf("storage = %d, want 4096", got.StorageBytes)
+	}
+
+	// t-2 had storage but no deploys → messages 0, deploys 0, storage 0.
+	rows2, _ := repo.ListUsageDaily(ctx, "t-2", today, today)
+	if len(rows2) != 1 || rows2[0].Deploys != 0 {
+		t.Errorf("t-2 row = %+v, want one row with deploys=0", rows2)
+	}
+}
+
+func TestUsageRollup_StorageOnlyWhenNoProm(t *testing.T) {
+	ctx := context.Background()
+	repo := NewMockRepository()
+	_, _ = repo.GetTenantQuotas(ctx, "t-1")
+	_ = repo.SetTenantStorageUsage(ctx, "t-1", 9999)
+
+	quietRollup(repo, nil).runOnce(ctx) // nil prom → storage-only
+
+	today := time.Now().UTC()
+	rows, _ := repo.ListUsageDaily(ctx, "t-1", today, today)
+	if len(rows) != 1 || rows[0].StorageBytes != 9999 || rows[0].MessagesPublished != 0 {
+		t.Errorf("row = %+v, want storage=9999 messages=0", rows)
+	}
+}

--- a/src/pkg/promquery/promquery.go
+++ b/src/pkg/promquery/promquery.go
@@ -1,0 +1,95 @@
+// Package promquery is a minimal read-only Prometheus HTTP API client. The
+// management-api uses it for the per-tenant usage rollup (#92): it issues instant
+// queries and folds the vector result into a tenant_id → value map. It is
+// deliberately tiny — no push, no range queries, no auth — because the only
+// caller runs against the in-cluster Prometheus over the private network.
+package promquery
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+)
+
+// Client queries a Prometheus server's instant-query endpoint.
+type Client struct {
+	baseURL string
+	http    *http.Client
+}
+
+// New returns a Client for the given Prometheus base URL (e.g.
+// "http://prometheus:9090"). A nil httpClient gets a 10s-timeout default.
+func New(baseURL string, httpClient *http.Client) *Client {
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: 10 * time.Second}
+	}
+	return &Client{baseURL: baseURL, http: httpClient}
+}
+
+// promResponse is the subset of the Prometheus query API envelope we read.
+type promResponse struct {
+	Status string `json:"status"`
+	Data   struct {
+		ResultType string `json:"resultType"`
+		Result     []struct {
+			Metric map[string]string `json:"metric"`
+			// value is [ <unix_ts float>, "<sample as string>" ].
+			Value []json.RawMessage `json:"value"`
+		} `json:"result"`
+	} `json:"data"`
+	ErrorType string `json:"errorType"`
+	Error     string `json:"error"`
+}
+
+// QueryByLabel runs an instant query and returns a map keyed by the value of
+// label on each result series → the series' scalar sample. Series missing the
+// label, or whose sample is NaN/unparseable, are skipped. An empty/zero result
+// is not an error (returns an empty map). Use this for rollups like
+// `sum by (tenant_id)(increase(metric[24h]))` with label="tenant_id".
+func (c *Client) QueryByLabel(ctx context.Context, query, label string) (map[string]float64, error) {
+	u := c.baseURL + "/api/v1/query?" + url.Values{"query": {query}}.Encode()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("query prometheus: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("prometheus returned %d", resp.StatusCode)
+	}
+
+	var pr promResponse
+	if err := json.NewDecoder(resp.Body).Decode(&pr); err != nil {
+		return nil, fmt.Errorf("decode prometheus response: %w", err)
+	}
+	if pr.Status != "success" {
+		return nil, fmt.Errorf("prometheus query failed: %s: %s", pr.ErrorType, pr.Error)
+	}
+
+	out := make(map[string]float64, len(pr.Data.Result))
+	for _, series := range pr.Data.Result {
+		key, ok := series.Metric[label]
+		if !ok || key == "" || len(series.Value) != 2 {
+			continue
+		}
+		var sample string
+		if err := json.Unmarshal(series.Value[1], &sample); err != nil {
+			continue
+		}
+		v, err := strconv.ParseFloat(sample, 64)
+		if err != nil || math.IsNaN(v) || math.IsInf(v, 0) {
+			continue // "NaN"/"+Inf" parse to non-finite floats — drop them
+		}
+		out[key] = v
+	}
+	return out, nil
+}

--- a/src/pkg/promquery/promquery.go
+++ b/src/pkg/promquery/promquery.go
@@ -74,6 +74,12 @@ func (c *Client) QueryByLabel(ctx context.Context, query, label string) (map[str
 	if pr.Status != "success" {
 		return nil, fmt.Errorf("prometheus query failed: %s: %s", pr.ErrorType, pr.Error)
 	}
+	// QueryByLabel reads instant-vector samples. A non-vector result (e.g. a
+	// matrix from a range query) would decode fine but yield an empty map,
+	// silently masking a query mistake — fail loudly instead.
+	if pr.Data.ResultType != "" && pr.Data.ResultType != "vector" {
+		return nil, fmt.Errorf("prometheus returned %q result, want vector", pr.Data.ResultType)
+	}
 
 	out := make(map[string]float64, len(pr.Data.Result))
 	for _, series := range pr.Data.Result {

--- a/src/pkg/promquery/promquery_test.go
+++ b/src/pkg/promquery/promquery_test.go
@@ -69,4 +69,14 @@ func TestQueryByLabel_Errors(t *testing.T) {
 	if _, err := New(down.URL, down.Client()).QueryByLabel(context.Background(), "x", "tenant_id"); err == nil {
 		t.Error("expected error on 500 response")
 	}
+
+	// Non-vector result (e.g. a matrix from a range query) is rejected loudly
+	// rather than silently returning an empty map.
+	matrix := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"status":"success","data":{"resultType":"matrix","result":[]}}`))
+	}))
+	defer matrix.Close()
+	if _, err := New(matrix.URL, matrix.Client()).QueryByLabel(context.Background(), "x", "tenant_id"); err == nil {
+		t.Error("expected error on non-vector (matrix) result")
+	}
 }

--- a/src/pkg/promquery/promquery_test.go
+++ b/src/pkg/promquery/promquery_test.go
@@ -1,0 +1,72 @@
+package promquery
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestQueryByLabel(t *testing.T) {
+	const body = `{
+	  "status": "success",
+	  "data": {
+	    "resultType": "vector",
+	    "result": [
+	      {"metric": {"tenant_id": "t-1"}, "value": [1718000000, "42"]},
+	      {"metric": {"tenant_id": "t-2"}, "value": [1718000000, "7.5"]},
+	      {"metric": {"other": "x"},       "value": [1718000000, "99"]},
+	      {"metric": {"tenant_id": "t-3"}, "value": [1718000000, "NaN"]}
+	    ]
+	  }
+	}`
+	var gotQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.Query().Get("query")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, srv.Client())
+	got, err := c.QueryByLabel(context.Background(), `sum by (tenant_id)(increase(vrsky_messages_published_total[24h]))`, "tenant_id")
+	if err != nil {
+		t.Fatalf("QueryByLabel: %v", err)
+	}
+	if gotQuery == "" {
+		t.Error("query param was not forwarded")
+	}
+	if got["t-1"] != 42 {
+		t.Errorf("t-1 = %v, want 42", got["t-1"])
+	}
+	if got["t-2"] != 7.5 {
+		t.Errorf("t-2 = %v, want 7.5", got["t-2"])
+	}
+	// Series without the label is skipped; NaN sample is skipped.
+	if _, ok := got["t-3"]; ok {
+		t.Error("NaN sample should be skipped")
+	}
+	if len(got) != 2 {
+		t.Errorf("len = %d, want 2 (label-less + NaN series dropped)", len(got))
+	}
+}
+
+func TestQueryByLabel_Errors(t *testing.T) {
+	// Prometheus-level error.
+	bad := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"status":"error","errorType":"bad_data","error":"parse error"}`))
+	}))
+	defer bad.Close()
+	if _, err := New(bad.URL, bad.Client()).QueryByLabel(context.Background(), "x", "tenant_id"); err == nil {
+		t.Error("expected error on status=error response")
+	}
+
+	// HTTP-level error.
+	down := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer down.Close()
+	if _, err := New(down.URL, down.Client()).QueryByLabel(context.Background(), "x", "tenant_id"); err == nil {
+		t.Error("expected error on 500 response")
+	}
+}

--- a/ui/src/pages/UsagePage.tsx
+++ b/ui/src/pages/UsagePage.tsx
@@ -83,16 +83,21 @@ export default function UsagePage() {
 
   useEffect(() => {
     if (!currentTenant) return
+    // ignore guards against a slow response from a previous tenant landing after
+    // the user has switched — which would otherwise show cross-tenant data.
+    let ignore = false
     setLoading(true)
     setError(null)
+    setUsage(null) // clear the prior tenant's card before the new request resolves
     getQuotas(currentTenant.id)
-      .then(reset)
-      .catch((e) => setError(e instanceof Error ? e.message : 'Failed to load quotas'))
-      .finally(() => setLoading(false))
+      .then((next) => { if (!ignore) reset(next) })
+      .catch((e) => { if (!ignore) setError(e instanceof Error ? e.message : 'Failed to load quotas') })
+      .finally(() => { if (!ignore) setLoading(false) })
     // Usage is non-critical: a failure here shouldn't blank the quota editor.
     getUsage(currentTenant.id)
-      .then(setUsage)
-      .catch(() => setUsage(null))
+      .then((u) => { if (!ignore) setUsage(u) })
+      .catch(() => { if (!ignore) setUsage(null) })
+    return () => { ignore = true }
   }, [currentTenant?.id])
 
   const exportCSV = async () => {

--- a/ui/src/pages/UsagePage.tsx
+++ b/ui/src/pages/UsagePage.tsx
@@ -8,6 +8,8 @@
 import { useEffect, useState } from 'react'
 import { useAuthStore } from '@/store/authStore'
 import { getQuotas, updateQuotas, type TenantQuotas } from '@/services/quotasService'
+import { getUsage, usageExportURL, type UsageResponse } from '@/services/usageService'
+import apiClient from '@/services/api'
 
 function fmtBytes(n: number): string {
   const units = ['B', 'KiB', 'MiB', 'GiB', 'TiB']
@@ -62,6 +64,9 @@ export default function UsagePage() {
   const [error, setError] = useState<string | null>(null)
   const [busy, setBusy] = useState(false)
 
+  // Usage metering (#92): current-month consumption from the daily rollup.
+  const [usage, setUsage] = useState<UsageResponse | null>(null)
+
   // Editable copies of the configurable fields.
   const [planName, setPlanName] = useState('')
   const [maxMsg, setMaxMsg] = useState(0)
@@ -84,7 +89,27 @@ export default function UsagePage() {
       .then(reset)
       .catch((e) => setError(e instanceof Error ? e.message : 'Failed to load quotas'))
       .finally(() => setLoading(false))
+    // Usage is non-critical: a failure here shouldn't blank the quota editor.
+    getUsage(currentTenant.id)
+      .then(setUsage)
+      .catch(() => setUsage(null))
   }, [currentTenant?.id])
+
+  const exportCSV = async () => {
+    if (!currentTenant) return
+    try {
+      // Fetch via apiClient (not window.open) so the X-Tenant-ID header is sent.
+      const resp = await apiClient.get(usageExportURL(currentTenant.id), { responseType: 'blob' })
+      const url = URL.createObjectURL(new Blob([resp.data], { type: 'text/csv' }))
+      const a = document.createElement('a')
+      a.href = url
+      a.download = `vrsky-usage-${new Date().toISOString().slice(0, 10)}.csv`
+      a.click()
+      URL.revokeObjectURL(url)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Export failed')
+    }
+  }
 
   const save = async () => {
     if (!currentTenant || !q) return
@@ -122,6 +147,60 @@ export default function UsagePage() {
       {error && (
         <div style={{ padding: '10px', background: '#fef2f2', color: '#991b1b', fontSize: '13px', borderRadius: '6px', marginBottom: '12px' }}>
           {error}
+        </div>
+      )}
+
+      {usage && (
+        <div style={card}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '12px' }}>
+            <strong style={{ fontSize: '14px' }}>Usage this month</strong>
+            <button
+              onClick={exportCSV}
+              style={{ padding: '6px 12px', background: '#fff', color: '#374151', border: '1px solid #d1d5db', borderRadius: '6px', fontSize: '12px', cursor: 'pointer' }}
+            >
+              Export CSV
+            </button>
+          </div>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: '12px', marginBottom: usage.daily.length ? '14px' : 0 }}>
+            <div>
+              <span style={label}>Messages</span>
+              <div style={{ fontSize: '22px', fontWeight: 600 }}>{usage.month.messages_published.toLocaleString()}</div>
+            </div>
+            <div>
+              <span style={label}>Deploys</span>
+              <div style={{ fontSize: '22px', fontWeight: 600 }}>{usage.month.deploys.toLocaleString()}</div>
+            </div>
+            <div>
+              <span style={label}>Storage</span>
+              <div style={{ fontSize: '22px', fontWeight: 600 }}>{fmtBytes(usage.month.storage_bytes)}</div>
+            </div>
+          </div>
+          {usage.daily.length > 0 ? (
+            <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '12px' }}>
+              <thead>
+                <tr style={{ textAlign: 'left', color: '#6b7280' }}>
+                  <th style={{ padding: '4px 0', fontWeight: 600 }}>Day</th>
+                  <th style={{ padding: '4px 0', fontWeight: 600, textAlign: 'right' }}>Messages</th>
+                  <th style={{ padding: '4px 0', fontWeight: 600, textAlign: 'right' }}>Deploys</th>
+                  <th style={{ padding: '4px 0', fontWeight: 600, textAlign: 'right' }}>Storage</th>
+                </tr>
+              </thead>
+              <tbody>
+                {usage.daily.map((d) => (
+                  <tr key={d.day} style={{ borderTop: '1px solid #f3f4f6' }}>
+                    <td style={{ padding: '4px 0' }}>{d.day}</td>
+                    <td style={{ padding: '4px 0', textAlign: 'right' }}>{d.messages_published.toLocaleString()}</td>
+                    <td style={{ padding: '4px 0', textAlign: 'right' }}>{d.deploys.toLocaleString()}</td>
+                    <td style={{ padding: '4px 0', textAlign: 'right' }}>{fmtBytes(d.storage_bytes)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          ) : (
+            <p style={{ fontSize: '12px', color: '#6b7280', margin: 0 }}>
+              No usage recorded yet this month.
+            </p>
+          )}
         </div>
       )}
 

--- a/ui/src/services/usageService.ts
+++ b/ui/src/services/usageService.ts
@@ -1,0 +1,53 @@
+/**
+ * Per-tenant usage metering service — Phase 4A (#92).
+ *
+ * Reads current-month (or a custom range) message/deploy/storage usage and
+ * builds the CSV-export URL. The export is fetched as a blob via apiClient (not
+ * window.open) so the X-Tenant-ID header from the axios interceptor is attached.
+ */
+
+import apiClient from './api'
+
+export interface UsageDaily {
+  day: string
+  messages_published: number
+  deploys: number
+  storage_bytes: number
+}
+
+export interface UsageTotals {
+  messages_published: number
+  deploys: number
+  storage_bytes: number
+}
+
+export interface UsageResponse {
+  from: string
+  to: string
+  month: UsageTotals
+  daily: UsageDaily[]
+}
+
+interface Envelope<T> { data: T }
+
+function rangeParams(from?: string, to?: string): string {
+  const p = new URLSearchParams()
+  if (from) p.set('from', from)
+  if (to) p.set('to', to)
+  const s = p.toString()
+  return s ? `?${s}` : ''
+}
+
+export async function getUsage(tenantID: string, from?: string, to?: string): Promise<UsageResponse> {
+  const resp = await apiClient.get<Envelope<UsageResponse>>(
+    `/api/v1/tenants/${tenantID}/usage${rangeParams(from, to)}`,
+  )
+  return resp.data.data
+}
+
+export function usageExportURL(tenantID: string, from?: string, to?: string): string {
+  const p = new URLSearchParams({ format: 'csv' })
+  if (from) p.set('from', from)
+  if (to) p.set('to', to)
+  return `/api/v1/tenants/${tenantID}/usage/export?${p.toString()}`
+}


### PR DESCRIPTION
First **Phase 4 (Commercial)** item: make VRSky billable. Counts **messages, deploys and storage** per tenant, snapshots them daily into `usage_daily`, surfaces current-month usage on the **Usage & quotas** settings page, and exports CSV for handoff to a billing/invoice system.

## Design
- **Messages** are already counted (`vrsky_messages_published_total{tenant_id}`, publisher.go) — the new work is the durable **Prometheus → Postgres daily snapshot**, which is exactly the acceptance criterion ("counters survive restart — Prometheus + Postgres snapshot").
- **Deploys**: new `vrsky_connection_deploys_total{tenant_id}` counter incremented on each successful connection start.
- **Storage**: snapshot of `tenant_quotas.storage_bytes`.

## Changes
- **`infrastructure/migrations/000016_usage_daily`** — `(tenant_id, day)` PK + messages/deploys/storage_bytes; added to the tenant-isolation linter allowlist.
- **`pkg/promquery`** (new) — minimal Prometheus instant-query client, folds a vector result into a `label → value` map.
- **`UsageRollup`** — hourly job: `increase(metric[24h])` by `tenant_id` for messages/deploys + `tenant_quotas` storage → idempotent upsert into `usage_daily`. Runs on boot, re-derives the live day after a restart; prior days persist. `PROMETHEUS_URL` unset → storage-only.
- **API** — `GET /api/v1/tenants/{id}/usage[?from=&to=]` (month totals + daily rows) and `…/usage/export?format=csv`. Repo: `UpsertUsageDaily` / `ListUsageDaily` / `SumUsage` / `ListTenantStorage`.
- **UI** — `usageService.ts` + a "Usage this month" section on `UsagePage` (stat cards + daily table + Export CSV). Extends the existing #74 quota page rather than duplicating it.
- **compose** — `PROMETHEUS_URL` for management-api. **docs/OBSERVABILITY.md** — usage-metering section.

## Verification
- **Unit:** promquery parse + error paths; usage handler GET (with tenant-isolation check) + CSV; rollup `runOnce` (Prometheus-backed + storage-only). Go build/vet/gofmt, golangci-lint v1.64.8, tenant-filter linter, UI typecheck/build — all clean.
- **Live (compose):** applied migration; deployed a webhook→http connection (deploys) + sent 8 webhooks (messages); after Prometheus scrapes the rollup wrote `usage_daily`; `GET /usage` → `messages=8, deploys=2`; CSV downloaded with correct headers; totals **survived an API restart** (acceptance #1).

## Notes
- `deploys` via `increase()` undercounts the very first deploy of a freshly-created counter series by ~1 (standard Prometheus cold-start behaviour); steady-state deploys are captured, and the count is reset-aware across API restarts.
- A live **Stripe API** integration is out of scope — CSV export is the billing handoff the issue asks for.

Closes #92.

🤖 Generated with [Claude Code](https://claude.com/claude-code)