### PR TITLE
feat: per-connection worker autoscaling — replicas + HPA (#135)

### DIFF
--- a/src/pkg/orchestrator/autoscaling_test.go
+++ b/src/pkg/orchestrator/autoscaling_test.go
@@ -1,0 +1,82 @@
+package orchestrator
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// #135: per-connection worker deployments get configurable replicas + an HPA.
+
+func TestResolveScaling_Defaults(t *testing.T) {
+	node := createNode("c1", "consumer", map[string]interface{}{"type": "kafka"})
+	s := resolveScaling(node, DefaultConfig())
+	if s.MinReplicas != 1 || s.MaxReplicas != 10 || s.TargetCPUPercent != 75 {
+		t.Fatalf("defaults wrong: %+v", s)
+	}
+}
+
+func TestResolveScaling_Override(t *testing.T) {
+	node := createNode("c1", "consumer", map[string]interface{}{
+		"type":    "kafka",
+		"scaling": map[string]interface{}{"min_replicas": 3, "max_replicas": 20, "target_cpu_percent": 60},
+	})
+	s := resolveScaling(node, DefaultConfig())
+	if s.MinReplicas != 3 || s.MaxReplicas != 20 || s.TargetCPUPercent != 60 {
+		t.Fatalf("override not applied: %+v", s)
+	}
+}
+
+func TestResolveScaling_ClampsMaxBelowMin(t *testing.T) {
+	node := createNode("c1", "consumer", map[string]interface{}{
+		"scaling": map[string]interface{}{"min_replicas": 5, "max_replicas": 2},
+	})
+	s := resolveScaling(node, DefaultConfig())
+	if s.MinReplicas != 5 || s.MaxReplicas != 5 {
+		t.Fatalf("expected max clamped up to min, got %+v", s)
+	}
+}
+
+func TestBuildHPA(t *testing.T) {
+	labels := buildLabels("conn-1", "n1", "consumer", "tenant-1")
+	hpa := buildHPA(DefaultConfig(), labels, "vrsky-conn-1-n1", NodeScaling{MinReplicas: 2, MaxReplicas: 8, TargetCPUPercent: 70})
+	if hpa.Spec.ScaleTargetRef.Name != "vrsky-conn-1-n1" || hpa.Spec.ScaleTargetRef.Kind != "Deployment" {
+		t.Fatalf("scale target ref wrong: %+v", hpa.Spec.ScaleTargetRef)
+	}
+	if hpa.Spec.MinReplicas == nil || *hpa.Spec.MinReplicas != 2 || hpa.Spec.MaxReplicas != 8 {
+		t.Fatalf("min/max wrong: min=%v max=%d", hpa.Spec.MinReplicas, hpa.Spec.MaxReplicas)
+	}
+	if len(hpa.Spec.Metrics) != 1 ||
+		hpa.Spec.Metrics[0].Resource == nil ||
+		hpa.Spec.Metrics[0].Resource.Name != corev1.ResourceCPU ||
+		hpa.Spec.Metrics[0].Resource.Target.AverageUtilization == nil ||
+		*hpa.Spec.Metrics[0].Resource.Target.AverageUtilization != 70 {
+		t.Fatalf("cpu metric wrong: %+v", hpa.Spec.Metrics)
+	}
+}
+
+func TestCreateDeploymentSpec_IncludesHPAAndMinReplicas(t *testing.T) {
+	graph := &ExecutionGraph{
+		ExecutionOrder: []string{"c1"},
+		TenantID:       "tenant-1",
+		ConnectionID:   "conn-1",
+		ConsumerNodeID: "c1",
+	}
+	node := createNode("c1", "consumer", map[string]interface{}{
+		"type":    "kafka",
+		"scaling": map[string]interface{}{"min_replicas": 2, "max_replicas": 6},
+	})
+	spec, err := CreateDeploymentSpec(node, graph, DefaultConfig())
+	if err != nil {
+		t.Fatalf("CreateDeploymentSpec: %v", err)
+	}
+	if spec.Deployment.Spec.Replicas == nil || *spec.Deployment.Spec.Replicas != 2 {
+		t.Fatalf("deployment should start at min replicas 2, got %v", spec.Deployment.Spec.Replicas)
+	}
+	if spec.HPA == nil {
+		t.Fatal("expected an HPA on the deployment spec")
+	}
+	if spec.HPA.Spec.MaxReplicas != 6 || spec.HPA.Name != spec.Deployment.Name {
+		t.Fatalf("HPA wrong: name=%s max=%d (deployment=%s)", spec.HPA.Name, spec.HPA.Spec.MaxReplicas, spec.Deployment.Name)
+	}
+}

--- a/src/pkg/orchestrator/deployment.go
+++ b/src/pkg/orchestrator/deployment.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ValueRetail/vrsky/pkg/managementapi"
 	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -41,14 +42,57 @@ func CreateDeploymentSpec(node *managementapi.Node, graph *ExecutionGraph, confi
 	// Build labels
 	labels := buildLabels(graph.ConnectionID, node.ID, node.Type, graph.TenantID)
 
-	// Build the deployment
-	deployment := buildDeployment(node, graph, config, labels, envVars)
+	// Resolve autoscaling bounds (node override → orchestrator defaults).
+	scaling := resolveScaling(node, config)
+	deploymentName := buildDeploymentName(graph.ConnectionID, node.ID)
+
+	// Build the deployment (starts at MinReplicas; the HPA scales it).
+	deployment := buildDeployment(node, graph, config, labels, envVars, scaling.MinReplicas)
+	hpa := buildHPA(config, labels, deploymentName, scaling)
 
 	return &DeploymentSpec{
 		NodeID:     node.ID,
 		NodeType:   node.Type,
 		Deployment: deployment,
+		HPA:        hpa,
 	}, nil
+}
+
+// resolveScaling computes the effective autoscaling bounds for a node: the
+// orchestrator defaults, overridden by any "scaling" block in the node config,
+// clamped so 1 <= min <= max.
+func resolveScaling(node *managementapi.Node, config *OrchestratorConfig) NodeScaling {
+	s := NodeScaling{
+		MinReplicas:      config.DefaultMinReplicas,
+		MaxReplicas:      config.DefaultMaxReplicas,
+		TargetCPUPercent: config.TargetCPUPercent,
+	}
+	if len(node.Config) > 0 {
+		var wrap struct {
+			Scaling *NodeScaling `json:"scaling"`
+		}
+		if json.Unmarshal(node.Config, &wrap) == nil && wrap.Scaling != nil {
+			if wrap.Scaling.MinReplicas > 0 {
+				s.MinReplicas = wrap.Scaling.MinReplicas
+			}
+			if wrap.Scaling.MaxReplicas > 0 {
+				s.MaxReplicas = wrap.Scaling.MaxReplicas
+			}
+			if wrap.Scaling.TargetCPUPercent > 0 {
+				s.TargetCPUPercent = wrap.Scaling.TargetCPUPercent
+			}
+		}
+	}
+	if s.MinReplicas < 1 {
+		s.MinReplicas = 1
+	}
+	if s.MaxReplicas < s.MinReplicas {
+		s.MaxReplicas = s.MinReplicas
+	}
+	if s.TargetCPUPercent <= 0 {
+		s.TargetCPUPercent = 75
+	}
+	return s
 }
 
 // buildEnvironmentVariables builds the environment variables for a component.
@@ -106,8 +150,8 @@ func sanitizeLabelValue(s string) string {
 }
 
 // buildDeployment builds the Kubernetes Deployment object.
-func buildDeployment(node *managementapi.Node, graph *ExecutionGraph, config *OrchestratorConfig, labels map[string]string, envVars []corev1.EnvVar) *appsv1.Deployment {
-	replicas := int32(1)
+func buildDeployment(node *managementapi.Node, graph *ExecutionGraph, config *OrchestratorConfig, labels map[string]string, envVars []corev1.EnvVar, minReplicas int32) *appsv1.Deployment {
+	replicas := minReplicas
 	containerImage := GetContainerImage(config, node.Type)
 	deploymentName := buildDeploymentName(graph.ConnectionID, node.ID)
 
@@ -180,6 +224,45 @@ func buildDeployment(node *managementapi.Node, graph *ExecutionGraph, config *Or
 						},
 					},
 					RestartPolicy: corev1.RestartPolicyAlways,
+				},
+			},
+		},
+	}
+}
+
+// buildHPA builds a HorizontalPodAutoscaler that scales the per-connection
+// worker Deployment between MinReplicas and MaxReplicas on average CPU
+// utilization. This is what lets a single hot connection scale out instead of
+// being pinned at one replica (#135). The HPA shares the deployment's name and
+// labels. Resource requests are already set on the container, which the CPU
+// utilization target requires.
+func buildHPA(config *OrchestratorConfig, labels map[string]string, deploymentName string, scaling NodeScaling) *autoscalingv2.HorizontalPodAutoscaler {
+	minReplicas := scaling.MinReplicas
+	targetCPU := scaling.TargetCPUPercent
+	return &autoscalingv2.HorizontalPodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      deploymentName,
+			Namespace: config.Namespace,
+			Labels:    labels,
+		},
+		Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+			ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
+				APIVersion: "apps/v1",
+				Kind:       "Deployment",
+				Name:       deploymentName,
+			},
+			MinReplicas: &minReplicas,
+			MaxReplicas: scaling.MaxReplicas,
+			Metrics: []autoscalingv2.MetricSpec{
+				{
+					Type: autoscalingv2.ResourceMetricSourceType,
+					Resource: &autoscalingv2.ResourceMetricSource{
+						Name: corev1.ResourceCPU,
+						Target: autoscalingv2.MetricTarget{
+							Type:               autoscalingv2.UtilizationMetricType,
+							AverageUtilization: &targetCPU,
+						},
+					},
 				},
 			},
 		},

