### PR TITLE
Fix consumer data-path bugs found by #15 scaled load run

### DIFF
--- a/docs/LOAD.md
+++ b/docs/LOAD.md
@@ -97,6 +97,52 @@ item (#90), consistent with the rest of this doc. The heartbeat's cost is one
 short-lived goroutine + a ticker per message, stopped the instant the handler
 acks — negligible at the sink-bound rates above.
 
+### Scaled topology — k8s orchestrator path (#15, k3d)
+
+The numbers above run the **compose** stack (SDK connectors, one host). The
+**k8s orchestrator path** — where the management-api's orchestrator (#157)
+deploys per-node `pkg/runtime` workers with per-connection HPAs (#135) — was
+load-validated separately on the local k3d cluster used for the #157/#159/#160
+validations. k6 ran **as an in-cluster Job** driving a constant arrival rate at
+a ClusterIP Service in front of the connection's autoscaled consumer replicas:
+`k6 → Service → consumer(HTTP input) → NATS → producer → sink`.
+
+- **Ingress:** sustained the full **3,000 req/s** target at **p99 < 1 ms, 0%
+  HTTP failures** — the webhook input accepts at the same sub-millisecond
+  latencies as the compose path.
+- **Autoscaling under load (#135):** the consumer HPA scaled from 1 toward
+  `maxReplicas` (consumer CPU > 360% of request; producer > 220%), i.e. the
+  per-node HPAs the orchestrator creates react to real traffic — consistent with
+  the dedicated #159 run (consumer 1→10 under load).
+- **End-to-end delivery:** confirmed working through the orchestrator pipeline
+  (messages arrive on the sink subject; the producer saturates). A **precise
+  sustained delivered-msg/s ceiling is not claimed on k3d**: it shares one
+  laptop's cores with everything else, a 30 s window doesn't outlast HPA
+  scale-up lag, and the delivered count here is read by grepping a `nats sub`
+  pod's log (a floor, not a ceiling). A clean scaled delivered-throughput
+  baseline stays a real-multi-node-cluster item (with in-cluster Prometheus),
+  consistent with the deferral at the top of this doc.
+
+**Two data-path bugs were found and fixed by this run** (both would hit
+production, not just k3d):
+
+1. **`HTTPInput.Start()` blocked forever** in `ListenAndServe`, violating the
+   `component.Input` contract ("Start … must be called before Read()"). Callers
+   start the OUTPUT and the read→write loop only *after* `Start` returns, so the
+   consumer never connected its NATS output and never drained its channel — every
+   webhook was accepted with **202 and then silently dropped** once the 100-slot
+   buffer filled. A 3,000 req/s run delivered **0** messages end-to-end. Fixed to
+   serve in a background goroutine (binding synchronously so a port conflict
+   still surfaces as a `Start` error). Regression tests added
+   (`http_input_contract_test.go`) — the pre-existing tests all called `Start` in
+   a goroutine and were `//go:build integration`, so none could catch this.
+2. **`NATSOutput.Write` flushed per message** (`conn.Flush()` is a full
+   server round-trip) and logged at **Info per message** — capping end-to-end
+   delivery at a few hundred msg/s while the ingress accepted thousands. Removed
+   the per-message flush (the client buffers + flushes asynchronously; `Close`
+   flushes on shutdown; core NATS gives no per-publish ack regardless) and
+   dropped the hot-path logging to Debug.
+
 ### CDC — Postgres logical-replication capture
 
 `generators/cdc_insert.sh` bulk-inserts into the source Postgres and watches the

--- a/src/pkg/io/http_input.go
+++ b/src/pkg/io/http_input.go
@@ -60,9 +60,11 @@ func (h *HTTPInput) Start(ctx context.Context) error {
 		return fmt.Errorf("http input listen on %s: %w", h.server.Addr, err)
 	}
 
+	// On cancel, go through Close() so shutdown is idempotent (the caller also
+	// calls Close() on stop) and graceful (Server.Shutdown, not an abrupt Close).
 	go func() {
 		<-ctx.Done()
-		_ = h.server.Close()
+		_ = h.Close()
 	}()
 
 	// Serve in the background — Start MUST return. The component.Input contract

--- a/src/pkg/io/http_input.go
+++ b/src/pkg/io/http_input.go
@@ -54,18 +54,30 @@ func (h *HTTPInput) Start(ctx context.Context) error {
 		Handler: mux,
 	}
 
+	// Bind synchronously so a port conflict still surfaces as a Start() error.
+	ln, err := net.Listen("tcp", h.server.Addr)
+	if err != nil {
+		return fmt.Errorf("http input listen on %s: %w", h.server.Addr, err)
+	}
+
 	go func() {
 		<-ctx.Done()
 		_ = h.server.Close()
 	}()
 
+	// Serve in the background — Start MUST return. The component.Input contract
+	// is "Start initializes the input ... must be called before Read()", and
+	// every caller starts the OUTPUT and the read loop only after Start returns.
+	// Serving inline (ListenAndServe) blocked forever, so the consumer never
+	// connected its NATS output and never drained the message channel: webhooks
+	// were accepted with 202 and then silently dropped once the buffer filled.
+	go func() {
+		if err := h.server.Serve(ln); err != nil && err != http.ErrServerClosed {
+			slog.Error("HTTP server error", "error", err)
+		}
+	}()
+
 	slog.Info("HTTP input started", "port", h.port, "endpoint", "POST /webhook")
-
-	if err := h.server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-		slog.Error("HTTP server error", "error", err)
-		return fmt.Errorf("http server: %w", err)
-	}
-
 	return nil
 }
 
@@ -96,7 +108,8 @@ func (h *HTTPInput) handleWebhook(w http.ResponseWriter, r *http.Request) {
 	// Send to message channel (non-blocking, fire-and-forget)
 	select {
 	case h.messages <- env:
-		slog.Info("Webhook queued", "id", env.ID)
+		// Debug, not Info: one log line per request dominates CPU under load.
+		slog.Debug("Webhook queued", "id", env.ID)
 	default:
 		// Channel full, drop message (fire-and-forget philosophy)
 		slog.Warn("Message channel full, dropping webhook", "id", env.ID)

--- a/src/pkg/io/http_input_contract_test.go
+++ b/src/pkg/io/http_input_contract_test.go
@@ -1,0 +1,136 @@
+package io
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+)
+
+// freePort returns a port that was free a moment ago.
+func freePort(t *testing.T) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("reserve port: %v", err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	_ = ln.Close()
+	return fmt.Sprintf("%d", port)
+}
+
+// TestHTTPInput_StartIsNonBlocking pins the component.Input contract: Start
+// "initializes the input ... must be called before Read()", so it MUST return.
+//
+// Regression guard for the bug found during the #15 scaled-topology load run:
+// Start served inline via ListenAndServe and blocked forever, so callers
+// (cmd/consumer) never reached output.Start() and never launched their
+// read→write loop. The HTTP server still accepted webhooks and answered 202,
+// so the failure was silent: every message was dropped once the 100-slot
+// buffer filled. A 3,000 req/s run delivered 0 messages end-to-end.
+//
+// The pre-existing tests all call Start() inside a goroutine, which
+// accommodates a blocking Start and therefore cannot catch this — hence this
+// test calls it directly and fails if it does not return.
+func TestHTTPInput_StartIsNonBlocking(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	port := freePort(t)
+	input, err := NewHTTPInput([]byte(`{"port":"` + port + `"}`))
+	if err != nil {
+		t.Fatalf("NewHTTPInput() error = %v", err)
+	}
+	defer input.Close()
+
+	done := make(chan error, 1)
+	go func() { done <- input.Start(ctx) }()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Start() error = %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("Start() blocked: it must return so callers can start the output and Read()")
+	}
+}
+
+// TestHTTPInput_DeliversAfterStartReturns proves the whole path works once
+// Start has returned — a webhook POSTed after Start is readable via Read(),
+// which is exactly what the consumer's read→write loop depends on.
+func TestHTTPInput_DeliversAfterStartReturns(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	port := freePort(t)
+	input, err := NewHTTPInput([]byte(`{"port":"` + port + `"}`))
+	if err != nil {
+		t.Fatalf("NewHTTPInput() error = %v", err)
+	}
+	defer input.Close()
+
+	if err := input.Start(ctx); err != nil { // called directly — must not block
+		t.Fatalf("Start() error = %v", err)
+	}
+
+	url := "http://127.0.0.1:" + port + "/webhook"
+	var resp *http.Response
+	// The listener is bound before Start returns, but give the serve goroutine
+	// a moment to begin accepting.
+	for i := 0; i < 20; i++ {
+		resp, err = http.Post(url, "application/json", bytes.NewReader([]byte(`{"hello":"world"}`)))
+		if err == nil {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if err != nil {
+		t.Fatalf("POST webhook: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusAccepted {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusAccepted)
+	}
+
+	env, err := input.Read(ctx)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if env == nil || len(env.Payload) == 0 {
+		t.Fatal("Read() returned an empty envelope")
+	}
+	if got := string(env.Payload); got != `{"hello":"world"}` {
+		t.Errorf("payload = %s, want %s", got, `{"hello":"world"}`)
+	}
+}
+
+// TestHTTPInput_StartReportsBindFailure ensures binding stays synchronous, so a
+// port conflict is still surfaced as a Start() error rather than swallowed by
+// the background serve goroutine.
+func TestHTTPInput_StartReportsBindFailure(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Hold the port on ALL interfaces — the input binds ":<port>", which does
+	// not necessarily conflict with a 127.0.0.1-only listener on macOS.
+	ln, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+	port := fmt.Sprintf("%d", ln.Addr().(*net.TCPAddr).Port)
+
+	input, err := NewHTTPInput([]byte(`{"port":"` + port + `"}`))
+	if err != nil {
+		t.Fatalf("NewHTTPInput() error = %v", err)
+	}
+	defer input.Close()
+
+	if err := input.Start(ctx); err == nil {
+		t.Fatal("Start() = nil, want an error when the port is already in use")
+	}
+}

--- a/src/pkg/io/http_input_contract_test.go
+++ b/src/pkg/io/http_input_contract_test.go
@@ -78,11 +78,14 @@ func TestHTTPInput_DeliversAfterStartReturns(t *testing.T) {
 	}
 
 	url := "http://127.0.0.1:" + port + "/webhook"
+	// Bounded client so a stuck server fails fast instead of hanging until the
+	// package test timeout.
+	client := &http.Client{Timeout: 2 * time.Second}
 	var resp *http.Response
 	// The listener is bound before Start returns, but give the serve goroutine
 	// a moment to begin accepting.
 	for i := 0; i < 20; i++ {
-		resp, err = http.Post(url, "application/json", bytes.NewReader([]byte(`{"hello":"world"}`)))
+		resp, err = client.Post(url, "application/json", bytes.NewReader([]byte(`{"hello":"world"}`)))
 		if err == nil {
 			break
 		}

--- a/src/pkg/io/nats_output.go
+++ b/src/pkg/io/nats_output.go
@@ -112,10 +112,6 @@ func (n *NATSOutput) Write(ctx context.Context, env *envelope.Envelope) error {
 		"message_id", env.ID,
 		"size", len(envJSON))
 
-	// Publish to NATS with timeout
-	_, cancel := context.WithTimeout(ctx, 5*time.Second)
-	defer cancel()
-
 	// Create NATS message with headers
 	msg := &nats.Msg{
 		Subject: n.config.Subject,
@@ -133,16 +129,18 @@ func (n *NATSOutput) Write(ctx context.Context, env *envelope.Envelope) error {
 		return fmt.Errorf("failed to publish to NATS subject %s: %w", n.config.Subject, err)
 	}
 
-	slog.Info("Message published to NATS",
+	// Per-message logging stays at Debug: this is a data-plane hot path, and an
+	// Info line per message dominates CPU at real rates.
+	slog.Debug("Message published to NATS",
 		"subject", n.config.Subject,
 		"message_id", env.ID)
 
-	// Ensure message is flushed (optional, for reliability)
-	if err := conn.Flush(); err != nil {
-		slog.Warn("Failed to flush NATS connection", "error", err)
-		// Don't fail the write if flush fails - message was published
-	}
-
+	// NB: deliberately no per-message conn.Flush(). Flush is a full round-trip
+	// to the server, so flushing per publish serialises the hot path on network
+	// latency (measured: it capped end-to-end delivery at a few hundred msg/s
+	// while the ingress accepted thousands). The NATS client buffers and flushes
+	// asynchronously, and Close() flushes on the way out; core NATS gives no
+	// delivery ack either way, so the per-message flush bought no guarantee.
 	return nil
 }
 

--- a/src/pkg/io/nats_output.go
+++ b/src/pkg/io/nats_output.go
@@ -139,8 +139,9 @@ func (n *NATSOutput) Write(ctx context.Context, env *envelope.Envelope) error {
 	// to the server, so flushing per publish serialises the hot path on network
 	// latency (measured: it capped end-to-end delivery at a few hundred msg/s
 	// while the ingress accepted thousands). The NATS client buffers and flushes
-	// asynchronously, and Close() flushes on the way out; core NATS gives no
-	// delivery ack either way, so the per-message flush bought no guarantee.
+	// asynchronously, and Close() drains the buffer (FlushTimeout) on the way
+	// out; core NATS gives no delivery ack either way, so the per-message flush
+	// bought no guarantee.
 	return nil
 }
 
@@ -150,6 +151,13 @@ func (n *NATSOutput) Close() error {
 	defer n.mu.Unlock()
 
 	if n.conn != nil {
+		// Flush the async write buffer before closing. With the per-message
+		// Flush removed from Write (hot-path), shutdown is the point that must
+		// drain in-flight publishes — conn.Close() alone does NOT flush, so
+		// skipping this would drop buffered messages on stop.
+		if err := n.conn.FlushTimeout(5 * time.Second); err != nil {
+			slog.Warn("NATS output flush on close failed", "error", err)
+		}
 		n.conn.Close()
 	}
 

--- a/tests/load/webhook_k8s.js
+++ b/tests/load/webhook_k8s.js
@@ -1,0 +1,64 @@
+// k8s orchestrator-path load scenario (#15 scaled-topology run).
+//
+// Drives a constant arrival rate of JSON POSTs at the pkg/runtime consumer's
+// HTTP input (`POST /webhook` on :8000) THROUGH a ClusterIP Service, so load
+// spreads across the connection's autoscaled consumer replicas. Each accepted
+// request (HTTP 202) is queued for publish onto NATS; the producer delivers it
+// to the sink subject. Unlike the compose harness this runs INSIDE the cluster
+// (as a k6 Job) and writes its summary to stdout — there is no in-cluster
+// Prometheus to cross-check, so delivery is confirmed separately by counting the
+// sink subject.
+//
+// Env:
+//   TARGET_URL   full URL, e.g. http://consumer-lb.vrsky-platform:8000/webhook (required)
+//   RATE         target requests/sec           (default 2000)
+//   DURATION     constant-rate duration         (default 30s)
+//   PREALLOC_VUS pre-allocated VUs              (default 100)
+//   MAX_VUS      VU ceiling                     (default 800)
+import http from 'k6/http';
+import { check } from 'k6';
+
+const TARGET_URL = __ENV.TARGET_URL;
+const RATE = parseInt(__ENV.RATE || '2000', 10);
+const DURATION = __ENV.DURATION || '30s';
+const PREALLOC = parseInt(__ENV.PREALLOC_VUS || '100', 10);
+const MAX_VUS = parseInt(__ENV.MAX_VUS || '800', 10);
+
+export const options = {
+  discardResponseBodies: true,
+  summaryTrendStats: ['avg', 'min', 'med', 'max', 'p(95)', 'p(99)'],
+  scenarios: {
+    webhook: {
+      executor: 'constant-arrival-rate',
+      rate: RATE,
+      timeUnit: '1s',
+      duration: DURATION,
+      preAllocatedVUs: PREALLOC,
+      maxVUs: MAX_VUS,
+    },
+  },
+};
+
+export default function () {
+  const body = JSON.stringify({
+    event: 'order.created',
+    ts: Date.now(),
+    vu: __VU,
+    iter: __ITER,
+    payload: { id: `${__VU}-${__ITER}`, amount: 42, currency: 'GBP' },
+  });
+  const res = http.post(TARGET_URL, body, { headers: { 'Content-Type': 'application/json' } });
+  check(res, { 'accepted (202)': (r) => r.status === 202 });
+}
+
+export function handleSummary(data) {
+  const dur = data.metrics.http_req_duration ? data.metrics.http_req_duration.values : {};
+  const reqs = data.metrics.http_reqs ? data.metrics.http_reqs.values : {};
+  const failed = data.metrics.http_req_failed ? data.metrics.http_req_failed.values : {};
+  const line =
+    `RESULT k8s-webhook: ${Math.round(reqs.rate || 0)} req/s sustained, ` +
+    `med=${(dur.med || 0).toFixed(1)}ms p95=${(dur['p(95)'] || 0).toFixed(1)}ms ` +
+    `p99=${(dur['p(99)'] || 0).toFixed(1)}ms, ${reqs.count || 0} reqs, ` +
+    `failed=${((failed.rate || 0) * 100).toFixed(2)}%`;
+  return { stdout: '\n' + line + '\n' };
+}

--- a/tests/load/webhook_k8s.js
+++ b/tests/load/webhook_k8s.js
@@ -19,6 +19,9 @@ import http from 'k6/http';
 import { check } from 'k6';
 
 const TARGET_URL = __ENV.TARGET_URL;
+if (!TARGET_URL) {
+  throw new Error('TARGET_URL is required (e.g. http://consumer-lb.vrsky-platform:8000/webhook)');
+}
 const RATE = parseInt(__ENV.RATE || '2000', 10);
 const DURATION = __ENV.DURATION || '30s';
 const PREALLOC = parseInt(__ENV.PREALLOC_VUS || '100', 10);
@@ -27,6 +30,15 @@ const MAX_VUS = parseInt(__ENV.MAX_VUS || '800', 10);
 export const options = {
   discardResponseBodies: true,
   summaryTrendStats: ['avg', 'min', 'med', 'max', 'p(95)', 'p(99)'],
+  // Guard rails so a misconfigured run (wrong URL, non-202 responses) exits
+  // non-zero instead of printing a misleading "success" summary. The consumer
+  // answers 202 on accept (fire-and-forget), so the 202 check reflects ingress
+  // health; downstream backpressure drops are expected and measured via the
+  // sink, not here.
+  thresholds: {
+    http_req_failed: ['rate<0.01'],
+    checks: ['rate>0.99'],
+  },
   scenarios: {
     webhook: {
       executor: 'constant-arrival-rate',


### PR DESCRIPTION
The #15 scaled-topology load run (k6 → in-cluster Service → autoscaled `pkg/runtime` workers → NATS → producer → sink, on k3d) surfaced **two serious data-path bugs** in the generic connectors. Both cause data loss / throughput collapse in *any* deployment, not just k8s. This PR fixes them, adds regression coverage, and records the run in `docs/LOAD.md`.

## Bug 1 — silent 100% message loss (`HTTPInput.Start` blocked)
`HTTPInput.Start()` served inline via `ListenAndServe`, which **never returns**. The `component.Input` contract is *"Start initializes the input … must be called before `Read()`"* — and every caller (`cmd/consumer`) starts the **output** and the **read→write loop** only *after* `Start` returns. So the consumer never connected its NATS output and never drained its channel: webhooks were accepted with **202** and then **silently dropped** once the 100-slot buffer filled.

Measured: a 3,000 req/s run accepted 89,765 requests at sub-ms latency and delivered **0** end-to-end.

Fix: serve in a background goroutine; bind synchronously so a port conflict still surfaces as a `Start()` error.

## Bug 2 — delivery capped at a few hundred/s (`NATSOutput.Write` per-message flush)
`Write` called `conn.Flush()` **on every message** (a full server round-trip) and logged at **Info per message**. That serialised the publish hot path on network latency — delivery capped at ~355/s while ingress accepted ~2,662/s. Removed the per-message flush (the NATS client buffers and flushes asynchronously; `Close` flushes on shutdown; core NATS gives no per-publish ack regardless) and moved hot-path logging to Debug.

## Why it was never caught
The existing `http_input_test.go` tests all call `Start` **inside a goroutine** (accommodating the block) and are behind `//go:build integration`. Added `http_input_contract_test.go` (no build tag) that calls `Start` directly and asserts it returns, delivers end-to-end, and reports bind failures — the first test fails against the old code.

## Load-run record
`docs/LOAD.md` gains a "Scaled topology — k8s orchestrator path" section: ingress sustained 3,000/s at p99 < 1 ms with the consumer+producer HPAs scaling under load; end-to-end delivery confirmed after the fixes. A precise *delivered ceiling* is explicitly **not** claimed on k3d (shared laptop cores, HPA lag in a 30 s window, log-counted sink) and stays a real-cluster item, consistent with the doc's existing deferral. Adds `tests/load/webhook_k8s.js` (the in-cluster k6 scenario).

## Verification
`go build ./...`, `go vet`, `gofmt` clean; `go test ./pkg/io/... -run TestHTTPInput_|TestNATSOutput` green; end-to-end on k3d (0 → delivering after fixes).

Refs #135, #157, #15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)