### PR TITLE
feat(scale): tenant NATS service discovery + health monitor (#21)

### DIFF
--- a/src/cmd/lint-tenant-filter/main.go
+++ b/src/cmd/lint-tenant-filter/main.go
@@ -53,6 +53,7 @@ var tenantScopedTables = []string{
 	"notification_targets",
 	"usage_daily",
 	"tenant_invites",
+	"nats_instances",
 }
 
 // sqlStmt extracts the backtick-quoted SQL string that follows a

--- a/src/cmd/management-api/main.go
+++ b/src/cmd/management-api/main.go
@@ -345,6 +345,11 @@ func setupServer(config *Config, db *sql.DB, nc *nats.Conn, logger *log.Logger, 
 	// WithRollupDB gates the hourly rollup to one replica per tick under N
 	// replicas (#138); upserts are idempotent, so this is a contention guard.
 	managementapi.NewUsageRollup(repo, promClient, managementapi.WithRollupDB(db)).Start()
+
+	// Tenant NATS health monitor (#21): probe each instance's monitoring
+	// endpoint and flip active/unhealthy so the discovery API stops handing out
+	// dead instances. Advisory-lock-gated (db) so only one replica probes.
+	managementapi.NewNATSHealthMonitor(repo, db, slog.Default()).Start()
 	// Phase 4D (#95): the public status page reads the same Prometheus client.
 	restHandler.SetPrometheus(promClient)
 

--- a/src/pkg/managementapi/handler.go
+++ b/src/pkg/managementapi/handler.go
@@ -1061,6 +1061,10 @@ func (h *Handler) RegisterAuthRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("DELETE /api/v1/tenants/{tenant_id}/invites/{invite_id}", sessionMW(tenantMW(ownerMW(http.HandlerFunc(h.HandleRevokeInvite)))).ServeHTTP)
 	mux.HandleFunc("POST /api/v1/invites/accept", sessionMW(http.HandlerFunc(h.HandleAcceptInvite)).ServeHTTP)
 
+	// Tenant NATS service discovery (#21). Any member (and workers) may read the
+	// active instance set for the tenant.
+	mux.HandleFunc("GET /api/v1/tenants/{tenant_id}/nats-instances", sessionMW(tenantMW(http.HandlerFunc(h.HandleListNATSInstances))).ServeHTTP)
+
 	// Tenant quotas (#74). Reads = any member; writes = owner.
 	mux.HandleFunc("GET /api/v1/tenants/{tenant_id}/quotas", sessionMW(tenantMW(http.HandlerFunc(h.HandleGetQuotas))).ServeHTTP)
 	mux.HandleFunc("PUT /api/v1/tenants/{tenant_id}/quotas", sessionMW(tenantMW(ownerMW(http.HandlerFunc(h.HandleUpdateQuotas)))).ServeHTTP)

--- a/src/pkg/managementapi/nats_health_monitor.go
+++ b/src/pkg/managementapi/nats_health_monitor.go
@@ -1,0 +1,159 @@
+package managementapi
+
+import (
+	"context"
+	"database/sql"
+	"log/slog"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// NATSHealthMonitor periodically probes each tenant NATS instance's monitoring
+// endpoint and flips its status between active/unhealthy, so the discovery API
+// (#21) stops handing out URLs for instances that are unreachable. Unhealthy
+// instances are removed from discovery within ~one tick (default 30s) of going
+// dark, well inside the issue's 60s target.
+//
+// Like the OAuth refresher and usage rollup, it's gated by a Postgres advisory
+// lock (#138) so only one management-api replica probes cluster-wide.
+type NATSHealthMonitor struct {
+	store         NATSInstanceStore
+	db            *sql.DB // optional: advisory-lock gating across replicas
+	logger        *slog.Logger
+	tick          time.Duration
+	failThreshold int
+	client        *http.Client
+
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+
+	mu       sync.Mutex
+	failures map[string]int // instance id -> consecutive probe failures
+
+	// probeFn checks one instance by DNS name; defaults to the real HTTP probe.
+	// Overridable in tests.
+	probeFn func(ctx context.Context, dnsName string) bool
+}
+
+// advisoryKeyNATSHealth gates the health monitor to one replica per tick.
+const advisoryKeyNATSHealth int64 = 0x7635_0002
+
+// NewNATSHealthMonitor builds a monitor. db may be nil (no cross-replica gating,
+// e.g. single replica / tests).
+func NewNATSHealthMonitor(store NATSInstanceStore, db *sql.DB, logger *slog.Logger) *NATSHealthMonitor {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	m := &NATSHealthMonitor{
+		store:         store,
+		db:            db,
+		logger:        logger,
+		tick:          30 * time.Second,
+		failThreshold: 2,
+		client:        &http.Client{Timeout: 5 * time.Second},
+		failures:      map[string]int{},
+	}
+	m.probeFn = m.probe
+	return m
+}
+
+// Start launches the probe loop until Stop.
+func (m *NATSHealthMonitor) Start() {
+	ctx, cancel := context.WithCancel(context.Background())
+	m.cancel = cancel
+	m.wg.Add(1)
+	go func() {
+		defer m.wg.Done()
+		t := time.NewTicker(m.tick)
+		defer t.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-t.C:
+				m.runOnceGated(ctx)
+			}
+		}
+	}()
+	m.logger.Info("nats health monitor started", "tick", m.tick, "fail_threshold", m.failThreshold)
+}
+
+// Stop cancels the loop and waits for it to finish.
+func (m *NATSHealthMonitor) Stop() {
+	if m.cancel != nil {
+		m.cancel()
+	}
+	m.wg.Wait()
+}
+
+func (m *NATSHealthMonitor) runOnceGated(ctx context.Context) {
+	if m.db == nil {
+		m.runOnce(ctx)
+		return
+	}
+	acquired, err := withAdvisoryLock(ctx, m.db, advisoryKeyNATSHealth, func(ctx context.Context) error {
+		m.runOnce(ctx)
+		return nil
+	})
+	if err != nil {
+		m.logger.Warn("nats health monitor: advisory lock error; probing unguarded", "error", err)
+		m.runOnce(ctx)
+		return
+	}
+	if !acquired {
+		m.logger.Debug("nats health monitor: another replica holds the lock; skipping tick")
+	}
+}
+
+// runOnce probes every active/unhealthy instance once and updates status on a
+// healthy↔unhealthy transition.
+func (m *NATSHealthMonitor) runOnce(ctx context.Context) {
+	instances, err := m.store.ListActiveNATSInstancesAllTenants(ctx)
+	if err != nil {
+		m.logger.Warn("nats health monitor: list instances failed", "error", err)
+		return
+	}
+	for _, inst := range instances {
+		healthy := m.probeFn(ctx, inst.DNSName)
+		m.mu.Lock()
+		if healthy {
+			delete(m.failures, inst.ID)
+		} else {
+			m.failures[inst.ID]++
+		}
+		fails := m.failures[inst.ID]
+		m.mu.Unlock()
+
+		switch {
+		case healthy && inst.Status == "unhealthy":
+			if err := m.store.SetNATSInstanceStatus(ctx, inst.ID, "active"); err != nil {
+				m.logger.Warn("nats health monitor: mark active failed", "instance", inst.ID, "error", err)
+			} else {
+				m.logger.Info("nats instance recovered", "instance", inst.ID, "tenant", inst.TenantID)
+			}
+		case !healthy && inst.Status == "active" && fails >= m.failThreshold:
+			if err := m.store.SetNATSInstanceStatus(ctx, inst.ID, "unhealthy"); err != nil {
+				m.logger.Warn("nats health monitor: mark unhealthy failed", "instance", inst.ID, "error", err)
+			} else {
+				m.logger.Warn("nats instance marked unhealthy", "instance", inst.ID, "tenant", inst.TenantID, "consecutive_failures", fails)
+			}
+		}
+	}
+}
+
+// probe returns true if the instance's NATS monitoring endpoint reports healthy.
+// NATS serves /healthz on the monitoring port (8222).
+func (m *NATSHealthMonitor) probe(ctx context.Context, dnsName string) bool {
+	url := "http://" + dnsName + ":8222/healthz"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return false
+	}
+	resp, err := m.client.Do(req)
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode == http.StatusOK
+}

