### PR TITLE
Fix tenant NATS provisioning crash-loop + validate discovery (#160)

### DIFF
--- a/docs/TIER3_VALIDATION.md
+++ b/docs/TIER3_VALIDATION.md
@@ -188,10 +188,11 @@ path does not) drove the full flow:
   right-sized the pod's oversized `1 CPU / 2Gi` requests to `250m / 512Mi` to match
   the platform components.
 
-## What this can't cover here
+## Where these runs happen
 
-This environment is single-host (no K8s), so the run itself must happen on your
-cluster. Everything up to that point — the manifests, migrations, control loops,
-metrics, and this runbook — is in place. `validate-tier3.sh` wraps the deploy +
-checks 1–3 into one command with pass/fail output; check 4 (throughput) is run
-explicitly because it needs a load target.
+The CI/sandbox environment is single-host (no Kubernetes), so a Tier-3 run must
+happen on a real cluster — the validation runs recorded above were done on a
+local **k3d** cluster (1 server + 2 agents). Everything the runbook needs — the
+manifests, migrations, control loops, metrics — is in the repo.
+`validate-tier3.sh` wraps the deploy + checks 1–3 into one command with pass/fail
+output; check 4 (throughput) is run explicitly because it needs a load target.

--- a/docs/TIER3_VALIDATION.md
+++ b/docs/TIER3_VALIDATION.md
@@ -160,6 +160,34 @@ producer needs `{"output_type":"nats|http","output_config":{...}}` (the default
 `file` output type is not supported by that runtime). An empty `{}` config makes a
 worker crash-loop on startup — valid config is required to exercise a pipeline.
 
