### PR TITLE
feat(infra): object storage HA (distributed MinIO) + managed-S3 docs (#136)

### DIFF
--- a/infrastructure/kubernetes/minio/README.md
+++ b/infrastructure/kubernetes/minio/README.md
@@ -4,11 +4,15 @@ This directory contains Kubernetes manifests for deploying MinIO as the S3-compa
 
 ## Architecture
 
-- **Type**: Deployment (1 replica for POC)
+- **Type**: Deployment (1 replica — DEV/POC only) → see **High Availability** below for production
 - **Storage Backend**: S3-compatible object storage
 - **Resources**: 2 CPU, 4GB RAM (requests: 1 CPU, 2GB RAM)
 - **Storage**: 100GB via Longhorn distributed storage
 - **Access**: Internal cluster access only (ClusterIP)
+
+> ⚠️ `deployment.yaml` is a **single replica with a single drive** — a node or PVC
+> loss means data loss and downtime. For production pick a path in
+> [High Availability (production) — #136](#high-availability-production--136).
 
 ## Components
 
@@ -17,9 +21,10 @@ This directory contains Kubernetes manifests for deploying MinIO as the S3-compa
 1. **namespace.yaml** - Creates `vrsky-storage` namespace
 2. **secret.yaml** - MinIO credentials (⚠️ CHANGE IN PRODUCTION!)
 3. **configmap.yaml** - MinIO configuration
-4. **deployment.yaml** - MinIO Deployment + PVC
-5. **service.yaml** - ClusterIP service (API: 9000, Console: 9001)
-6. **setup-job.yaml** - Job to create buckets and configure lifecycle policies
+4. **deployment.yaml** - MinIO Deployment + PVC (DEV/single-node only)
+5. **statefulset-distributed.yaml** - HA: 4-node erasure-coded StatefulSet + headless service + PodDisruptionBudget (production self-hosted)
+6. **service.yaml** - ClusterIP service (API: 9000, Console: 9001) — fronts either the Deployment or the StatefulSet
+7. **setup-job.yaml** - Job to create buckets and configure lifecycle policies
 
 ### Bucket Structure
 
@@ -352,21 +357,81 @@ kubectl apply -f deployment.yaml
 kubectl rollout restart deployment/minio -n vrsky-storage
 ```
 
-### Distributed Mode (Post-POC)
+## High Availability (production) — #136
 
-For production HA, deploy MinIO in distributed mode (4+ nodes):
+`deployment.yaml` is single-node and not durable. For production choose **one**
+of the two options below. Both are drop-in for VRSky's object-storage workers —
+the cloud-storage consumer/producer already speak the S3 API and select GCS /
+Azure via the `objectstore` backend, so switching is endpoint + credentials, not
+code.
+
+### Option A — Managed object store (recommended)
+
+Use **AWS S3**, **Google Cloud Storage**, or **Azure Blob Storage** and let the
+provider own durability (11 nines), replication, HA, and scaling. There is
+nothing to operate, patch, or capacity-plan, and it removes MinIO from the
+failure domain entirely.
+
+Point the workers at the managed bucket via the existing env/secret wiring
+(no manifest in this directory needed — there is no MinIO to deploy):
+
+```yaml
+env:
+  - name: S3_ENDPOINT
+    value: "https://s3.eu-west-1.amazonaws.com" # or omit for AWS SDK default; GCS/Azure use their own endpoints
+  - name: S3_BUCKET
+    value: "vrsky-objects"
+  - name: S3_USE_SSL
+    value: "true"
+  # S3_ACCESS_KEY / S3_SECRET_KEY from a secret, or use IRSA / Workload Identity
+```
+
+Prefer cloud-native auth (IAM Roles for Service Accounts on EKS, Workload
+Identity on GKE, Managed Identity on AKS) over long-lived static keys. Lifecycle
+rules (the `temp/` 1-day expiry) are set on the managed bucket instead of via
+`setup-job.yaml`.
+
+### Option B — Self-hosted distributed MinIO (`statefulset-distributed.yaml`)
+
+When data must stay in-cluster / on-prem, run MinIO in **distributed mode**: 4
+servers × 1 drive in one erasure-coded pool. With the default `EC:2` parity the
+pool tolerates losing **up to 2 drives or nodes** with no data loss and stays
+read+write available while write quorum holds. The included
+`PodDisruptionBudget` (`minAvailable: 3`) keeps node drains/upgrades from
+dropping below quorum.
 
 ```bash
-# Use MinIO Operator
-kubectl apply -k github.com/minio/operator
+# Prereqs (shared with the dev box): namespace, secret, configmap, service
+kubectl apply -f namespace.yaml
+kubectl apply -f secret.yaml          # ⚠️ change credentials first
+kubectl apply -f configmap.yaml
+kubectl apply -f service.yaml         # client-facing ClusterIP (selector app: minio)
 
-# Create MinIO Tenant (distributed)
-kubectl minio tenant create vrsky-minio \
-  --servers 4 \
-  --volumes 16 \
-  --capacity 400Gi \
-  --storage-class longhorn
+# HA workload — REPLACES deployment.yaml (do NOT apply both: same `app: minio`
+# selector would make the client Service fan out across two workloads)
+kubectl apply -f statefulset-distributed.yaml
+
+# Wait for all 4 servers to join the pool
+kubectl rollout status statefulset/minio -n vrsky-storage
+
+# Bootstrap buckets + lifecycle once the pool is Ready
+kubectl apply -f setup-job.yaml
 ```
+
+**Operational notes**
+
+- A distributed pool's server count is **fixed**. To grow capacity, add a *new*
+  server pool — append another `https://...{4...7}` range to the `server` args
+  and raise `replicas` — never resize an existing pool in place.
+- Use a real block / replicated `StorageClass` (Longhorn, EBS, PD), not
+  `local-path`, so a PVC survives node loss. Minimum 4 drives for erasure coding.
+- Spread servers across nodes (the manifest sets a `topologySpreadConstraint`)
+  so one node failure costs at most one drive.
+
+> The MinIO **Operator** (`kubectl apply -k github.com/minio/operator` + a
+> `Tenant` CR) is an alternative to the raw StatefulSet that adds automated
+> upgrades, TLS, and multi-tenant management. Prefer it if you already run the
+> operator; otherwise the StatefulSet here has no operator dependency.
 
 ## Integration with VRSky
 

--- a/infrastructure/kubernetes/minio/deployment.yaml
+++ b/infrastructure/kubernetes/minio/deployment.yaml
@@ -1,3 +1,15 @@
+# =============================================================================
+# MinIO — DEV / SINGLE-NODE ONLY (#136)
+# =============================================================================
+# Single replica, single drive, no erasure coding: a node or PVC loss means
+# data loss and downtime. Fine for local/POC clusters; NOT for production.
+#
+# For production use ONE of:
+#   - statefulset-distributed.yaml  (self-hosted HA: 4-node erasure-coded pool)
+#   - a managed object store (AWS S3 / GCS / Azure Blob)  <-- recommended
+# See README "High Availability (production) — #136". Do not apply this file
+# alongside statefulset-distributed.yaml (they share the `app: minio` selector).
+# =============================================================================
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/infrastructure/kubernetes/minio/statefulset-distributed.yaml
+++ b/infrastructure/kubernetes/minio/statefulset-distributed.yaml
@@ -1,0 +1,183 @@
+# =============================================================================
+# MinIO — DISTRIBUTED / HIGH-AVAILABILITY mode (#136)
+# =============================================================================
+# Production-grade, self-hosted object storage. Replaces deployment.yaml (the
+# single-replica dev box). Do NOT apply both — they share the `app: minio`
+# selector and the client-facing Service (service.yaml) would fan out across two
+# different workloads.
+#
+# Topology: 4 MinIO servers, each with one drive, joined into a single
+# erasure-coded pool. With the default EC:2 parity on a 4-drive set, the cluster
+# tolerates the loss of up to 2 drives/nodes with zero data loss and stays
+# READ+WRITE available while >= quorum (write quorum = drives/2 + parity) is up.
+#
+# RECOMMENDED PRODUCTION ALTERNATIVE: a managed object store (AWS S3, GCS,
+# Azure Blob) where the provider owns durability/HA/scaling. VRSky's
+# cloud-storage workers already speak S3/GCS/Azure — see README "High
+# Availability" for when to pick managed vs. self-hosted MinIO.
+#
+# Prerequisites (same as the dev box):
+#   - namespace.yaml          (vrsky-storage)
+#   - secret minio-credentials (keys: accesskey, secretkey)
+#   - configmap minio-config   (key: MINIO_BROWSER)
+#   - StorageClass providing ReadWriteOnce PVs (here: local-path; use a real
+#     block/replicated class such as Longhorn/EBS/PD in production)
+#   - service.yaml             (client-facing ClusterIP, selector app: minio)
+#   - setup-job.yaml           (bucket bootstrap; runs once cluster is Ready)
+#
+# Scaling note: a distributed pool's server count is FIXED for the pool. To grow
+# capacity, add a NEW server pool (expand the `server` arg with another
+# https://...{4...7} range and bump replicas), never by editing an existing
+# pool's size in place. MinIO requires a minimum of 4 drives for erasure coding.
+# =============================================================================
+---
+# Headless service: gives each pod a stable DNS name
+# (minio-<ordinal>.minio-headless.vrsky-storage.svc.cluster.local) so the MinIO
+# servers can discover each other. Client traffic uses the regular `minio`
+# Service in service.yaml, not this one.
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio-headless
+  namespace: vrsky-storage
+  labels:
+    app: minio
+    component: object-storage
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true # peers must resolve each other before Ready
+  selector:
+    app: minio
+  ports:
+    - port: 9000
+      targetPort: 9000
+      protocol: TCP
+      name: api
+    - port: 9001
+      targetPort: 9001
+      protocol: TCP
+      name: console
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: minio
+  namespace: vrsky-storage
+  labels:
+    app: minio
+    component: object-storage
+spec:
+  serviceName: minio-headless
+  replicas: 4 # minimum for erasure coding; do not reduce below 4
+  podManagementPolicy: Parallel # all servers must come up together to form the pool
+  selector:
+    matchLabels:
+      app: minio
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: minio
+        component: object-storage
+    spec:
+      # Spread the 4 servers across nodes so a single node failure takes out at
+      # most one drive (stays within EC:2 fault tolerance). "ScheduleAnyway"
+      # keeps it best-effort on small/single-node dev clusters.
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app: minio
+      containers:
+        - name: minio
+          image: minio/minio:RELEASE.2025-09-07T16-13-09Z
+          args:
+            - server
+            - http://minio-{0...3}.minio-headless.vrsky-storage.svc.cluster.local/data
+            - --console-address
+            - :9001
+
+          env:
+            - name: MINIO_ROOT_USER
+              valueFrom:
+                secretKeyRef:
+                  name: minio-credentials
+                  key: accesskey
+            - name: MINIO_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: minio-credentials
+                  key: secretkey
+            - name: MINIO_BROWSER
+              valueFrom:
+                configMapKeyRef:
+                  name: minio-config
+                  key: MINIO_BROWSER
+
+          ports:
+            - containerPort: 9000
+              name: api
+            - containerPort: 9001
+              name: console
+
+          volumeMounts:
+            - name: data
+              mountPath: /data
+
+          resources:
+            requests:
+              cpu: 1
+              memory: 2Gi
+            limits:
+              cpu: 2
+              memory: 4Gi
+
+          livenessProbe:
+            httpGet:
+              path: /minio/health/live
+              port: 9000
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 10
+            failureThreshold: 3
+
+          # Cluster-aware readiness: a node reports ready only once the pool has
+          # read quorum, so the client Service won't route to a not-yet-joined
+          # server.
+          readinessProbe:
+            httpGet:
+              path: /minio/health/ready
+              port: 9000
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        storageClassName: local-path
+        resources:
+          requests:
+            storage: 100Gi
+---
+# Keep at least 3 of 4 servers up during voluntary disruptions (drains, node
+# upgrades) so the pool never drops below write quorum.
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: minio
+  namespace: vrsky-storage
+  labels:
+    app: minio
+    component: object-storage
+spec:
+  minAvailable: 3
+  selector:
+    matchLabels:
+      app: minio


### PR DESCRIPTION
## What

Adds a high-availability path for VRSky object storage. Production was a single MinIO replica with one drive — a node or PVC loss meant **data loss and downtime**. Closes #136.

## Changes

- **`statefulset-distributed.yaml` (new)** — self-hosted HA MinIO:
  - 4-server / 4-drive StatefulSet, single erasure-coded pool (default `EC:2` → tolerates **2 drive/node failures** with no data loss, stays read+write while write quorum holds)
  - headless Service for peer DNS discovery (`minio-{0...3}.minio-headless…`)
  - `topologySpreadConstraint` so a node failure costs at most one drive
  - `PodDisruptionBudget` (`minAvailable: 3`) keeps drains/upgrades above quorum
  - fronted by the existing client `service.yaml` (shared `app: minio` selector)
- **`deployment.yaml`** — header-marked **DEV / single-node only**.
- **`README.md`** — new **High Availability (production) — #136** section:
  - **Option A — managed object store (recommended):** S3 / GCS / Azure Blob; the cloud-storage workers already speak the S3 API, so it's endpoint + creds, not code. Prefer IRSA / Workload Identity / Managed Identity over static keys.
  - **Option B — self-hosted distributed MinIO:** apply order, pool-expansion (add a new pool, never resize in place), real `StorageClass`, node spread. Notes the MinIO Operator as an alternative.
  - replaces the old thin "Distributed Mode (Post-POC)" stub.

## Verification

YAML lint — both manifests parse (`yaml.safe_load_all`). No live k8s cluster available in this environment, so this is manifest + docs only (consistent with how #137 Postgres HA was handled).

## Notes

`deployment.yaml` and `statefulset-distributed.yaml` must **not** be applied together — they share the `app: minio` selector and the client Service would fan out across two workloads. README calls this out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)