--- a/src/pkg/orchestrator/orchestrator.go
+++ b/src/pkg/orchestrator/orchestrator.go
@@ -128,7 +128,7 @@ func (o *Orchestrator) deployComponent(ctx context.Context, spec *DeploymentSpec
 		if err != nil {
 			return fmt.Errorf("failed to update deployment %s: %w", spec.Deployment.Name, err)
 		}
-		return nil
+		return o.applyHPA(ctx, spec)
 	}
 
 	// Create new deployment
@@ -137,6 +137,26 @@ func (o *Orchestrator) deployComponent(ctx context.Context, spec *DeploymentSpec
 		return fmt.Errorf("failed to create deployment %s: %w", spec.Deployment.Name, err)
 	}
 
+	return o.applyHPA(ctx, spec)
+}
+
+// applyHPA creates or updates the HorizontalPodAutoscaler for a deployment so
+// the connection's worker scales between min/max replicas under load (#135).
+func (o *Orchestrator) applyHPA(ctx context.Context, spec *DeploymentSpec) error {
+	if spec.HPA == nil {
+		return nil
+	}
+	hpaClient := o.K8sClient.AutoscalingV2().HorizontalPodAutoscalers(o.Config.Namespace)
+	if existing, err := hpaClient.Get(ctx, spec.HPA.Name, metav1.GetOptions{}); err == nil && existing != nil {
+		spec.HPA.ResourceVersion = existing.ResourceVersion
+		if _, err = hpaClient.Update(ctx, spec.HPA, metav1.UpdateOptions{}); err != nil {
+			return fmt.Errorf("failed to update HPA %s: %w", spec.HPA.Name, err)
+		}
+		return nil
+	}
+	if _, err := hpaClient.Create(ctx, spec.HPA, metav1.CreateOptions{}); err != nil {
+		return fmt.Errorf("failed to create HPA %s: %w", spec.HPA.Name, err)
+	}
 	return nil
 }
 