+## Validation run — k3d, 2026-07-20 (#160 tenant provisioning → discovery)
+
+Validated the tenant NATS provisioning → service-discovery chain (#21) end-to-end.
+`POST /api/v1/tenants` (the path that enqueues a provisioning job — the *register*
+path does not) drove the full flow:
+
+- **Provisioner creates the instance.** The `K8sNATSProvisioner` created a
+  `nats-<slug>-1` **Deployment + Service (4222/8222) + NetworkPolicy** (tenant-id
+  isolation) in `vrsky-tenants`; the pod reached `1/1 Running` and the provisioning
+  job completed (`status=completed`, `progress=100`, "NATS instance ready").
+- **Discovery returns it (#21).** `GET /api/v1/tenants/{id}/nats-instances` returned
+  the instance with `status: active` and its
+  `nats://nats-<slug>-1.vrsky-tenants.svc.cluster.local:4222` URL.
+- **DB.** A `nats_instances` row (instance 1, `active`) was written by the
+  provisioner (not manually) — closing the gap left by the 2026-06-30 run, which
+  had inserted that row by hand.
+
+### Bug fixed during this run
+
+- **Tenant NATS pod crash-looped → provisioning always failed.** The provisioner
+  passed `--max_payload 8MB` and `--max_connections 1000` as nats-server **CLI
+  flags**, but those are config-file-only options — nats-server prints usage and
+  `exit(0)`, so the pod `CrashLoopBackOff`'d and `waitForDeployment` timed out
+  (`provisioning_jobs.status = failed`). This broke tenant provisioning on *any*
+  cluster. Fixed by dropping the invalid flags (defaults are fine); also
+  right-sized the pod's oversized `1 CPU / 2Gi` requests to `250m / 512Mi` to match
+  the platform components.
+
 ## What this can't cover here
 
 This environment is single-host (no K8s), so the run itself must happen on your

--- a/infrastructure/kubernetes/tenant-nats/deployment-template.yaml
+++ b/infrastructure/kubernetes/tenant-nats/deployment-template.yaml
@@ -27,6 +27,10 @@ spec:
         - name: nats
           image: nats:2.12-alpine
 
+          # NOTE: --max_payload / --max_connections are nats-server CONFIG-file
+          # options, NOT CLI flags. Passing them makes nats-server print usage
+          # and exit(0) → CrashLoopBackOff. Keep to real flags (set those limits
+          # via a config file if ever needed). Mirrors K8sNATSProvisioner.
           args:
             - --port
             - "4222"
@@ -34,10 +38,6 @@ spec:
             - "8222"
             - --server_name
             - nats-${TENANT_ID}-${INSTANCE_NUM}
-            - --max_payload
-            - 8MB
-            - --max_connections
-            - "1000"
 
           ports:
             - containerPort: 4222
@@ -52,9 +52,11 @@ spec:
               value: "${INSTANCE_NUM}"
 
           resources:
+            # Modest requests so a tenant instance bin-packs onto small nodes
+            # (the scheduling floor); limits stay generous for burst.
             requests:
-              cpu: 1
-              memory: 2Gi
+              cpu: 250m
+              memory: 512Mi
             limits:
               cpu: 2
               memory: 4Gi

--- a/src/pkg/managementapi/k8s_nats_provisioner.go
+++ b/src/pkg/managementapi/k8s_nats_provisioner.go
@@ -158,12 +158,16 @@ func (p *K8sNATSProvisioner) createDeployment(ctx context.Context, name string, 
 						{
 							Name:  "nats",
 							Image: natsImage,
+							// nats-server CLI accepts only a subset of settings as
+							// flags; --max_payload / --max_connections are config-file
+							// options, NOT flags — passing them makes nats-server print
+							// usage and exit(0), so the pod crash-loops and provisioning
+							// times out. Keep to real flags (defaults are fine for a
+							// tenant instance; tune via a config file if ever needed).
 							Args: []string{
 								"--port", "4222",
 								"--http_port", "8222",
 								"--server_name", name,
-								"--max_payload", "8MB",
-								"--max_connections", "1000",
 							},
 							Ports: []corev1.ContainerPort{
 								{Name: "client", ContainerPort: 4222},
@@ -173,10 +177,14 @@ func (p *K8sNATSProvisioner) createDeployment(ctx context.Context, name string, 
 								{Name: "TENANT_ID", Value: tenantSlug},
 								{Name: "INSTANCE_NUM", Value: "1"},
 							},
+							// Requests are the scheduling floor — keep them modest so a
+							// tenant instance bin-packs onto small/k3d nodes (the same
+							// right-sizing applied to the platform components). Limits
+							// stay generous for burst.
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse("1"),
-									corev1.ResourceMemory: resource.MustParse("2Gi"),
+									corev1.ResourceCPU:    resource.MustParse("250m"),
+									corev1.ResourceMemory: resource.MustParse("512Mi"),
 								},
 								Limits: corev1.ResourceList{
 									corev1.ResourceCPU:    resource.MustParse("2"),


### PR DESCRIPTION
Validates the tenant provisioning → service-discovery chain (#21) end-to-end on k3d, and fixes the bug that validation surfaced. Closes #160.

## Bug fixed
The tenant NATS provisioner passed `--max_payload 8MB` and `--max_connections 1000` as **nats-server CLI flags** — but those are config-file-only options. nats-server responds by printing usage and `exit(0)`, so the tenant NATS pod `CrashLoopBackOff`'d, `waitForDeployment` timed out, and **every `POST /api/v1/tenants` provisioning job failed** (`provisioning_jobs.status = failed`). This broke tenant provisioning on any cluster, not just k3d.

- Drop the two invalid flags (server defaults are fine for a tenant instance).
- Right-size the pod's requests `1 CPU / 2Gi → 250m / 512Mi` (same over-request class fixed for the platform components in the #140 run).

## Validation (k3d)
`POST /api/v1/tenants` (the path that enqueues provisioning — *register* does not):
- Provisioner creates `nats-<slug>-1` **Deployment `1/1 Running` + Service (4222/8222) + NetworkPolicy** (tenant-id isolation) in `vrsky-tenants`; job `completed` (100%).
- **Discovery (#21):** `GET /api/v1/tenants/{id}/nats-instances` returns the instance `status: active` + `nats://…:4222` URL.
- DB: `nats_instances` row written by the provisioner (not by hand) — closing the gap from the 2026-06-30 run that inserted it manually.

Evidence recorded in `docs/TIER3_VALIDATION.md`.

## Verification
`go build ./...`, `go vet`, `gofmt` clean; `go test ./pkg/managementapi/...` green; end-to-end on k3d as above.

Refs #21, #140.

🤖 Generated with [Claude Code](https://claude.com/claude-code)