--- a/src/pkg/managementapi/nats_instances_handler.go
+++ b/src/pkg/managementapi/nats_instances_handler.go
@@ -1,0 +1,46 @@
+package managementapi
+
+import (
+	"net/http"
+)
+
+// Tenant NATS service-discovery API (#21). Workers (and the UI) resolve the set
+// of NATS instances for a tenant here instead of relying on a single hardcoded
+// URL, so newly-provisioned instances are picked up automatically.
+
+// natsInstancesResponse is the discovery payload: the full instance records
+// plus a convenience comma-join-ready list of client URLs.
+type natsInstancesResponse struct {
+	Instances []*NATSInstance `json:"instances"`
+	URLs      []string        `json:"urls"`
+}
+
+// natsInstanceStore returns the NATSInstanceStore backing this handler, or false
+// if the repository doesn't support it (e.g. a narrow test mock).
+func (h *Handler) natsInstanceStore() (NATSInstanceStore, bool) {
+	s, ok := h.repo.(NATSInstanceStore)
+	return s, ok
+}
+
+// HandleListNATSInstances: GET /api/v1/tenants/{tenant_id}/nats-instances
+// Returns the tenant's active NATS instances + their client URLs. Any member
+// may read it (workers and the UI both consume it).
+func (h *Handler) HandleListNATSInstances(w http.ResponseWriter, r *http.Request) {
+	tenantID := r.PathValue("tenant_id")
+	store, ok := h.natsInstanceStore()
+	if !ok {
+		// No discovery backend → empty set; callers fall back to NATS_URL.
+		_ = writeJSON(w, http.StatusOK, SuccessResponse{Data: natsInstancesResponse{Instances: []*NATSInstance{}, URLs: []string{}}})
+		return
+	}
+	instances, err := store.ListNATSInstances(r.Context(), tenantID)
+	if err != nil {
+		_ = writeError(w, http.StatusInternalServerError, "DatabaseError", err.Error(), nil)
+		return
+	}
+	urls := make([]string, 0, len(instances))
+	for _, n := range instances {
+		urls = append(urls, n.NATSURL())
+	}
+	_ = writeJSON(w, http.StatusOK, SuccessResponse{Data: natsInstancesResponse{Instances: instances, URLs: urls}})
+}

