### PR TITLE
Validate #157 orchestrator + fix worker deploy bugs (#159)

### DIFF
--- a/docs/TIER3_VALIDATION.md
+++ b/docs/TIER3_VALIDATION.md
@@ -110,18 +110,55 @@ These broke *any* clean deploy — several would hit production identically:
 
 ### Blocked / deferred
 
-- **#135 worker autoscaling under load — orchestrator now wired (#157).** The k8s
-  orchestrator that creates per-connection worker `Deployment`s + HPAs is now wired
-  into the management-api: `main.go` calls `SetOrchestratorFactory` when
-  `ORCHESTRATOR_MODE=k8s` (set in `management-api/deployment.yaml`), sharing the same
-  K8s client as the tenant NATS provisioner. Starting a graph connection deploys a
-  Deployment + HPA per node; stopping it tears them down. The end-to-end scale-up
-  test (check 1 above) is now **runnable** once the generic worker images are imported
-  (`k3d-load-images.sh workers`) — live validation of the scale-up/down is tracked as
-  **#159**.
 - **Throughput re-measure on the scaled topology** → `docs/LOAD.md` (tracked on
-  **#15**). Needs the orchestrator (now wired) plus a load generator against the
-  cluster ingress.
+  **#15**). Needs a load generator against the cluster ingress; the per-connection
+  workers now run and autoscale (below), so this is unblocked.
+
+## Validation run — k3d, 2026-07-20 (#157 orchestrator + #135 autoscaling)
+
+Validated the per-connection orchestrator (#157) and worker autoscaling (#135)
+end-to-end on the local k3d cluster. Imported the generic worker images
+(`k3d-load-images.sh workers` → `vrsky-{consumer,producer,filter,converter}`),
+enabled `ORCHESTRATOR_MODE=k8s`, and drove a `consumer → producer` graph
+connection through its lifecycle:
+
+- **Start → Deployment + HPA per node (#157).** Starting the connection created
+  `vrsky-<conn>-consumer-0` and `vrsky-<conn>-producer-0` Deployments **and** an
+  HPA each (min 1 / max 10 / 75% CPU); both worker pods reached `Running`.
+- **Autoscale under load (#135) — PASS.** Flooding the consumer's `POST /webhook`
+  input drove its CPU to ~620%; the **consumer HPA scaled 1 → 4 → 8 → 10**
+  (maxReplicas), `10/10` available. The **producer HPA stayed at 1** (cpu ~2%) —
+  only the node actually under load scaled, confirming per-node HPAs act
+  independently. Scale-down follows the standard ~5-min HPA stabilization window.
+- **Stop → teardown (#157).** Stopping the connection removed both Deployments and
+  both HPAs (`deploy=0 hpa=0` within ~2s).
+
+### Bugs fixed during this run (all on the #159 branch)
+
+1. **Connection status never persisted.** `StartConnection`/`StopConnection` set
+   `conn.Status` in memory then called the general `UpdateConnection`, whose SQL
+   never writes the `status` column — so connections stayed `stopped` in the DB
+   even while running. The stop path's `status == "stopped"` idempotency guard then
+   skipped orchestrator teardown, **leaking worker Deployments + HPAs on every
+   stop**. Fixed by routing both through `UpdateConnectionStatus`. (Latent before
+   #157 — status was cosmetic; load-bearing once teardown depends on it.)
+2. **Orchestrator worker images used the default pull policy.** With `:latest` that
+   defaults to `Always`, so pods `ErrImagePull`'d against the unreachable
+   `gcr.io/vrsky` even when the image was k3d-imported. Set `imagePullPolicy:
+   IfNotPresent` on the generated Deployments.
+3. **`vrsky-converter` image wouldn't build** (`cmd/converter/Dockerfile`): forced
+   `CGO_ENABLED=1 GOARCH=amd64` (uncompilable on arm64; the converter needs CGO for
+   wasmtime) into an alpine/musl runtime a glibc binary can't load. Now builds for
+   the native arch on a glibc (`debian-slim`) runtime.
+
+### Worker config note
+
+The generic `pkg/runtime` workers the orchestrator deploys take their source/sink
+config from the node `config` JSON: a consumer needs `{"input_type":...,
+"input_config":{...}}` (default `http` → `POST /webhook` on port 8000) and a
+producer needs `{"output_type":"nats|http","output_config":{...}}` (the default
+`file` output type is not supported by that runtime). An empty `{}` config makes a
+worker crash-loop on startup — valid config is required to exercise a pipeline.
 
 ## What this can't cover here
 

--- a/src/cmd/converter/Dockerfile
+++ b/src/cmd/converter/Dockerfile
@@ -11,16 +11,23 @@ COPY src/internal/ ./internal/
 
 RUN go mod download
 
-RUN CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build \
+# The converter needs CGO (wasmtime WASM engine), so it cannot be cross-compiled
+# without a matching cross toolchain. Build for the build platform's native arch
+# (BuildKit sets GOARCH via TARGETARCH) instead of hardcoding amd64 — that let the
+# image build on arm64 hosts (e.g. Apple Silicon / k3d) and keeps CI multi-arch.
+ARG TARGETARCH
+RUN CGO_ENABLED=1 GOOS=linux GOARCH=${TARGETARCH} go build \
     -ldflags="-w -s" \
     -o converter \
     ./cmd/converter
 
-FROM alpine:3.18
+# wasmtime links against glibc (not musl), so the runtime base must be glibc —
+# an alpine/musl runtime would fail to load the CGO binary at startup.
+FROM debian:bookworm-slim
 
 WORKDIR /app
 
-RUN apk add --no-cache ca-certificates curl
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /build/converter .
 

--- a/src/pkg/managementapi/handler.go
+++ b/src/pkg/managementapi/handler.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"strconv"
 	"strings"
@@ -560,17 +561,21 @@ func (h *Handler) StartConnection(w http.ResponseWriter, r *http.Request) {
 		orch := h.orchestratorFactory(conn)
 		if err := orch.StartPipeline(ctx, conn); err != nil {
 			// Deployment failed - don't update status to running
+			slog.Default().Error("connection start: orchestrator deploy failed", "connection", connID, "error", err)
 			_ = writeError(w, http.StatusInternalServerError, "OrchestratorError",
 				fmt.Sprintf("failed to deploy pipeline: %v", err), nil)
 			return
 		}
 	}
 
-	// Update connection status to Running
+	// Update connection status to Running. Must use UpdateConnectionStatus:
+	// the general UpdateConnection does NOT persist status/started_at, so relying
+	// on it left connections permanently "stopped" in the DB — which made the
+	// stop path's idempotency guard skip orchestrator teardown (leaking workers).
 	conn.Status = "running"
 	conn.StartedAt = pointerTo(time.Now().UTC())
 
-	if err := h.repo.UpdateConnection(ctx, conn); err != nil {
+	if err := h.repo.UpdateConnectionStatus(ctx, connID, "running", nil); err != nil {
 		_ = writeError(w, http.StatusInternalServerError, "DatabaseError", "failed to update connection status", nil)
 		return
 	}
@@ -647,13 +652,21 @@ func (h *Handler) StopConnection(w http.ResponseWriter, r *http.Request) {
 	if len(conn.Nodes) > 0 && h.orchestratorFactory != nil {
 		orch := h.orchestratorFactory(conn)
 		orchestratorErr = orch.StopPipeline(ctx, conn)
+		if orchestratorErr != nil {
+			slog.Default().Error("connection stop: orchestrator teardown failed", "connection", connID, "error", orchestratorErr)
+		}
 	}
 
-	// Update connection status to Stopped
+	// Update connection status to Stopped (via UpdateConnectionStatus — see the
+	// note in StartConnection; the general UpdateConnection drops status).
 	conn.Status = "stopped"
 	conn.StoppedAt = pointerTo(time.Now().UTC())
 
-	if err := h.repo.UpdateConnection(ctx, conn); err != nil {
+	var stopLastErr *string
+	if orchestratorErr != nil {
+		stopLastErr = pointerTo(orchestratorErr.Error())
+	}
+	if err := h.repo.UpdateConnectionStatus(ctx, connID, "stopped", stopLastErr); err != nil {
 		_ = writeError(w, http.StatusInternalServerError, "DatabaseError", "failed to update connection status", nil)
 		return
 	}

--- a/src/pkg/managementapi/postgres_repository.go
+++ b/src/pkg/managementapi/postgres_repository.go
@@ -324,6 +324,10 @@ func (r *PostgresRepository) DeleteConnection(ctx context.Context, id string) er
 
 // UpdateConnectionStatus updates the status of a connection
 func (r *PostgresRepository) UpdateConnectionStatus(ctx context.Context, id string, status string, lastError *string) error {
+	// NOTE: Start/Stop must persist status through THIS method — the general
+	// UpdateConnection does not touch the status column, so relying on it left
+	// connections permanently "stopped" in the DB, which made the stop path skip
+	// orchestrator teardown (leaking worker Deployments/HPAs). See StartConnection.
 	query := `
 		UPDATE connections
 		SET

--- a/src/pkg/orchestrator/deployment.go
+++ b/src/pkg/orchestrator/deployment.go
@@ -178,6 +178,11 @@ func buildDeployment(node *managementapi.Node, graph *ExecutionGraph, config *Or
 						{
 							Name:  "component",
 							Image: containerImage,
+							// IfNotPresent so pre-pulled / k3d-imported images run
+							// without a registry round-trip (and unreachable
+							// registries don't ErrImagePull). Matches the platform's
+							// other manifests; redeploys use a new image tag/digest.
+							ImagePullPolicy: corev1.PullIfNotPresent,
 							Ports: []corev1.ContainerPort{
 								{
 									Name:          "http",

--- a/src/pkg/orchestrator/orchestrator.go
+++ b/src/pkg/orchestrator/orchestrator.go
@@ -4,6 +4,7 @@ package orchestrator
 import (
 	"context"
 	"fmt"
+	"log/slog"
 
 	"github.com/ValueRetail/vrsky/pkg/managementapi"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -94,6 +95,9 @@ func (o *Orchestrator) StartConnection(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+
+	slog.Default().Info("orchestrator deploying connection components",
+		"connection", o.Graph.ConnectionID, "components", len(specs), "namespace", o.Config.Namespace)
 
 	// Track successfully deployed nodes for error reporting
 	var deployedNodes []string


### PR DESCRIPTION
Live k3d validation of the per-connection orchestrator (#157) and worker autoscaling (#135), plus the fixes that validation surfaced. Closes #159.

## Validation result (k3d)
Drove a `consumer → producer` graph connection through its full lifecycle:

- **Start → Deployment + HPA per node (#157):** creates `vrsky-<conn>-{consumer,producer}-0` Deployments + one HPA each (min 1 / max 10 / 75% CPU); both pods reach `Running`.
- **Autoscale under load (#135) — PASS:** flooding the consumer's `POST /webhook` drove CPU to ~620%; the **consumer HPA scaled 1 → 4 → 8 → 10** while the **producer HPA stayed at 1** — only the loaded node scaled.
- **Stop → teardown (#157):** removes both Deployments + both HPAs (`deploy=0 hpa=0`).

Full evidence in `docs/TIER3_VALIDATION.md` (run dated 2026-07-20).

## Fixes in this PR
1. **Connection status never persisted** (`handler.go`, `postgres_repository.go`). `Start`/`Stop` set `conn.Status` in memory then called the general `UpdateConnection`, whose SQL never writes the `status` column — so connections stayed `stopped` in the DB even while running, and the stop path's `status == "stopped"` idempotency guard then **skipped orchestrator teardown, leaking worker Deployments + HPAs on every stop**. Routed both through `UpdateConnectionStatus` (already in the Repository interface + mocks). Latent before #157 (status was cosmetic); load-bearing once teardown depends on it.
2. **Worker Deployments used the default image pull policy** (`orchestrator/deployment.go`). `:latest` defaults to `Always`, so pods `ErrImagePull`'d against the unreachable `gcr.io/vrsky` even when the image was pre-pulled / k3d-imported. Set `IfNotPresent` to match the platform's other manifests.
3. **`vrsky-converter` image wouldn't build** (`cmd/converter/Dockerfile`, separate commit). Forced `CGO_ENABLED=1 GOARCH=amd64` (uncompilable on arm64; converter needs CGO for wasmtime) into an alpine/musl runtime a glibc binary can't load. Now native-arch on a glibc (`debian-slim`) runtime.

## Verification
- `go build ./...`, `go vet`, `gofmt` clean; `go test ./pkg/managementapi/... ./pkg/orchestrator/...` green.
- End-to-end on k3d as above.

Refs #135, #140, #157.

🤖 Generated with [Claude Code](https://claude.com/claude-code)