@@ -175,9 +195,21 @@ func (o *Orchestrator) StopConnection(ctx context.Context) error {
 		}
 	}
 
+	// Delete the connection's HPAs too (#135) — they share the connection
+	// label selector. Best-effort: an HPA delete failure shouldn't mask the
+	// deployment teardown result.
+	hpaClient := o.K8sClient.AutoscalingV2().HorizontalPodAutoscalers(o.Config.Namespace)
+	if hpas, listErr := hpaClient.List(ctx, metav1.ListOptions{LabelSelector: labelSelector}); listErr == nil {
+		for _, hpa := range hpas.Items {
+			if err := hpaClient.Delete(ctx, hpa.Name, metav1.DeleteOptions{}); err != nil {
+				deleteErrors = append(deleteErrors, fmt.Sprintf("hpa/%s: %v", hpa.Name, err))
+			}
+		}
+	}
+
 	if len(deleteErrors) > 0 {
 		return NewOrchestratorError(ErrCodeK8sDeleteFailed,
-			fmt.Sprintf("failed to delete some deployments: %v", deleteErrors),
+			fmt.Sprintf("failed to delete some resources: %v", deleteErrors),
 			map[string]string{"connectionID": o.Connection.ID})
 	}
 

--- a/src/pkg/orchestrator/types.go
+++ b/src/pkg/orchestrator/types.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ValueRetail/vrsky/pkg/managementapi"
 	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 )
 
 // ExecutionGraph represents a validated and topologically ordered pipeline.