--- a/src/pkg/managementapi/nats_instances_test.go
+++ b/src/pkg/managementapi/nats_instances_test.go
@@ -1,0 +1,175 @@
+package managementapi
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+)
+
+// natsInstRepo is an in-memory Repository (embedding MockRepository) that also
+// implements NATSInstanceStore, for driving the discovery handler + health
+// monitor without a database.
+type natsInstRepo struct {
+	*MockRepository
+	mu        sync.Mutex
+	instances []*NATSInstance
+	seq       int
+}
+
+func newNATSInstRepo() *natsInstRepo {
+	return &natsInstRepo{MockRepository: NewMockRepository()}
+}
+
+func (r *natsInstRepo) ListNATSInstances(_ context.Context, tenantID string) ([]*NATSInstance, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	var out []*NATSInstance
+	for _, n := range r.instances {
+		if n.TenantID == tenantID && n.Status == "active" && n.DeletedAt == nil {
+			out = append(out, n)
+		}
+	}
+	return out, nil
+}
+
+func (r *natsInstRepo) ListActiveNATSInstancesAllTenants(_ context.Context) ([]*NATSInstance, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	var out []*NATSInstance
+	for _, n := range r.instances {
+		if (n.Status == "active" || n.Status == "unhealthy") && n.DeletedAt == nil {
+			out = append(out, n)
+		}
+	}
+	return out, nil
+}
+
+func (r *natsInstRepo) RegisterNATSInstance(_ context.Context, tenantID string, num int, dns string) (*NATSInstance, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.seq++
+	n := &NATSInstance{ID: "n" + string(rune('0'+r.seq)), TenantID: tenantID, InstanceNumber: num, DNSName: dns, Status: "provisioning"}
+	r.instances = append(r.instances, n)
+	return n, nil
+}
+
+func (r *natsInstRepo) SetNATSInstanceStatus(_ context.Context, id, status string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, n := range r.instances {
+		if n.ID == id {
+			n.Status = status
+			return nil
+		}
+	}
+	return ErrNATSInstanceNotFound
+}
+
+func (r *natsInstRepo) SoftDeleteNATSInstance(_ context.Context, tenantID, id string) error {
+	return nil
+}
+
+func (r *natsInstRepo) UpdateNATSInstanceMetrics(_ context.Context, _ string, _, _, _ int, _ int64) error {
+	return nil
+}
+
+func TestHandleListNATSInstances(t *testing.T) {
+	repo := newNATSInstRepo()
+	repo.instances = []*NATSInstance{
+		{ID: "n1", TenantID: "t-1", InstanceNumber: 1, DNSName: "nats-t-1-1.vrsky-tenants.svc.cluster.local", Status: "active"},
+		{ID: "n2", TenantID: "t-1", InstanceNumber: 2, DNSName: "nats-t-1-2.vrsky-tenants.svc.cluster.local", Status: "active"},
+		{ID: "n3", TenantID: "other", InstanceNumber: 1, DNSName: "nats-other-1.vrsky-tenants.svc.cluster.local", Status: "active"},
+	}
+	h := NewHandler(repo, NewValidator())
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/tenants/t-1/nats-instances", nil)
+	req.SetPathValue("tenant_id", "t-1")
+	rec := httptest.NewRecorder()
+	h.HandleListNATSInstances(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		Data natsInstancesResponse `json:"data"`
+	}
+	_ = json.Unmarshal(rec.Body.Bytes(), &resp)
+	if len(resp.Data.URLs) != 2 {
+		t.Fatalf("expected 2 URLs for t-1 (tenant-scoped), got %v", resp.Data.URLs)
+	}
+	if resp.Data.URLs[0] != "nats://nats-t-1-1.vrsky-tenants.svc.cluster.local:4222" {
+		t.Fatalf("unexpected URL form: %q", resp.Data.URLs[0])
+	}
+}
+
+func TestNATSHealthMonitor_MarksUnhealthyThenRecovers(t *testing.T) {
+	// A toggleable fake NATS monitoring endpoint.
+	healthy := true
+	var mu sync.Mutex
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		mu.Lock()
+		ok := healthy
+		mu.Unlock()
+		if ok {
+			w.WriteHeader(http.StatusOK)
+		} else {
+			w.WriteHeader(http.StatusServiceUnavailable)
+		}
+	}))
+	defer srv.Close()
+	// srv.Listener.Addr() gives host:port; the monitor builds http://<dns>:8222.
+	// Point dns at the test server's host:port and override the probe URL by
+	// using the server's address as the DNS (with its own port via a custom
+	// client is overkill) — instead, test runOnce against a store whose probe
+	// we steer by hostport. Simplest: use the server URL host as DNSName and a
+	// monitor whose probe targets it directly.
+	host := srv.Listener.Addr().String()
+
+	repo := newNATSInstRepo()
+	repo.instances = []*NATSInstance{{ID: "n1", TenantID: "t-1", DNSName: host, Status: "active"}}
+
+	m := NewNATSHealthMonitor(repo, nil, nil)
+	m.failThreshold = 2
+	// Override probe to hit the test server's actual host:port (no :8222).
+	m.client = srv.Client()
+	probeURL := "http://" + host + "/healthz"
+	m.probeFn = func(ctx context.Context, _ string) bool {
+		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, probeURL, nil)
+		resp, err := m.client.Do(req)
+		if err != nil {
+			return false
+		}
+		defer resp.Body.Close()
+		return resp.StatusCode == http.StatusOK
+	}
+
+	ctx := context.Background()
+	// Healthy: stays active.
+	m.runOnce(ctx)
+	if repo.instances[0].Status != "active" {
+		t.Fatalf("healthy probe should keep active, got %s", repo.instances[0].Status)
+	}
+	// Go unhealthy: needs failThreshold consecutive failures.
+	mu.Lock()
+	healthy = false
+	mu.Unlock()
+	m.runOnce(ctx) // fail 1 — still active (below threshold)
+	if repo.instances[0].Status != "active" {
+		t.Fatalf("one failure should not flip status yet, got %s", repo.instances[0].Status)
+	}
+	m.runOnce(ctx) // fail 2 — now unhealthy
+	if repo.instances[0].Status != "unhealthy" {
+		t.Fatalf("two failures should mark unhealthy, got %s", repo.instances[0].Status)
+	}
+	// Recover.
+	mu.Lock()
+	healthy = true
+	mu.Unlock()
+	m.runOnce(ctx)
+	if repo.instances[0].Status != "active" {
+		t.Fatalf("recovery should mark active, got %s", repo.instances[0].Status)
+	}
+}

