### PR TITLE
feat(#93): first-login onboarding wizard with templates (Phase 4B)

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -24,6 +24,7 @@ import UsersPage from './pages/UsersPage'
 import UsagePage from './pages/UsagePage'
 import OAuthProvidersPage from './pages/OAuthProvidersPage'
 import NotificationsPage from './pages/NotificationsPage'
+import OnboardingWizard from './onboarding/OnboardingWizard'
 
 function App() {
   const { confirmDialog, hideConfirmDialog } = useUIStore()
@@ -58,6 +59,12 @@ function App() {
           <Route path="/connections/create" element={
             <ProtectedRoute>
               <PipelineBuilderPage />
+            </ProtectedRoute>
+          } />
+          {/* First-login onboarding wizard (#93) */}
+          <Route path="/welcome" element={
+            <ProtectedRoute>
+              <OnboardingWizard />
             </ProtectedRoute>
           } />
           

--- a/ui/src/config/env.ts
+++ b/ui/src/config/env.ts
@@ -23,6 +23,11 @@ export const config = {
   isDev: import.meta.env.DEV,
   isProd: import.meta.env.PROD,
   fileProducerUrl: getEnv('VITE_FILE_PRODUCER_URL', 'http://localhost:9900'),
+  // Public base URL of the webhook-consumer ingress. The onboarding wizard (#93)
+  // surfaces `${webhookIngressUrl}/webhook/{id}` and POSTs the sample event to
+  // it. Defaults to the local compose port; override in deployments where
+  // webhooks enter via the gateway/public host.
+  webhookIngressUrl: getEnv('VITE_WEBHOOK_INGRESS_URL', 'http://localhost:9100'),
   // Optional bearer token for the file-producer's /files API. Empty in local
   // dev (the server leaves auth disabled); set in deployments that enable
   // FILE_PRODUCER_AUTH_TOKEN on the file-producer. Read directly because an

--- a/ui/src/onboarding/OnboardingWizard.tsx
+++ b/ui/src/onboarding/OnboardingWizard.tsx
@@ -11,6 +11,7 @@
 import { useMemo, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import apiClient from '../services/api'
+import { config } from '../config/env'
 import { useAuthStore } from '../store/authStore'
 import { materializeSecrets } from '../utils/secrets'
 import SecretInput from '../components/Pipeline/SecretInput'
@@ -19,6 +20,9 @@ import { markOnboarded } from './state'
 
 // --- nested config helpers ------------------------------------------------
 
+// getObj resolves (and creates) the nested object at objectPath. It MUTATES
+// root, so only call it on a cloned config inside a setConfigs updater — never
+// during render or on a state object directly.
 function getObj(root: Record<string, unknown>, objectPath: string): Record<string, unknown> {
   if (!objectPath) return root
   let cur = root
@@ -27,6 +31,19 @@ function getObj(root: Record<string, unknown>, objectPath: string): Record<strin
     cur = cur[part] as Record<string, unknown>
   }
   return cur
+}
+
+// readObj is the non-mutating counterpart used during render and in derived
+// state: it never creates intermediate objects (so it can't mutate React
+// state), returning an empty object when the path is absent.
+function readObj(root: Record<string, unknown>, objectPath: string): Record<string, unknown> {
+  if (!objectPath) return root
+  let cur: unknown = root
+  for (const part of objectPath.split('.')) {
+    if (!cur || typeof cur !== 'object') return {}
+    cur = (cur as Record<string, unknown>)[part]
+  }
+  return cur && typeof cur === 'object' ? (cur as Record<string, unknown>) : {}
 }
 
 // --- styles (inline, matching the rest of the app) ------------------------
@@ -89,13 +106,20 @@ export default function OnboardingWizard() {
     })
   }
 
-  // Required non-secret fields must be filled before deploy.
+  // Every template field is required before deploy. A secret field is satisfied
+  // by either freshly-typed plaintext (`key`) or an already-bound secret
+  // (`key_secret_id`); a text field by a non-empty string.
   const missing = useMemo(() => {
     if (!template) return []
     return template.fields.filter((f) => {
-      if (f.secret) return false // secrets optional here; user may reuse env creds
-      const v = getObj(configs[f.nodeId] || {}, f.objectPath)[f.key]
-      return typeof v !== 'string' || v.trim() === ''
+      const obj = readObj(configs[f.nodeId] || {}, f.objectPath)
+      const v = obj[f.key]
+      const filled = typeof v === 'string' && v.trim() !== ''
+      if (f.secret) {
+        const bound = obj[`${f.key}_secret_id`]
+        return !filled && !(typeof bound === 'string' && bound !== '')
+      }
+      return !filled
     })
   }, [template, configs])
 
@@ -127,7 +151,7 @@ export default function OnboardingWizard() {
         /* best-effort auto-start; connection still created */
       }
       setDeployedId(id)
-      if (template.webhookSource) setWebhookUrl(`http://localhost:9100/webhook/${id}`)
+      if (template.webhookSource) setWebhookUrl(`${config.webhookIngressUrl}/webhook/${id}`)
       markOnboarded(currentTenant?.id)
       setStep('done')
     } catch (e) {
@@ -204,7 +228,7 @@ export default function OnboardingWizard() {
           </div>
 
           {template.fields.map((f) => {
-            const obj = getObj(configs[f.nodeId] || {}, f.objectPath)
+            const obj = readObj(configs[f.nodeId] || {}, f.objectPath)
             return (
               <div style={card} key={`${f.nodeId}.${f.objectPath}.${f.key}`}>
                 {f.secret ? (
@@ -231,7 +255,7 @@ export default function OnboardingWizard() {
                   {f.link && (
                     <>
                       {' '}
-                      <a href={f.link.url} target="_blank" rel="noreferrer" style={{ color: '#2563eb' }}>
+                      <a href={f.link.url} target="_blank" rel="noopener noreferrer" style={{ color: '#2563eb' }}>
                         {f.link.text} ↗
                       </a>
                     </>

--- a/ui/src/onboarding/OnboardingWizard.tsx
+++ b/ui/src/onboarding/OnboardingWizard.tsx
@@ -1,0 +1,291 @@
+/**
+ * First-login onboarding wizard (Phase 4B / #93).
+ *
+ * Walks a non-developer from a template gallery to a deployed, running pipeline
+ * in a few steps: pick a template → fill the handful of fields it needs (mostly
+ * credentials) → deploy → see it work. It reuses the same deploy path as the
+ * visual builder (createConnection → materializeSecrets → start), so nothing
+ * plaintext is persisted and the result is a normal connection.
+ */
+
+import { useMemo, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import apiClient from '../services/api'
+import { useAuthStore } from '../store/authStore'
+import { materializeSecrets } from '../utils/secrets'
+import SecretInput from '../components/Pipeline/SecretInput'
+import { TEMPLATES, type PipelineTemplate, type TemplateField } from './templates'
+import { markOnboarded } from './state'
+
+// --- nested config helpers ------------------------------------------------
+
+function getObj(root: Record<string, unknown>, objectPath: string): Record<string, unknown> {
+  if (!objectPath) return root
+  let cur = root
+  for (const part of objectPath.split('.')) {
+    if (typeof cur[part] !== 'object' || cur[part] === null) cur[part] = {}
+    cur = cur[part] as Record<string, unknown>
+  }
+  return cur
+}
+
+// --- styles (inline, matching the rest of the app) ------------------------
+
+const page: React.CSSProperties = { maxWidth: '860px', margin: '0 auto', padding: '40px 20px' }
+const card: React.CSSProperties = { background: '#fff', border: '1px solid #e5e7eb', borderRadius: '10px', padding: '20px', marginBottom: '14px' }
+const label: React.CSSProperties = { display: 'block', fontSize: '12px', fontWeight: 600, color: '#374151', marginBottom: '4px' }
+const help: React.CSSProperties = { fontSize: '12px', color: '#6b7280', marginTop: '4px' }
+const input: React.CSSProperties = { width: '100%', padding: '8px 11px', border: '1px solid #d1d5db', borderRadius: '6px', fontSize: '13px', boxSizing: 'border-box' }
+const primaryBtn: React.CSSProperties = { padding: '9px 18px', background: '#2563eb', color: '#fff', border: 'none', borderRadius: '7px', fontSize: '14px', fontWeight: 600, cursor: 'pointer' }
+const ghostBtn: React.CSSProperties = { padding: '9px 16px', background: '#fff', color: '#374151', border: '1px solid #d1d5db', borderRadius: '7px', fontSize: '14px', cursor: 'pointer' }
+
+type Step = 'pick' | 'configure' | 'done'
+
+export default function OnboardingWizard() {
+  const navigate = useNavigate()
+  const currentTenant = useAuthStore((s) => s.currentTenant)
+
+  const [step, setStep] = useState<Step>('pick')
+  const [template, setTemplate] = useState<PipelineTemplate | null>(null)
+  const [name, setName] = useState('')
+  // Per-node working copy of the template config the user edits.
+  const [configs, setConfigs] = useState<Record<string, Record<string, unknown>>>({})
+
+  const [deploying, setDeploying] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [deployedId, setDeployedId] = useState<string | null>(null)
+  const [webhookUrl, setWebhookUrl] = useState<string>('')
+  const [sampleResult, setSampleResult] = useState<string | null>(null)
+
+  const finish = () => {
+    markOnboarded(currentTenant?.id)
+    navigate('/')
+  }
+
+  const choose = (t: PipelineTemplate) => {
+    // Deep-clone the template configs so edits don't mutate the catalog.
+    const cloned: Record<string, Record<string, unknown>> = {}
+    for (const n of t.nodes) cloned[n.id] = JSON.parse(JSON.stringify(n.config))
+    setTemplate(t)
+    setConfigs(cloned)
+    setName(t.name)
+    setError(null)
+    setStep('configure')
+  }
+
+  const setFieldValue = (f: TemplateField, value: string) => {
+    setConfigs((prev) => {
+      const next = JSON.parse(JSON.stringify(prev)) as Record<string, Record<string, unknown>>
+      getObj(next[f.nodeId], f.objectPath)[f.key] = value
+      return next
+    })
+  }
+
+  const patchSecret = (f: TemplateField, patch: Record<string, unknown>) => {
+    setConfigs((prev) => {
+      const next = JSON.parse(JSON.stringify(prev)) as Record<string, Record<string, unknown>>
+      Object.assign(getObj(next[f.nodeId], f.objectPath), patch)
+      return next
+    })
+  }
+
+  // Required non-secret fields must be filled before deploy.
+  const missing = useMemo(() => {
+    if (!template) return []
+    return template.fields.filter((f) => {
+      if (f.secret) return false // secrets optional here; user may reuse env creds
+      const v = getObj(configs[f.nodeId] || {}, f.objectPath)[f.key]
+      return typeof v !== 'string' || v.trim() === ''
+    })
+  }, [template, configs])
+
+  async function deploy() {
+    if (!template) return
+    setDeploying(true)
+    setError(null)
+    try {
+      const builtNodes = await Promise.all(
+        template.nodes.map(async (n) => ({
+          id: n.id,
+          type: n.type,
+          config: (await materializeSecrets(configs[n.id] || {}, n.id)) as Record<string, unknown>,
+          enabled: true,
+        }))
+      )
+      const payload = {
+        name: name.trim() || template.name,
+        description: `Created from the "${template.name}" template`,
+        nodes: builtNodes,
+        edges: template.edges.map((e, i) => ({ id: `edge-${i}`, source: e.source, target: e.target, order: i })),
+      }
+      const resp = await apiClient.post('/api/v1/connections', payload)
+      const id = resp.data?.data?.id
+      if (!id) throw new Error('No connection ID returned from server')
+      try {
+        await apiClient.post(`/api/v1/connections/${id}/start`)
+      } catch {
+        /* best-effort auto-start; connection still created */
+      }
+      setDeployedId(id)
+      if (template.webhookSource) setWebhookUrl(`http://localhost:9100/webhook/${id}`)
+      markOnboarded(currentTenant?.id)
+      setStep('done')
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to deploy the pipeline')
+    } finally {
+      setDeploying(false)
+    }
+  }
+
+  async function sendSample() {
+    if (!webhookUrl || !template) return
+    setSampleResult('sending…')
+    try {
+      const r = await fetch(webhookUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(template.samplePayload ?? {}),
+      })
+      setSampleResult(r.ok ? `✓ Delivered (HTTP ${r.status})` : `Webhook returned HTTP ${r.status}`)
+    } catch {
+      setSampleResult('Could not reach the webhook')
+    }
+  }
+
+  // --- render --------------------------------------------------------------
+
+  return (
+    <div style={page}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', marginBottom: '8px' }}>
+        <h1 style={{ fontSize: '26px', fontWeight: 700, margin: 0 }}>Get started</h1>
+        <button onClick={finish} style={{ ...ghostBtn, padding: '6px 12px', fontSize: '13px' }}>Skip for now</button>
+      </div>
+      <p style={{ fontSize: '14px', color: '#6b7280', marginTop: 0, marginBottom: '24px' }}>
+        Pick a template and deploy your first pipeline in a couple of minutes.
+      </p>
+
+      {error && (
+        <div style={{ padding: '10px 12px', background: '#fef2f2', color: '#991b1b', fontSize: '13px', borderRadius: '8px', marginBottom: '14px' }}>
+          {error}
+        </div>
+      )}
+
+      {step === 'pick' && (
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(240px, 1fr))', gap: '14px' }}>
+          {TEMPLATES.map((t) => (
+            <button
+              key={t.id}
+              onClick={() => choose(t)}
+              style={{ ...card, textAlign: 'left', cursor: 'pointer', marginBottom: 0, display: 'flex', flexDirection: 'column', gap: '6px' }}
+            >
+              <div style={{ fontSize: '26px' }}>{t.icon}</div>
+              <div style={{ fontSize: '15px', fontWeight: 600 }}>{t.name}</div>
+              <div style={{ fontSize: '13px', color: '#6b7280', lineHeight: 1.4 }}>{t.summary}</div>
+              <div style={{ marginTop: '6px', fontSize: '11px', fontWeight: 600, color: '#2563eb' }}>
+                {t.sourceLabel} → {t.destLabel}
+              </div>
+            </button>
+          ))}
+        </div>
+      )}
+
+      {step === 'configure' && template && (
+        <>
+          <div style={card}>
+            <div style={{ fontSize: '15px', fontWeight: 600, marginBottom: '2px' }}>
+              {template.icon} {template.name}
+            </div>
+            <div style={{ fontSize: '13px', color: '#6b7280' }}>{template.summary}</div>
+          </div>
+
+          <div style={card}>
+            <label style={label}>Pipeline name</label>
+            <input style={input} value={name} onChange={(e) => setName(e.target.value)} />
+          </div>
+
+          {template.fields.map((f) => {
+            const obj = getObj(configs[f.nodeId] || {}, f.objectPath)
+            return (
+              <div style={card} key={`${f.nodeId}.${f.objectPath}.${f.key}`}>
+                {f.secret ? (
+                  <SecretInput
+                    label={f.label}
+                    field={f.key}
+                    config={obj}
+                    placeholder={f.placeholder}
+                    onChange={(patch) => patchSecret(f, patch)}
+                  />
+                ) : (
+                  <>
+                    <label style={label}>{f.label}</label>
+                    <input
+                      style={input}
+                      value={(obj[f.key] as string) ?? ''}
+                      placeholder={f.placeholder}
+                      onChange={(e) => setFieldValue(f, e.target.value)}
+                    />
+                  </>
+                )}
+                <div style={help}>
+                  {f.help}
+                  {f.link && (
+                    <>
+                      {' '}
+                      <a href={f.link.url} target="_blank" rel="noreferrer" style={{ color: '#2563eb' }}>
+                        {f.link.text} ↗
+                      </a>
+                    </>
+                  )}
+                </div>
+              </div>
+            )
+          })}
+
+          <div style={{ display: 'flex', justifyContent: 'space-between', marginTop: '6px' }}>
+            <button onClick={() => setStep('pick')} style={ghostBtn}>← Back</button>
+            <button onClick={deploy} disabled={deploying || missing.length > 0} style={{ ...primaryBtn, opacity: deploying || missing.length > 0 ? 0.6 : 1 }}>
+              {deploying ? 'Deploying…' : 'Deploy pipeline'}
+            </button>
+          </div>
+          {missing.length > 0 && (
+            <div style={{ ...help, textAlign: 'right' }}>Fill in: {missing.map((m) => m.label).join(', ')}</div>
+          )}
+        </>
+      )}
+
+      {step === 'done' && template && (
+        <div style={card}>
+          <div style={{ fontSize: '18px', fontWeight: 700, marginBottom: '4px' }}>🎉 {name || template.name} is live</div>
+          <p style={{ fontSize: '13px', color: '#6b7280', marginTop: 0 }}>
+            Your pipeline is deployed and running.
+          </p>
+
+          {template.webhookSource && webhookUrl && (
+            <div style={{ marginTop: '10px' }}>
+              <label style={label}>Your webhook URL</label>
+              <code style={{ display: 'block', background: '#f3f4f6', padding: '9px 11px', borderRadius: '6px', fontSize: '12px', wordBreak: 'break-all' }}>
+                {webhookUrl}
+              </code>
+              <p style={help}>POST events here and they flow through your pipeline. Try it now:</p>
+              <button onClick={sendSample} style={{ ...ghostBtn, marginTop: '4px' }}>Send a sample event</button>
+              {sampleResult && (
+                <span style={{ marginLeft: '10px', fontSize: '13px', color: sampleResult.startsWith('✓') ? '#059669' : '#b45309' }}>
+                  {sampleResult}
+                </span>
+              )}
+            </div>
+          )}
+
+          <div style={{ display: 'flex', gap: '10px', marginTop: '18px' }}>
+            <button onClick={finish} style={primaryBtn}>Go to dashboard</button>
+            {deployedId && (
+              <button onClick={() => navigate(`/connections/${deployedId}`)} style={ghostBtn}>
+                View connection
+              </button>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/ui/src/onboarding/state.ts
+++ b/ui/src/onboarding/state.ts
@@ -1,0 +1,15 @@
+/**
+ * Per-tenant "has finished/skipped onboarding" flag (Phase 4B / #93). Stored in
+ * localStorage so the first-login redirect to the wizard fires at most once per
+ * tenant per browser. No server state — onboarding is a UI affordance.
+ */
+
+const key = (tenantId: string) => `vrsky:onboarded:${tenantId}`
+
+export function markOnboarded(tenantId: string | undefined): void {
+  if (tenantId) localStorage.setItem(key(tenantId), '1')
+}
+
+export function isOnboarded(tenantId: string | undefined): boolean {
+  return !!tenantId && localStorage.getItem(key(tenantId)) === '1'
+}

--- a/ui/src/onboarding/templates.ts
+++ b/ui/src/onboarding/templates.ts
@@ -1,0 +1,220 @@
+/**
+ * Pipeline templates for the first-login onboarding wizard (Phase 4B / #93).
+ *
+ * Each template is a fully pre-filled connection (consumer + producer nodes +
+ * the edge between them) plus a small list of `fields` the user must supply —
+ * almost always just credentials or one destination value. The wizard clones
+ * the template, lets the user fill those fields, then deploys via the same
+ * createConnection → materializeSecrets → start path the visual builder uses.
+ *
+ * Templates use only connectors that exist today. "Webhook → Slack" is an HTTP
+ * producer pointed at a Slack incoming-webhook URL (a Slack webhook is just an
+ * HTTP POST), so it needs no dedicated Slack connector.
+ */
+
+export type TemplateNode = {
+  id: string
+  type: 'consumer' | 'producer'
+  // Pre-filled connector config, e.g. { type: 'http', http: { url, method } }.
+  config: Record<string, unknown>
+}
+
+export type TemplateField = {
+  /** Node the field belongs to. */
+  nodeId: string
+  /** Dot-path to the object holding `key` within that node's config. '' = root. */
+  objectPath: string
+  /** Key within that object, e.g. 'url' or 'connection_string'. */
+  key: string
+  label: string
+  /** Inline help shown under the field. */
+  help: string
+  /** Optional "learn more" link. */
+  link?: { text: string; url: string }
+  /** Render a masked SecretInput; key must be in SECRET_FIELDS. */
+  secret?: boolean
+  placeholder?: string
+}
+
+export type PipelineTemplate = {
+  id: string
+  name: string
+  /** One-line plain-English description for the gallery card. */
+  summary: string
+  icon: string
+  sourceLabel: string
+  destLabel: string
+  nodes: TemplateNode[]
+  edges: { source: string; target: string }[]
+  fields: TemplateField[]
+  /** True when the source is an inbound webhook — the wizard then shows the
+   *  public URL and a "send a sample event" button so the user sees it work. */
+  webhookSource?: boolean
+  /** Body POSTed by the "send sample event" button (webhook templates). */
+  samplePayload?: unknown
+}
+
+export const TEMPLATES: PipelineTemplate[] = [
+  {
+    id: 'webhook-to-slack',
+    name: 'Webhook → Slack',
+    summary: 'Receive webhook events and post them to a Slack channel.',
+    icon: '💬',
+    sourceLabel: 'Webhook',
+    destLabel: 'Slack',
+    nodes: [
+      { id: 'src', type: 'consumer', config: { type: 'http' } },
+      {
+        id: 'dst',
+        type: 'producer',
+        config: {
+          type: 'http',
+          http: { url: '', method: 'POST', headers: { 'Content-Type': 'application/json' } },
+        },
+      },
+    ],
+    edges: [{ source: 'src', target: 'dst' }],
+    fields: [
+      {
+        nodeId: 'dst',
+        objectPath: 'http',
+        key: 'url',
+        label: 'Slack incoming webhook URL',
+        help: 'Create one in Slack: Apps → Incoming Webhooks → Add to a channel. It looks like https://hooks.slack.com/services/...',
+        link: { text: 'Slack: create an incoming webhook', url: 'https://api.slack.com/messaging/webhooks' },
+        placeholder: 'https://hooks.slack.com/services/T000/B000/XXXX',
+      },
+    ],
+    webhookSource: true,
+    samplePayload: { text: 'Hello from VRSky 👋 — your pipeline is live!' },
+  },
+  {
+    id: 'webhook-to-http',
+    name: 'Webhook → HTTP endpoint',
+    summary: 'Forward incoming webhooks to any HTTP API.',
+    icon: '🔗',
+    sourceLabel: 'Webhook',
+    destLabel: 'HTTP',
+    nodes: [
+      { id: 'src', type: 'consumer', config: { type: 'http' } },
+      { id: 'dst', type: 'producer', config: { type: 'http', http: { url: '', method: 'POST' } } },
+    ],
+    edges: [{ source: 'src', target: 'dst' }],
+    fields: [
+      {
+        nodeId: 'dst',
+        objectPath: 'http',
+        key: 'url',
+        label: 'Destination URL',
+        help: 'The HTTP endpoint each event is POSTed to.',
+        placeholder: 'https://api.example.com/ingest',
+      },
+    ],
+    webhookSource: true,
+    samplePayload: { hello: 'world', from: 'vrsky' },
+  },
+  {
+    id: 'webhook-to-file',
+    name: 'Webhook → File',
+    summary: 'Capture incoming webhooks to files on disk.',
+    icon: '📁',
+    sourceLabel: 'Webhook',
+    destLabel: 'File',
+    nodes: [
+      { id: 'src', type: 'consumer', config: { type: 'http' } },
+      { id: 'dst', type: 'producer', config: { type: 'file', file: { path: '/data/output' } } },
+    ],
+    edges: [{ source: 'src', target: 'dst' }],
+    fields: [
+      {
+        nodeId: 'dst',
+        objectPath: 'file',
+        key: 'path',
+        label: 'Output folder',
+        help: 'Folder the producer writes each event to. Leave the default unless you mounted another path.',
+        placeholder: '/data/output',
+      },
+    ],
+    webhookSource: true,
+    samplePayload: { event: 'sample', ts: 'now' },
+  },
+  {
+    id: 'csv-to-database',
+    name: 'CSV → Database',
+    summary: 'Load uploaded CSV rows into a database table.',
+    icon: '🗄️',
+    sourceLabel: 'CSV file',
+    destLabel: 'Database',
+    nodes: [
+      { id: 'src', type: 'consumer', config: { type: 'file', file: { format: 'csv' } } },
+      {
+        id: 'dst',
+        type: 'producer',
+        config: { type: 'database', database: { connection_string: '', table: '', operation: 'insert' } },
+      },
+    ],
+    edges: [{ source: 'src', target: 'dst' }],
+    fields: [
+      {
+        nodeId: 'dst',
+        objectPath: 'database',
+        key: 'connection_string',
+        label: 'Database connection string',
+        help: 'Postgres URL of the target database. Stored encrypted — never saved in plain text.',
+        secret: true,
+        placeholder: 'postgres://user:pass@host:5432/dbname',
+      },
+      {
+        nodeId: 'dst',
+        objectPath: 'database',
+        key: 'table',
+        label: 'Target table',
+        help: 'The table each CSV row is inserted into.',
+        placeholder: 'public.imported_rows',
+      },
+    ],
+  },
+  {
+    id: 'api-to-file',
+    name: 'API poll → File',
+    summary: 'Poll a REST API on a schedule and write each response to disk.',
+    icon: '⏱️',
+    sourceLabel: 'REST API',
+    destLabel: 'File',
+    nodes: [
+      { id: 'src', type: 'consumer', config: { type: 'api', api: { url: '', method: 'GET', interval: '60s' } } },
+      { id: 'dst', type: 'producer', config: { type: 'file', file: { path: '/data/output' } } },
+    ],
+    edges: [{ source: 'src', target: 'dst' }],
+    fields: [
+      {
+        nodeId: 'src',
+        objectPath: 'api',
+        key: 'url',
+        label: 'API URL',
+        help: 'A REST endpoint returning JSON. It is polled on the interval below.',
+        placeholder: 'https://api.example.com/v1/items',
+      },
+      {
+        nodeId: 'src',
+        objectPath: 'api',
+        key: 'interval',
+        label: 'Poll interval',
+        help: 'How often to call the API, e.g. 30s, 5m, 1h.',
+        placeholder: '60s',
+      },
+      {
+        nodeId: 'dst',
+        objectPath: 'file',
+        key: 'path',
+        label: 'Output folder',
+        help: 'Folder each response is written to.',
+        placeholder: '/data/output',
+      },
+    ],
+  },
+]
+
+export function templateById(id: string): PipelineTemplate | undefined {
+  return TEMPLATES.find((t) => t.id === id)
+}

--- a/ui/src/pages/PipelineBuilder.tsx
+++ b/ui/src/pages/PipelineBuilder.tsx
@@ -4,7 +4,7 @@ import KonvaCanvas from '../components/Pipeline/KonvaCanvas'
 import PropertyEditor from '../components/Pipeline/PropertyEditor'
 import DLQPanel from '../components/Pipeline/DLQPanel'
 import { listDLQ } from '../services/dlqService'
-import { createSecret } from '../services/secretService'
+import { materializeSecrets } from '../utils/secrets'
 import ComponentPalette from '../components/Pipeline/ComponentPalette'
 import CanvasSelector from '../components/CanvasSelector'
 import apiClient from '../services/api'
@@ -19,44 +19,6 @@ import { validatePipelineConnections, type ValidationResult } from '../utils/val
 import { useNodeDrag } from '../hooks/useNodeDrag'
 import { useConnectionDrawing } from '../hooks/useConnectionDrawing'
 import type { Node, Edge } from '../types/pipeline'
-
-// Config keys whose plaintext values are credentials and must be stored as
-// encrypted tenant secrets rather than persisted in the connection JSON.
-const SECRET_FIELDS = new Set(['password', 'secret', 'api_key', 'token', 'auth_value', 'private_key', 'client_key', 'secret_access_key', 'account_key', 'connection_string', 'credentials_json'])
-
-/**
- * Recursively walk a node config; for every plaintext credential field, mint a
- * tenant secret and replace the plaintext with a `<field>_secret_id` reference.
- * Already-bound `<field>_secret_id` values and all other config are preserved.
- * Throws if a secret cannot be created (deploy aborts rather than persisting
- * plaintext).
- */
-async function materializeSecrets(value: unknown, hint: string): Promise<unknown> {
-  if (Array.isArray(value)) {
-    return Promise.all(value.map((v, i) => materializeSecrets(v, `${hint}-${i}`)))
-  }
-  if (value && typeof value === 'object') {
-    const out: Record<string, unknown> = {}
-    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
-      if (SECRET_FIELDS.has(k) && typeof v === 'string' && v !== '') {
-        const secret = await createSecret(`${hint}-${k}-${Date.now()}`, v)
-        out[`${k}_secret_id`] = secret.id
-        // plaintext key intentionally dropped
-      } else if (v === undefined) {
-        // SecretInput clears a previously-bound `<field>_secret_id` by setting
-        // it to undefined while the user types a replacement. Skip such keys —
-        // otherwise this branch would clobber the `_secret_id` we just minted
-        // above (when iteration reaches the undefined key after the plaintext
-        // field), wiping BOTH the id and the plaintext on serialization.
-        continue
-      } else {
-        out[k] = await materializeSecrets(v, hint)
-      }
-    }
-    return out
-  }
-  return value
-}
 
 // Auth header for the file-producer /files API. Empty unless a token is
 // configured (see config.fileProducerToken), in which case the server requires it.

--- a/ui/src/pages/PipelineBuilderPage.tsx
+++ b/ui/src/pages/PipelineBuilderPage.tsx
@@ -1,7 +1,52 @@
+import { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { ReactFlowProvider } from 'reactflow'
 import PipelineBuilder from './PipelineBuilder'
+import apiClient from '../services/api'
+import { useAuthStore } from '../store/authStore'
+import { isOnboarded, markOnboarded } from '../onboarding/state'
 
 export default function PipelineBuilderPage() {
+  const navigate = useNavigate()
+  const currentTenant = useAuthStore((s) => s.currentTenant)
+  const [decided, setDecided] = useState(false)
+
+  // First-login onboarding (#93): a tenant with zero connections that hasn't
+  // been onboarded is redirected to the template wizard. Checked once per
+  // tenant; tenants that already have connections are flagged so we never look
+  // again. Failures fall through to the normal builder.
+  useEffect(() => {
+    const tenantId = currentTenant?.id
+    if (!tenantId || isOnboarded(tenantId)) return
+    let cancelled = false
+    ;(async () => {
+      try {
+        const resp = await apiClient.get('/api/v1/connections', { params: { limit: 1, offset: 0 } })
+        const d = resp.data?.data ?? resp.data
+        const total = d?.total ?? (Array.isArray(d?.connections) ? d.connections.length : 0)
+        if (cancelled) return
+        if (total === 0) {
+          navigate('/welcome', { replace: true })
+          return
+        }
+        markOnboarded(tenantId)
+      } catch {
+        /* ignore — show the builder */
+      }
+      if (!cancelled) setDecided(true)
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [currentTenant?.id, navigate])
+
+  // Hold the (blank) canvas back until the redirect decision is made, so a
+  // first-time user doesn't see the empty builder flash before the wizard.
+  const tenantId = currentTenant?.id
+  if (tenantId && !isOnboarded(tenantId) && !decided) {
+    return null
+  }
+
   return (
     <ReactFlowProvider>
       <PipelineBuilder />

--- a/ui/src/utils/secrets.ts
+++ b/ui/src/utils/secrets.ts
@@ -1,0 +1,58 @@
+/**
+ * Shared credential-materialization used at deploy time by both the visual
+ * pipeline builder and the onboarding wizard (#93). Kept in one place so the
+ * security-sensitive "never persist plaintext" logic has a single source of
+ * truth.
+ */
+
+import { createSecret } from '../services/secretService'
+
+// Config keys whose plaintext values are credentials and must be stored as
+// encrypted tenant secrets rather than persisted in the connection JSON.
+export const SECRET_FIELDS = new Set([
+  'password',
+  'secret',
+  'api_key',
+  'token',
+  'auth_value',
+  'private_key',
+  'client_key',
+  'secret_access_key',
+  'account_key',
+  'connection_string',
+  'credentials_json',
+])
+
+/**
+ * Recursively walk a node config; for every plaintext credential field, mint a
+ * tenant secret and replace the plaintext with a `<field>_secret_id` reference.
+ * Already-bound `<field>_secret_id` values and all other config are preserved.
+ * Throws if a secret cannot be created (deploy aborts rather than persisting
+ * plaintext).
+ */
+export async function materializeSecrets(value: unknown, hint: string): Promise<unknown> {
+  if (Array.isArray(value)) {
+    return Promise.all(value.map((v, i) => materializeSecrets(v, `${hint}-${i}`)))
+  }
+  if (value && typeof value === 'object') {
+    const out: Record<string, unknown> = {}
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      if (SECRET_FIELDS.has(k) && typeof v === 'string' && v !== '') {
+        const secret = await createSecret(`${hint}-${k}-${Date.now()}`, v)
+        out[`${k}_secret_id`] = secret.id
+        // plaintext key intentionally dropped
+      } else if (v === undefined) {
+        // SecretInput clears a previously-bound `<field>_secret_id` by setting
+        // it to undefined while the user types a replacement. Skip such keys —
+        // otherwise this branch would clobber the `_secret_id` we just minted
+        // above (when iteration reaches the undefined key after the plaintext
+        // field), wiping BOTH the id and the plaintext on serialization.
+        continue
+      } else {
+        out[k] = await materializeSecrets(v, hint)
+      }
+    }
+    return out
+  }
+  return value
+}

--- a/ui/tests/unit/onboarding.templates.test.ts
+++ b/ui/tests/unit/onboarding.templates.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Onboarding template catalog tests (Phase 4B / #93).
+ *
+ * Guards the contract the wizard relies on: enough templates, valid node/edge
+ * graphs, and every field pointing at a real connector config path. A broken
+ * template would otherwise only surface at deploy time in the UI.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { TEMPLATES, templateById, type PipelineTemplate } from '@/onboarding/templates'
+import { SECRET_FIELDS } from '@/utils/secrets'
+
+function nodeConfig(t: PipelineTemplate, nodeId: string): Record<string, unknown> | undefined {
+  return t.nodes.find((n) => n.id === nodeId)?.config
+}
+
+describe('onboarding templates', () => {
+  it('ships at least 4 templates (acceptance criterion)', () => {
+    expect(TEMPLATES.length).toBeGreaterThanOrEqual(4)
+  })
+
+  it('has unique ids and templateById resolves them', () => {
+    const ids = TEMPLATES.map((t) => t.id)
+    expect(new Set(ids).size).toBe(ids.length)
+    for (const t of TEMPLATES) expect(templateById(t.id)).toBe(t)
+  })
+
+  it('every template is a valid consumer→producer graph', () => {
+    for (const t of TEMPLATES) {
+      const types = t.nodes.map((n) => n.type)
+      expect(types).toContain('consumer')
+      expect(types).toContain('producer')
+      // Edges reference real nodes.
+      const nodeIds = new Set(t.nodes.map((n) => n.id))
+      expect(t.edges.length).toBeGreaterThan(0)
+      for (const e of t.edges) {
+        expect(nodeIds.has(e.source)).toBe(true)
+        expect(nodeIds.has(e.target)).toBe(true)
+      }
+      // Every node config declares a connector "type".
+      for (const n of t.nodes) expect(typeof n.config.type).toBe('string')
+    }
+  })
+
+  it('every field points at a real node + object path, and secrets use SECRET_FIELDS', () => {
+    for (const t of TEMPLATES) {
+      for (const f of t.fields) {
+        const cfg = nodeConfig(t, f.nodeId)
+        expect(cfg, `${t.id}: field references missing node ${f.nodeId}`).toBeDefined()
+        // objectPath must resolve to an object in the pre-filled config.
+        let cur: unknown = cfg
+        if (f.objectPath) {
+          for (const part of f.objectPath.split('.')) {
+            expect(cur && typeof cur === 'object').toBe(true)
+            cur = (cur as Record<string, unknown>)[part]
+          }
+        }
+        expect(cur && typeof cur === 'object', `${t.id}.${f.key}: objectPath "${f.objectPath}" is not an object`).toBe(true)
+        expect(f.label.length).toBeGreaterThan(0)
+        expect(f.help.length).toBeGreaterThan(0)
+        if (f.secret) {
+          expect(SECRET_FIELDS.has(f.key), `${t.id}: secret field "${f.key}" not in SECRET_FIELDS`).toBe(true)
+        }
+      }
+    }
+  })
+
+  it('webhook-source templates carry a sample payload to send', () => {
+    for (const t of TEMPLATES) {
+      if (t.webhookSource) {
+        expect(t.samplePayload, `${t.id}: webhook template needs a samplePayload`).toBeDefined()
+      }
+    }
+  })
+})


### PR DESCRIPTION
Phase 4B: a guided **first-login wizard** that gets a non-developer from zero to a deployed, running pipeline in a few steps — the on-ramp that sits in front of the visual canvas. Frontend-only; no backend changes.

## What it does
1. **Pick a template** from a gallery (card per use-case)
2. **Fill only what's yours** — usually one credential or destination URL; the template pre-fills ~80% (node types, wiring, defaults). Reuses `SecretInput` for credentials.
3. **Deploy** — same path as the builder (`createConnection` → `materializeSecrets` → `start`), so nothing plaintext is persisted.
4. **See it work** — for webhook templates the final step shows the public URL + a **Send a sample event** button.

## Templates (`ui/src/onboarding/templates.ts`) — real connectors only
- **Webhook → Slack** (HTTP producer pointed at a Slack incoming-webhook URL — Slack webhooks are just an HTTP POST, so no new connector)
- **Webhook → HTTP endpoint**
- **Webhook → File**
- **CSV → Database** (exercises the encrypted-credential path)
- **API poll → File**

The issue named Webhook→Slack and Salesforce→HubSpot; Slack/HubSpot aren't data connectors today, so Slack is delivered via the HTTP-to-webhook approach and Salesforce→HubSpot is substituted with real connectors. Native Slack/HubSpot connectors are noted as follow-ups.

## Changes
- `onboarding/{templates,OnboardingWizard,state}.ts(x)` — catalog, wizard, per-tenant onboarded flag (localStorage).
- `/welcome` route; `PipelineBuilderPage` redirects a tenant with **zero connections** there on first login (once), with "Skip for now".
- `utils/secrets.ts` — extracted `SECRET_FIELDS` + `materializeSecrets` out of `PipelineBuilder` so the wizard and builder share one credential-materialization path (no behavior change to the builder).

## Verification
- **Unit:** template-catalog tests (≥4 templates, valid consumer→producer graphs, every field maps to a real config path, secret fields ∈ `SECRET_FIELDS`, webhook templates carry a sample payload). `tsc`, eslint (new files), `vite build` clean; **329 UI tests pass** (incl. the existing PipelineBuilder/secret tests after the refactor).
- **Live:** deployed the **Webhook→Slack** template payload exactly as the wizard POSTs it → started → sent a sample event → **202 → http-producer delivered (HTTP 200)**.

## Out of scope (follow-ups)
- Native Slack/HubSpot pipeline connectors.
- The acceptance "user-test with 3 non-developers, all <10 min" — a process/validation step, not code.

Closes #93.

🤖 Generated with [Claude Code](https://claude.com/claude-code)