### PR TITLE
feat(infra): PostgreSQL HA (CloudNativePG) + PgBouncer pooling (#137)

### DIFF
--- a/infrastructure/kubernetes/postgresql/README.md
+++ b/infrastructure/kubernetes/postgresql/README.md
@@ -10,6 +10,63 @@ This directory contains Kubernetes manifests for deploying PostgreSQL 18 as the 
 - **Storage**: 50GB via Longhorn distributed storage
 - **Persistence**: Full durability via Longhorn replication
 
+## High Availability (production) — #137
+
+The single-replica `statefulset.yaml` has **no HA**: a pod/node failure is a
+control-plane outage and risks data loss. It is now **dev/single-node only**.
+For production, choose one of:
+
+### Option A — CloudNativePG (self-hosted HA)
+
+A 3-instance cluster (primary + 2 replicas), automated failover, one
+synchronous standby (zero data loss on promotion), and PgBouncer pooling.
+
+```bash
+# 1. Install the operator (once per cluster)
+kubectl apply --server-side -f \
+  https://raw.githubusercontent.com/cloudnative-pg/cloudnative-pg/release-1.24/releases/cnpg-1.24.0.yaml
+
+# 2. App role secret — keys MUST be username/password (CNPG convention)
+kubectl -n vrsky-database create secret generic postgres-app-credentials \
+  --from-literal=username=vrsky --from-literal=password='<strong-password>'
+
+# 3. Schema ConfigMap (single-sources init-schema.sql)
+kubectl -n vrsky-database create configmap vrsky-pg-init-schema \
+  --from-file=init.sql=init-schema.sql
+
+# 4. Apply the cluster + pooler
+kubectl apply -f cnpg-cluster.yaml -f cnpg-pooler.yaml
+```
+
+Then point the app at the **pooler** (not the primary directly) by setting the
+`connection_string` key in the `postgres-credentials` secret to:
+
+```
+postgres://vrsky:<password>@vrsky-pg-pooler-rw.vrsky-database.svc.cluster.local:5432/vrsky?sslmode=require
+```
+
+CNPG also exposes `vrsky-pg-rw` (primary), `vrsky-pg-ro` (replicas), `vrsky-pg-r`
+(any). Use `-rw` if you skip the pooler.
+
+**Pooling mode caveat:** the pooler uses **session** mode because the Go workers
+use server-side prepared statements (lib/pq / pgx), which transaction pooling
+breaks unless every client switches to the simple query protocol. Session
+pooling still bounds backend connections. Switch `poolMode` to `transaction` in
+`cnpg-pooler.yaml` only after confirming all DB clients tolerate it.
+
+### Option B — Managed database (recommended for most)
+
+Run **RDS / Cloud SQL / AlloyDB** and let the provider handle HA, failover, and
+backups. Skip the CNPG manifests entirely and set `connection_string` to the
+managed endpoint (`sslmode=require`). Optionally still front it with the pooler.
+
+### Migration note
+
+These manifests provision a **fresh** HA cluster (schema applied via the init
+ConfigMap). To move data off the existing single-node StatefulSet, dump/restore
+with the `vrsky-cli` backup/restore tooling (#86) into the new cluster before
+cutting `connection_string` over.
+
 ## Components
 
 ### Files

--- a/infrastructure/kubernetes/postgresql/cnpg-cluster.yaml
+++ b/infrastructure/kubernetes/postgresql/cnpg-cluster.yaml
@@ -1,0 +1,78 @@
+# PostgreSQL HA via CloudNativePG (#137).
+#
+# Replaces the single-replica StatefulSet (statefulset.yaml — now dev-only) with
+# a 3-instance cluster: one primary + two streaming replicas, with automated
+# failover and one synchronous standby for zero data loss on promotion.
+#
+# Prerequisites:
+#   1. Install the CloudNativePG operator (once per cluster):
+#        kubectl apply --server-side -f \
+#          https://raw.githubusercontent.com/cloudnative-pg/cloudnative-pg/release-1.24/releases/cnpg-1.24.0.yaml
+#   2. Create the application role secret (keys MUST be `username`/`password` —
+#      CNPG's convention, distinct from the legacy POSTGRES_* secret):
+#        kubectl -n vrsky-database create secret generic postgres-app-credentials \
+#          --from-literal=username=vrsky --from-literal=password='<strong-password>'
+#   3. Provide the schema as a ConfigMap the cluster applies after bootstrap
+#      (single-sources init-schema.sql — no duplication):
+#        kubectl -n vrsky-database create configmap vrsky-pg-init-schema \
+#          --from-file=init.sql=init-schema.sql
+#
+# CNPG creates these Services automatically:
+#   vrsky-pg-rw  → always the current primary (read/write)   ← the app/pooler uses this
+#   vrsky-pg-ro  → replicas only (read-only)
+#   vrsky-pg-r   → any instance (read, incl. primary)
+#
+# Managed-database alternative: if you run RDS / Cloud SQL / AlloyDB instead,
+# skip this entirely and point MGMT_API_DB_URL at the managed endpoint — the
+# provider handles HA. See README.md.
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: vrsky-pg
+  namespace: vrsky-database
+  labels:
+    app: vrsky
+    component: database
+spec:
+  instances: 3
+
+  # Match the engine major version used by the legacy StatefulSet (postgres 18).
+  imageName: ghcr.io/cloudnative-pg/postgresql:18
+
+  # Let the operator promote a replica automatically on primary failure.
+  primaryUpdateStrategy: unsupervised
+
+  # One synchronous standby → a committed write is on at least two instances
+  # before it's acknowledged, so an automatic failover loses no data.
+  minSyncReplicas: 1
+  maxSyncReplicas: 1
+
+  postgresql:
+    parameters:
+      max_connections: "200"
+      shared_buffers: "256MB"
+
+  bootstrap:
+    initdb:
+      database: vrsky
+      owner: vrsky
+      secret:
+        name: postgres-app-credentials
+      # Apply the existing schema once, as the app owner, after the DB is created.
+      postInitApplicationSQLRefs:
+        configMapRefs:
+          - name: vrsky-pg-init-schema
+            key: init.sql
+
+  storage:
+    size: 10Gi
+
+  # Continuous WAL archiving / PITR can be added here later via spec.backup
+  # (object store) — backups are otherwise covered by the vrsky-cli drill (#86).
+  resources:
+    requests:
+      cpu: "250m"
+      memory: "512Mi"
+    limits:
+      cpu: "1"
+      memory: "1Gi"

--- a/infrastructure/kubernetes/postgresql/cnpg-pooler.yaml
+++ b/infrastructure/kubernetes/postgresql/cnpg-pooler.yaml
@@ -1,0 +1,31 @@
+# PgBouncer connection pooling in front of the HA cluster (#137).
+#
+# CloudNativePG manages a PgBouncer deployment (2 replicas) and a Service named
+# after this Pooler (vrsky-pg-pooler-rw). The management-api and workers connect
+# here instead of directly to the primary, so backend connections stay bounded
+# under fan-out (many worker pods × per-connection pools).
+#
+# Pooling mode: SESSION is used deliberately. The Go workers use database/sql
+# (lib/pq / pgx) which relies on server-side prepared statements; transaction
+# pooling breaks those unless every driver is switched to the simple query
+# protocol. Session pooling still bounds backend connections (reuses a backend
+# across client sessions) without that risk. Switch to `transaction` only after
+# confirming every DB client tolerates it — see README.md.
+apiVersion: postgresql.cnpg.io/v1
+kind: Pooler
+metadata:
+  name: vrsky-pg-pooler-rw
+  namespace: vrsky-database
+  labels:
+    app: vrsky
+    component: database-pooler
+spec:
+  cluster:
+    name: vrsky-pg
+  instances: 2
+  type: rw
+  pgbouncer:
+    poolMode: session
+    parameters:
+      max_client_conn: "1000"
+      default_pool_size: "25"

--- a/infrastructure/kubernetes/postgresql/statefulset.yaml
+++ b/infrastructure/kubernetes/postgresql/statefulset.yaml
@@ -1,3 +1,8 @@
+# DEV / SINGLE-NODE ONLY (#137). This single-replica StatefulSet has no HA:
+# a node or pod failure means a control-plane outage and risks data loss.
+# For production use the CloudNativePG cluster (cnpg-cluster.yaml +
+# cnpg-pooler.yaml) or a managed database — see README.md. Kept for local dev
+# and minimal deployments.
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:


### PR DESCRIPTION
Epic #140, item 2. The control-plane Postgres ran single-replica (no HA — a pod/node failure is an outage + data-loss risk).

## Adds
- **cnpg-cluster.yaml** — CloudNativePG `Cluster`: 3 instances (primary + 2 replicas), unsupervised automated failover, 1 synchronous standby (zero-loss promotion), schema bootstrapped from the existing `init-schema.sql` via a ConfigMap.
- **cnpg-pooler.yaml** — PgBouncer `Pooler` (session mode) fronting the rw service to bound backend connections under worker fan-out.
- `statefulset.yaml` marked **dev/single-node only**.
- **README** — operator install, app secret, `connection_string` → pooler, **managed-DB alternative** (RDS/Cloud SQL), pooling-mode caveat (why session not transaction), and a migration note.

## Verification
Manifests validated as **well-formed YAML**. Full validation needs a cluster with the CNPG CRDs (`kubectl apply --dry-run=server`) — not runnable in this environment. No app code changes (the app reads its DSN from the `connection_string` secret key, repointed at the pooler).

Part of #140.

🤖 Generated with [Claude Code](https://claude.com/claude-code)