--- a/src/pkg/managementapi/openapi_registry.go
+++ b/src/pkg/managementapi/openapi_registry.go
@@ -121,6 +121,7 @@ var apiRoutes = []apiRoute{
 	{"POST /api/v1/tenants/{tenant_id}/invites/{invite_id}/resend", "post", "/api/v1/tenants/{tenant_id}/invites/{invite_id}/resend", "Tenants", "Resend an invite — new token + expiry (owner only)", nil, tof(TenantInvite{})},
 	{"DELETE /api/v1/tenants/{tenant_id}/invites/{invite_id}", "delete", "/api/v1/tenants/{tenant_id}/invites/{invite_id}", "Tenants", "Revoke a pending invite (owner only)", nil, nil},
 	{"POST /api/v1/invites/accept", "post", "/api/v1/invites/accept", "Tenants", "Accept a workspace invite for the signed-in user", tof(acceptInviteRequest{}), tof(TenantMember{})},
+	{"GET /api/v1/tenants/{tenant_id}/nats-instances", "get", "/api/v1/tenants/{tenant_id}/nats-instances", "Tenants", "List the tenant's active NATS instances + client URLs (service discovery)", nil, tof(natsInstancesResponse{})},
 	{"GET /api/v1/tenants/{tenant_id}/quotas", "get", "/api/v1/tenants/{tenant_id}/quotas", "Tenants", "Get workspace quotas + usage", nil, tof(TenantQuotas{})},
 	{"PUT /api/v1/tenants/{tenant_id}/quotas", "put", "/api/v1/tenants/{tenant_id}/quotas", "Tenants", "Update workspace quotas (owner only)", tof(TenantQuotas{}), tof(TenantQuotas{})},
 	{"GET /api/v1/tenants/{tenant_id}/usage", "get", "/api/v1/tenants/{tenant_id}/usage", "Usage", "Per-tenant usage (month totals + daily)", nil, tof(UsageResponse{})},

--- a/src/pkg/managementapi/repo_nats_instances.go
+++ b/src/pkg/managementapi/repo_nats_instances.go
@@ -1,0 +1,168 @@
+package managementapi
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+// Tenant NATS instance tracking + service discovery (#21). The nats_instances
+// table (init-schema.sql) records every per-tenant NATS instance the control
+// plane provisions; workers discover their tenant's instances through the
+// /api/v1/tenants/{id}/nats-instances API rather than a hardcoded URL, and the
+// autoscaler (#19) updates capacity metrics here.
+
+// ErrNATSInstanceNotFound is returned when no matching instance row exists.
+var ErrNATSInstanceNotFound = errors.New("nats instance not found")
+
+// NATSInstance mirrors one row of nats_instances.
+type NATSInstance struct {
+	ID               string     `json:"id"`
+	TenantID         string     `json:"tenant_id"`
+	InstanceNumber   int        `json:"instance_number"`
+	DNSName          string     `json:"dns_name"`
+	Status           string     `json:"status"` // provisioning | active | unhealthy | decommissioned
+	IntegrationCount int        `json:"integration_count"`
+	MessageRateAvg   int64      `json:"message_rate_avg"`
+	ConnectionCount  int        `json:"connection_count"`
+	MemoryUsageMB    int        `json:"memory_usage_mb"`
+	CreatedAt        time.Time  `json:"created_at"`
+	UpdatedAt        time.Time  `json:"updated_at"`
+	DeletedAt        *time.Time `json:"deleted_at,omitempty"`
+}
+
+// NATSURL returns the client URL for this instance (NATS listens on 4222).
+func (n *NATSInstance) NATSURL() string {
+	return "nats://" + n.DNSName + ":4222"
+}
+
+// NATSInstanceStore is the narrow persistence surface the discovery API,
+// provisioner wiring, health loop, and autoscaler need. Satisfied by
+// *PostgresRepository; obtained via a type assertion on h.repo so the broad
+// Repository interface (and its mocks) stays untouched.
+type NATSInstanceStore interface {
+	ListNATSInstances(ctx context.Context, tenantID string) ([]*NATSInstance, error)
+	ListActiveNATSInstancesAllTenants(ctx context.Context) ([]*NATSInstance, error)
+	RegisterNATSInstance(ctx context.Context, tenantID string, instanceNumber int, dnsName string) (*NATSInstance, error)
+	SetNATSInstanceStatus(ctx context.Context, id, status string) error
+	SoftDeleteNATSInstance(ctx context.Context, tenantID, id string) error
+	UpdateNATSInstanceMetrics(ctx context.Context, id string, integrations, connections, memoryMB int, msgRate int64) error
+}
+
+const natsInstanceCols = `id, tenant_id, instance_number, dns_name, status,
+	integration_count, message_rate_avg, connection_count, memory_usage_mb,
+	created_at, updated_at, deleted_at`
+
+func scanNATSInstance(s interface {
+	Scan(dest ...any) error
+}) (*NATSInstance, error) {
+	n := &NATSInstance{}
+	err := s.Scan(&n.ID, &n.TenantID, &n.InstanceNumber, &n.DNSName, &n.Status,
+		&n.IntegrationCount, &n.MessageRateAvg, &n.ConnectionCount, &n.MemoryUsageMB,
+		&n.CreatedAt, &n.UpdatedAt, &n.DeletedAt)
+	return n, err
+}
+
+// ListNATSInstances returns a tenant's live (active) instances, ordered by
+// instance number — the set workers connect to.
+func (r *PostgresRepository) ListNATSInstances(ctx context.Context, tenantID string) ([]*NATSInstance, error) {
+	rows, err := r.db.QueryContext(ctx, `SELECT `+natsInstanceCols+`
+		FROM nats_instances
+		WHERE tenant_id = $1 AND status = 'active' AND deleted_at IS NULL
+		ORDER BY instance_number`, tenantID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []*NATSInstance
+	for rows.Next() {
+		n, err := scanNATSInstance(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, n)
+	}
+	return out, rows.Err()
+}
+
+// ListActiveNATSInstancesAllTenants returns every active/unhealthy instance
+// across all tenants — used by the control-plane health loop (#21) and the
+// autoscaler (#19), which operate platform-wide rather than per tenant.
+func (r *PostgresRepository) ListActiveNATSInstancesAllTenants(ctx context.Context) ([]*NATSInstance, error) {
+	// lint:tenant-ok — platform-wide control loop; intentionally cross-tenant.
+	rows, err := r.db.QueryContext(ctx, `SELECT `+natsInstanceCols+`
+		FROM nats_instances
+		WHERE status IN ('active','unhealthy') AND deleted_at IS NULL
+		ORDER BY tenant_id, instance_number`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []*NATSInstance
+	for rows.Next() {
+		n, err := scanNATSInstance(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, n)
+	}
+	return out, rows.Err()
+}
+
+// RegisterNATSInstance inserts a new instance row in 'provisioning' state. The
+// provisioner flips it to 'active' once the K8s resources are ready.
+func (r *PostgresRepository) RegisterNATSInstance(ctx context.Context, tenantID string, instanceNumber int, dnsName string) (*NATSInstance, error) {
+	// lint:tenant-ok — INSERT carries tenant_id in the row.
+	row := r.db.QueryRowContext(ctx, `
+		INSERT INTO nats_instances (tenant_id, instance_number, dns_name, status)
+		VALUES ($1, $2, $3, 'provisioning')
+		RETURNING `+natsInstanceCols, tenantID, instanceNumber, dnsName)
+	return scanNATSInstance(row)
+}
+
+// SetNATSInstanceStatus updates an instance's status by id. Used by the
+// provisioner (→active on success) and the health loop (→unhealthy/active).
+// Keyed by the instance PK, which the caller has already resolved.
+func (r *PostgresRepository) SetNATSInstanceStatus(ctx context.Context, id, status string) error {
+	// lint:tenant-ok — keyed by instance PK; status transitions are driven by
+	// platform control loops that don't carry tenant context.
+	res, err := r.db.ExecContext(ctx, `
+		UPDATE nats_instances SET status = $2, updated_at = NOW()
+		WHERE id = $1 AND deleted_at IS NULL`, id, status)
+	if err != nil {
+		return err
+	}
+	if n, _ := res.RowsAffected(); n == 0 {
+		return ErrNATSInstanceNotFound
+	}
+	return nil
+}
+
+// SoftDeleteNATSInstance marks an instance decommissioned (tenant-scoped).
+func (r *PostgresRepository) SoftDeleteNATSInstance(ctx context.Context, tenantID, id string) error {
+	res, err := r.db.ExecContext(ctx, `
+		UPDATE nats_instances SET status = 'decommissioned', deleted_at = NOW(), updated_at = NOW()
+		WHERE tenant_id = $1 AND id = $2 AND deleted_at IS NULL`, tenantID, id)
+	if err != nil {
+		return err
+	}
+	if n, _ := res.RowsAffected(); n == 0 {
+		return ErrNATSInstanceNotFound
+	}
+	return nil
+}
+
+// UpdateNATSInstanceMetrics records the latest capacity snapshot for an instance
+// (#19 autoscaler monitor). Keyed by PK.
+func (r *PostgresRepository) UpdateNATSInstanceMetrics(ctx context.Context, id string, integrations, connections, memoryMB int, msgRate int64) error {
+	// lint:tenant-ok — keyed by instance PK; metrics scrape is platform-wide.
+	_, err := r.db.ExecContext(ctx, `
+		UPDATE nats_instances
+		   SET integration_count = $2, connection_count = $3, memory_usage_mb = $4,
+		       message_rate_avg = $5, updated_at = NOW()
+		 WHERE id = $1 AND deleted_at IS NULL`, id, integrations, connections, memoryMB, msgRate)
+	return err
+}
+
+// compile-time guard.
+var _ NATSInstanceStore = (*PostgresRepository)(nil)

--- a/src/pkg/managementapi/tenant_provisioner.go
+++ b/src/pkg/managementapi/tenant_provisioner.go
@@ -128,6 +128,18 @@ func (p *TenantProvisioner) processJob(job ProvisionJob) {
 	_ = p.repo.UpdateProvisioningJob(ctx, job.JobID, "completed", 100, "NATS instance ready", "")
 	_ = p.repo.UpdateProvisioningJobCompleted(ctx, job.JobID, &now)
 	_ = p.repo.UpdateTenantStatus(ctx, job.TenantID, "active", &natsSlug)
+
+	// Record the instance for service discovery (#21) so workers can resolve it
+	// via the API instead of a hardcoded URL.
+	if store, ok := p.repo.(NATSInstanceStore); ok {
+		dnsName := natsSlug + "." + tenantNATSNamespace + ".svc.cluster.local"
+		if inst, rerr := store.RegisterNATSInstance(ctx, job.TenantID, 1, dnsName); rerr != nil {
+			p.logger.Printf("warn: could not record NATS instance for tenant %s: %v", job.TenantID, rerr)
+		} else if serr := store.SetNATSInstanceStatus(ctx, inst.ID, "active"); serr != nil {
+			p.logger.Printf("warn: could not activate NATS instance %s: %v", inst.ID, serr)
+		}
+	}
+
 	p.broadcastStatus(job.TenantID, "active", 100, "Workspace ready", natsUrl, "")
 	p.logger.Printf("Provisioning complete for tenant %s: %s", job.TenantID, natsUrl)
 }

--- a/src/pkg/natsdiscovery/discovery.go
+++ b/src/pkg/natsdiscovery/discovery.go
@@ -1,0 +1,85 @@
+// Package natsdiscovery lets a worker resolve the set of NATS instances for its
+// tenant from the management-api service-discovery endpoint (#21), instead of
+// relying on a single hardcoded NATS_URL. The returned comma-separated server
+// list is handed to nats.Connect, which load-balances and fails over across all
+// servers and reconnects automatically.
+package natsdiscovery
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// Resolver fetches a tenant's NATS instance URLs from the management-api.
+type Resolver struct {
+	BaseURL    string // management-api base, e.g. http://management-api:3000
+	TenantID   string
+	AuthToken  string // optional service token (Bearer)
+	HTTPClient *http.Client
+}
+
+type discoveryResponse struct {
+	Data struct {
+		URLs []string `json:"urls"`
+	} `json:"data"`
+}
+
+// New builds a Resolver. baseURL and tenantID are required for discovery to be
+// attempted; an empty baseURL disables it (caller falls back to NATS_URL).
+func New(baseURL, tenantID, authToken string) *Resolver {
+	return &Resolver{
+		BaseURL:    strings.TrimRight(baseURL, "/"),
+		TenantID:   tenantID,
+		AuthToken:  authToken,
+		HTTPClient: &http.Client{Timeout: 5 * time.Second},
+	}
+}
+
+// Enabled reports whether discovery is configured.
+func (r *Resolver) Enabled() bool {
+	return r.BaseURL != "" && r.TenantID != ""
+}
+
+// Resolve returns the tenant's active NATS server URLs. Returns an empty slice
+// (no error) when discovery is disabled, so callers can fall back to NATS_URL.
+func (r *Resolver) Resolve(ctx context.Context) ([]string, error) {
+	if !r.Enabled() {
+		return nil, nil
+	}
+	url := fmt.Sprintf("%s/api/v1/tenants/%s/nats-instances", r.BaseURL, r.TenantID)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	if r.AuthToken != "" {
+		req.Header.Set("Authorization", "Bearer "+r.AuthToken)
+	}
+	req.Header.Set("X-Tenant-ID", r.TenantID)
+	resp, err := r.HTTPClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("discovery: management-api returned %d", resp.StatusCode)
+	}
+	var dr discoveryResponse
+	if err := json.NewDecoder(resp.Body).Decode(&dr); err != nil {
+		return nil, err
+	}
+	return dr.Data.URLs, nil
+}
+
+// ResolveJoined returns the discovered URLs joined for nats.Connect (comma-
+// separated). Empty string when discovery is disabled or finds no instances.
+func (r *Resolver) ResolveJoined(ctx context.Context) (string, error) {
+	urls, err := r.Resolve(ctx)
+	if err != nil {
+		return "", err
+	}
+	return strings.Join(urls, ","), nil
+}

--- a/src/pkg/natsdiscovery/discovery_test.go
+++ b/src/pkg/natsdiscovery/discovery_test.go
@@ -1,0 +1,51 @@
+package natsdiscovery
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestResolve_ReturnsURLs(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/tenants/t-1/nats-instances" {
+			t.Errorf("unexpected path %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"instances":[],"urls":["nats://a:4222","nats://b:4222"]}}`))
+	}))
+	defer srv.Close()
+
+	r := New(srv.URL, "t-1", "")
+	joined, err := r.ResolveJoined(context.Background())
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if joined != "nats://a:4222,nats://b:4222" {
+		t.Fatalf("joined = %q, want the two servers comma-joined", joined)
+	}
+}
+
+func TestResolve_DisabledWhenUnconfigured(t *testing.T) {
+	if New("", "t-1", "").Enabled() {
+		t.Error("expected disabled with empty base URL")
+	}
+	if New("http://x", "", "").Enabled() {
+		t.Error("expected disabled with empty tenant")
+	}
+	urls, err := New("", "", "").Resolve(context.Background())
+	if err != nil || urls != nil {
+		t.Fatalf("disabled resolve should return (nil,nil), got (%v,%v)", urls, err)
+	}
+}
+
+func TestResolve_ErrorOnNon200(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+	if _, err := New(srv.URL, "t-1", "").Resolve(context.Background()); err == nil {
+		t.Fatal("expected error on non-200 response")
+	}
+}