@@ -56,6 +57,20 @@ type DeploymentSpec struct {
 
 	// Deployment is the K8s Deployment specification
 	Deployment *appsv1.Deployment
+
+	// HPA is the HorizontalPodAutoscaler for this deployment so a single
+	// connection's worker scales out under load instead of being pinned to one
+	// replica (#135). nil only if autoscaling is explicitly disabled.
+	HPA *autoscalingv2.HorizontalPodAutoscaler
+}
+
+// NodeScaling is the optional per-node autoscaling override, read from a
+// top-level "scaling" key in the node config. Zero fields fall back to the
+// orchestrator defaults.
+type NodeScaling struct {
+	MinReplicas      int32 `json:"min_replicas"`
+	MaxReplicas      int32 `json:"max_replicas"`
+	TargetCPUPercent int32 `json:"target_cpu_percent"`
 }
 
 // OrchestratorConfig contains configuration for the orchestrator.
@@ -74,16 +89,25 @@ type OrchestratorConfig struct {
 
 	// NATSAccount is the NATS account for tenant isolation
 	NATSAccount string
+
+	// Default autoscaling bounds for per-connection worker deployments (#135).
+	// A node's config may override these via a "scaling" block.
+	DefaultMinReplicas int32
+	DefaultMaxReplicas int32
+	TargetCPUPercent   int32
 }
 
 // DefaultConfig returns the default orchestrator configuration.
 func DefaultConfig() *OrchestratorConfig {
 	return &OrchestratorConfig{
-		Namespace:     "vrsky",
-		ImageRegistry: "gcr.io/vrsky",
-		ImageVersion:  "latest",
-		NATSURLs:      "nats://nats:4222",
-		NATSAccount:   "",
+		Namespace:          "vrsky",
+		ImageRegistry:      "gcr.io/vrsky",
+		ImageVersion:       "latest",
+		NATSURLs:           "nats://nats:4222",
+		NATSAccount:        "",
+		DefaultMinReplicas: 1,
+		DefaultMaxReplicas: 10,
+		TargetCPUPercent:   75,
 	}
 }
 


### PR DESCRIPTION
First item of the production-scalability epic (#140). Removes the #1 throughput ceiling: per-connection worker Deployments were pinned to 1 replica with no autoscaling.

## Changes (orchestrator)
- `resolveScaling`: min/max replicas + target CPU from the node config `scaling` block, else orchestrator defaults (1 / 10 / 75%), clamped to 1 ≤ min ≤ max.
- Deployment starts at `min` replicas (was hardcoded 1).
- `buildHPA`: a CPU-utilization HorizontalPodAutoscaler per per-connection Deployment (container resource requests, which the HPA needs, were already set).
- HPA applied on deploy (create/update) and deleted on stop alongside deployments.
- Tests: scaling resolution (defaults/override/clamp), HPA shape, end-to-end spec.

## Verification
`go build ./...`, `go vet`, orchestrator tests pass. This is k8s-runtime behavior (the orchestrator only runs in k8s mode, not compose), so it's verified by unit tests + spec shape, not the live compose stack. Actuation requires metrics-server in-cluster.

## Follow-ups (tracked on #135)
- UI controls for min/max replicas (config is API-settable today via the node `scaling` block).
- A NATS consumer-lag custom metric alongside CPU.

Part of #140.

🤖 Generated with [Claude Code](https://claude.com/claude-code)