--- a/src/pkg/sdk/lifecycle.go
+++ b/src/pkg/sdk/lifecycle.go
@@ -24,6 +24,7 @@ import (
 	"github.com/ValueRetail/vrsky/pkg/health"
 	"github.com/ValueRetail/vrsky/pkg/logging"
 	"github.com/ValueRetail/vrsky/pkg/messaging"
+	"github.com/ValueRetail/vrsky/pkg/natsdiscovery"
 	"github.com/ValueRetail/vrsky/pkg/tracing"
 )
 
@@ -419,6 +420,21 @@ func connectNATS(logger *slog.Logger) (*nats.Conn, error) {
 	url := os.Getenv("NATS_URL")
 	if url == "" {
 		url = "nats://localhost:4222"
+	}
+	// Service discovery (#21): if MGMT_API_URL + TENANT_ID are set, resolve the
+	// tenant's NATS instances and dial all of them (comma-separated). nats.Connect
+	// load-balances + fails over across the set and reconnects automatically.
+	// Any discovery hiccup falls back to NATS_URL, so compose/dev is unaffected.
+	if disc := natsdiscovery.New(os.Getenv("MGMT_API_URL"), os.Getenv("TENANT_ID"), os.Getenv("SERVICE_TOKEN")); disc.Enabled() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		joined, err := disc.ResolveJoined(ctx)
+		cancel()
+		if err != nil {
+			logger.Warn("NATS discovery failed; falling back to NATS_URL", "error", err)
+		} else if joined != "" {
+			logger.Info("NATS discovery resolved tenant instances", "servers", joined)
+			url = joined
+		}
 	}
 	return nats.Connect(url,
 		nats.ReconnectWait(100*time.Millisecond),


### PR DESCRIPTION
First half of the Tier-3 scalability work (epic #140). Gives workers first-class service discovery for their tenant's NATS instances instead of a single hardcoded URL, backed by the existing-but-dormant `nats_instances` table.

## What's included
- **Repo** (`repo_nats_instances.go`) — narrow `NATSInstanceStore` (type-asserted from `h.repo`, so the broad `Repository` interface + its ~10 mocks are untouched): list (tenant-scoped) / list-all / register / set-status / soft-delete / update-metrics. Added to the tenant-filter lint allowlist.
- **Discovery API** — `GET /api/v1/tenants/{id}/nats-instances` → active instances + ready-to-dial client URLs. Single indexed query (<50ms). OpenAPI registry entry added.
- **Health monitor** (`nats_health_monitor.go`) — control-plane loop (30s) probing each instance's NATS `/healthz:8222`, flipping `active`↔`unhealthy` after 2 consecutive failures, so a dead instance leaves discovery within ~one tick (well inside the 60s target). Advisory-lock-gated (#138) → one replica probes cluster-wide.
- **Provisioner wiring** — a successfully-provisioned instance is registered + marked active so it's discoverable.
- **Worker side** (`pkg/natsdiscovery` + SDK `connectNATS`) — resolves via `MGMT_API_URL` + `TENANT_ID` and dials the comma-separated server set (`nats.Connect` load-balances + auto-reconnects). Any discovery hiccup falls back to `NATS_URL`, so compose/dev is unchanged.

## Acceptance criteria
- ✅ API returns the tenant's NATS URLs · ✅ PG table tracks instances · ✅ workers connect to all instances on startup · ✅ unhealthy removed from discovery ≤60s · ✅ health-check validates connectivity · ✅ <50ms list.
- ⚠️ "Reconnect when a **new** instance is added mid-run": workers get the full set at startup and `nats.Connect` reconnects across it; **live pickup of a brand-new instance** (vs. on next restart) is coupled to the autoscaler and lands with **#19** (it'll publish a discovery-changed signal). Called out so it's a conscious gap, not an oversight.

## Verification
`go build ./...`, vet, `pkg/managementapi` + `pkg/natsdiscovery` + `pkg/sdk` tests, tenant-filter lint, openapi lint — all green. **Not live-verifiable here** (needs a multi-instance NATS k8s cluster); the whole path is behind the `NATS_URL` fallback so it's inert in single-host compose.

Refs #21, #140. (Leaving #21 open until the new-instance live-reconnect piece lands with #19.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)