### PR TITLE
feat: Sitoo POS connector (poll + SPI-Event webhook)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -757,6 +757,32 @@ services:
     networks:
       - vrsky-network
 
+  # Sitoo Consumer - polls the Sitoo REST API (orders/stock/products) per
+  # connection and receives SPI-Event webhooks. See docs/connectors/sitoo.md.
+  sitoo-consumer:
+    build:
+      context: .
+      dockerfile: src/cmd/sitoo-consumer/Dockerfile
+    container_name: vrsky-sitoo-consumer
+    environment:
+      NATS_URL: "nats://nats:4222"
+      DATABASE_URL: "postgres://postgres:management_password@postgres-management:5432/management_db?sslmode=disable"
+      LOG_LEVEL: "info"
+      # Must match management-api's ENCRYPTION_KEY — the resolver decrypts the
+      # Sitoo API password (api_password_secret_id) at connection-start time.
+      ENCRYPTION_KEY: "${ENCRYPTION_KEY:-0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef}"
+      # Aux HTTP port serving POST /sitoo/events/{connectionID} (SPI-Event webhooks).
+      WORKER_HTTP_PORT: "9260"
+    ports:
+      - "127.0.0.1:9260:9260"
+    depends_on:
+      nats:
+        condition: service_healthy
+      postgres-management:
+        condition: service_healthy
+    networks:
+      - vrsky-network
+
   # SFTP Consumer (#76) - watches a remote SFTP dir, fetches + publishes files.
   sftp-consumer:
     build:

--- a/docs/connectors/index.md
+++ b/docs/connectors/index.md
@@ -15,6 +15,7 @@ set by `config.type` on the node. Sources are **consumers**, destinations are
 | [Apache Kafka](kafka.md) | ✓ | ✓ | `kafka` |
 | [RabbitMQ](rabbitmq.md) | ✓ | ✓ | `rabbitmq` |
 | [Salesforce](salesforce.md) | ✓ | ✓ | `salesforce` |
+| [Sitoo (POS)](sitoo.md) | ✓ (poll + webhook) | — | `sitoo` |
 | [Tenant-to-tenant](tenant.md) | ✓ | — | `tenant` |
 | [Filters & converters](filters-converters.md) | — | — | `filter` / `converter` |
 

--- a/docs/connectors/sitoo.md
+++ b/docs/connectors/sitoo.md
@@ -1,0 +1,73 @@
+# Sitoo
+
+The Sitoo connector (`sitoo`) ingests data from the [Sitoo Retail
+Platform](https://developer.sitoo.com/) — a cloud POS / unified-commerce system
+— into a VRSky pipeline. It supports two ingestion modes, usable together:
+
+- **Poll** — periodically fetch a Sitoo collection (orders/transactions,
+  warehouse stock, products, …) over the REST API with `start`/`num` pagination.
+- **Webhook** — receive Sitoo **SPI Event** notifications (Orders, Warehouse
+  Transactions, …) in real time.
+
+> **Credentials.** Sitoo authenticates with HTTP Basic auth using an **API ID +
+> password** generated in the Sitoo Backoffice (Settings → Sitoo REST API,
+> requires the API extension + Administrator rights). Store the password as a
+> secret and reference it from the node as `api_password_secret_id`; the
+> platform decrypts it at connection-start time. Never put the raw password on
+> the node.
+
+## As a source (consumer)
+
+### Poll mode
+
+A consumer node fetches the configured `resource` on `poll_interval_seconds`,
+paging through all results, and emits each page as a JSON-array message.
+
+- `account_id` / `site_id` — your Sitoo account and site (integers).
+- `api_id` — the Sitoo REST API ID.
+- `api_password_secret_id` — secret reference to the API password.
+- `resource` — the collection to poll (default `transactions`; e.g.
+  `warehouseitems`, `products`).
+- `poll_interval_seconds` — poll cadence. Set `0` (or omit) for **webhook-only**.
+- `page_size` — Sitoo `num` (default `1000`; 1000–5000 is optimal).
+- `base_url` — optional override (default `https://api.mysitoo.com/v2`).
+
+```json
+{
+  "type": "sitoo",
+  "sitoo": {
+    "account_id": 12345,
+    "site_id": 1,
+    "api_id": "your-api-id",
+    "api_password_secret_id": "<secret-uuid>",
+    "resource": "transactions",
+    "poll_interval_seconds": 300,
+    "page_size": 1000
+  }
+}
+```
+
+The connector honours Sitoo's rate limit: on HTTP `429` it waits for
+`X-Rate-Limit-Reset` / `Retry-After` and retries.
+
+### Webhook mode (real-time SPI Events)
+
+Point Sitoo's SPI Events at the connector's auxiliary HTTP endpoint:
+
+```
+POST /sitoo/events/{connectionID}
+```
+
+served on `WORKER_HTTP_PORT` (9260 in compose). Each event body is published as a
+message routed to the owning tenant/connection. Configure the connection with
+`poll_interval_seconds: 0` if you want webhook-only (no polling).
+
+## Notes & roadmap
+
+- **Producer (write-back)** — updating stock/prices/products in Sitoo (a
+  `sitoo` producer node) is the natural next step for two-way inventory sync.
+- **Incremental polling** — the current poller does a full paged fetch each
+  cycle; a `modified_after`-style cursor is a straightforward enhancement for
+  high-volume order streams.
+- **Webhook signature verification** — add HMAC verification once the SPI Event
+  signing scheme is confirmed for your account.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -73,6 +73,7 @@ nav:
       - Apache Kafka: connectors/kafka.md
       - RabbitMQ: connectors/rabbitmq.md
       - Salesforce: connectors/salesforce.md
+      - Sitoo (POS): connectors/sitoo.md
       - Tenant-to-tenant: connectors/tenant.md
       - Filters & converters: connectors/filters-converters.md
   - Security:

--- a/src/cmd/sitoo-consumer/Dockerfile
+++ b/src/cmd/sitoo-consumer/Dockerfile
@@ -1,0 +1,27 @@
+# Multi-stage build for minimal image size
+FROM golang:1.22-alpine AS builder
+
+WORKDIR /app
+
+COPY src/go.mod src/go.sum ./
+RUN go mod download
+
+COPY src/ ./
+
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
+    -ldflags="-w -s" \
+    -o sitoo-consumer \
+    ./cmd/sitoo-consumer
+
+FROM alpine:3.19
+
+RUN apk --no-cache add ca-certificates curl
+
+WORKDIR /app
+COPY --from=builder /app/sitoo-consumer .
+
+# The SDK runner serves /healthz + /readyz on HEALTH_PORT (default 8080).
+HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
+    CMD curl -f http://localhost:8080/healthz || exit 1
+
+ENTRYPOINT ["./sitoo-consumer"]

--- a/src/cmd/sitoo-consumer/consumer_test.go
+++ b/src/cmd/sitoo-consumer/consumer_test.go
@@ -1,0 +1,158 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/ValueRetail/vrsky/pkg/envelope"
+)
+
+// newTestConsumer returns a consumer wired with a capturing publish func.
+func newTestConsumer() (*sitooConsumer, *[]*envelope.Envelope, *sync.Mutex) {
+	var mu sync.Mutex
+	var got []*envelope.Envelope
+	c := &sitooConsumer{
+		logger:     slog.New(slog.NewTextHandler(io.Discard, nil)),
+		httpClient: http.DefaultClient,
+		publish: func(_ context.Context, env *envelope.Envelope) error {
+			mu.Lock()
+			defer mu.Unlock()
+			got = append(got, env)
+			return nil
+		},
+	}
+	return c, &got, &mu
+}
+
+// TestFetchAndPublish_PaginatesAndAuthenticates verifies Basic auth is sent, the
+// start/num pagination walks all pages, and each page is published.
+func TestFetchAndPublish_PaginatesAndAuthenticates(t *testing.T) {
+	const total = 5
+	const pageSize = 2
+	var authOK bool
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if u, p, ok := r.BasicAuth(); ok && u == "apiid" && p == "secretpw" {
+			authOK = true
+		}
+		start, _ := strconv.Atoi(r.URL.Query().Get("start"))
+		num, _ := strconv.Atoi(r.URL.Query().Get("num"))
+		items := []json.RawMessage{}
+		for i := start; i < start+num && i < total; i++ {
+			items = append(items, json.RawMessage(fmt.Sprintf(`{"id":%d}`, i)))
+		}
+		_ = json.NewEncoder(w).Encode(sitooCollection{TotalCount: total, Items: items})
+	}))
+	defer srv.Close()
+
+	c, got, mu := newTestConsumer()
+	cfg := &SitooConfig{
+		AccountID: 1, SiteID: 2, APIID: "apiid", APIPassword: "secretpw",
+		BaseURL: srv.URL, Resource: "transactions", PageSize: pageSize,
+	}
+	if err := c.fetchAndPublish(context.Background(), "conn-1", "tenant-1", cfg, c.logger); err != nil {
+		t.Fatalf("fetchAndPublish: %v", err)
+	}
+	if !authOK {
+		t.Error("Basic auth credentials were not sent")
+	}
+	// 5 items over pages of 2 → pages of 2,2,1 = 3 published envelopes, 5 records.
+	mu.Lock()
+	defer mu.Unlock()
+	if len(*got) != 3 {
+		t.Fatalf("published %d envelopes, want 3 (pages)", len(*got))
+	}
+	records := 0
+	for _, env := range *got {
+		var items []json.RawMessage
+		if err := json.Unmarshal(env.Payload, &items); err != nil {
+			t.Fatalf("payload not a JSON array: %v", err)
+		}
+		records += len(items)
+		if env.TenantID != "tenant-1" || env.IntegrationID != "conn-1" || env.Source != "sitoo-consumer" {
+			t.Errorf("bad envelope routing: %+v", env)
+		}
+	}
+	if records != total {
+		t.Errorf("published %d records, want %d", records, total)
+	}
+}
+
+// TestGet_RetriesOn429 verifies the rate-limit backoff retries and then succeeds.
+func TestGet_RetriesOn429(t *testing.T) {
+	var calls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if calls == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(sitooCollection{TotalCount: 0, Items: nil})
+	}))
+	defer srv.Close()
+
+	c, _, _ := newTestConsumer()
+	cfg := &SitooConfig{APIID: "x", APIPassword: "y"}
+	if _, err := c.get(context.Background(), cfg, srv.URL); err != nil {
+		t.Fatalf("get after 429 retry: %v", err)
+	}
+	if calls != 2 {
+		t.Errorf("server called %d times, want 2 (one 429, one success)", calls)
+	}
+}
+
+// TestWebhook_PublishesBody verifies the SPI-Event webhook path resolves the
+// tenant, publishes the body, and 202s — and 404s an unknown connection.
+func TestWebhook_PublishesBody(t *testing.T) {
+	c, got, mu := newTestConsumer()
+	c.resolveTenant = func(connID string) (string, error) {
+		if connID == "conn-9" {
+			return "tenant-9", nil
+		}
+		return "", fmt.Errorf("unknown")
+	}
+	h := c.handleWebhook()
+
+	// Valid connection → 202 + published.
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/sitoo/events/conn-9", strings.NewReader(`{"event":"transaction.created"}`))
+	h(rec, req)
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202", rec.Code)
+	}
+	mu.Lock()
+	n := len(*got)
+	mu.Unlock()
+	if n != 1 {
+		t.Fatalf("published %d, want 1", n)
+	}
+	if (*got)[0].TenantID != "tenant-9" || (*got)[0].IntegrationID != "conn-9" {
+		t.Errorf("bad webhook routing: %+v", (*got)[0])
+	}
+
+	// Unknown connection → 404, nothing published.
+	rec2 := httptest.NewRecorder()
+	req2 := httptest.NewRequest(http.MethodPost, "/sitoo/events/nope", strings.NewReader(`{}`))
+	h(rec2, req2)
+	if rec2.Code != http.StatusNotFound {
+		t.Errorf("unknown connection status = %d, want 404", rec2.Code)
+	}
+
+	// GET → 405.
+	rec3 := httptest.NewRecorder()
+	req3 := httptest.NewRequest(http.MethodGet, "/sitoo/events/conn-9", nil)
+	h(rec3, req3)
+	if rec3.Code != http.StatusMethodNotAllowed {
+		t.Errorf("GET status = %d, want 405", rec3.Code)
+	}
+}

--- a/src/cmd/sitoo-consumer/main.go
+++ b/src/cmd/sitoo-consumer/main.go
@@ -1,0 +1,32 @@
+// Command sitoo-consumer ingests data from the Sitoo Retail Platform into the
+// pipeline. Sitoo exposes a public REST API (JSON, HTTP Basic auth) plus SPI
+// Event webhooks; this connector supports both:
+//
+//   - Poll mode: for each active connection it periodically fetches a Sitoo
+//     collection (transactions/orders, warehouse stock, products, …) with
+//     start/num pagination and publishes each page as an envelope.
+//   - Webhook mode: it serves POST /sitoo/events/{connectionID} on the SDK
+//     auxiliary HTTP port so Sitoo's SPI Events (Orders, Warehouse
+//     Transactions, …) push in real time.
+//
+// It is an SDK Consumer: the runner owns NATS/DB/health/signals/shutdown; this
+// binary implements Configure + Run + Stop, subscribes to the connection
+// command subjects, and reads per-connection config from the connections table.
+//
+// Reference: https://developer.sitoo.com/  (REST API + SPI Events).
+package main
+
+import (
+	"context"
+	"log/slog"
+	"os"
+
+	"github.com/ValueRetail/vrsky/pkg/sdk"
+)
+
+func main() {
+	if err := sdk.RunConsumer(context.Background(), "sitoo-consumer", &sitooConsumer{}); err != nil {
+		slog.Error("sitoo-consumer exited", "error", err)
+		os.Exit(1)
+	}
+}

--- a/src/cmd/sitoo-consumer/server.go
+++ b/src/cmd/sitoo-consumer/server.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/ValueRetail/vrsky/pkg/envelope"
+)
+
+// handleWebhook serves Sitoo SPI Event notifications (real-time mode). Sitoo is
+// configured to POST events to /sitoo/events/{connectionID}; each request body
+// is wrapped in an envelope and published into the pipeline. Served on the SDK
+// auxiliary HTTP port (WORKER_HTTP_PORT).
+func (s *sitooConsumer) handleWebhook() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		connID := strings.TrimPrefix(r.URL.Path, "/sitoo/events/")
+		connID = strings.Trim(connID, "/")
+		if connID == "" {
+			http.Error(w, "missing connection id in path (/sitoo/events/{connectionID})", http.StatusBadRequest)
+			return
+		}
+
+		// Resolve the owning tenant so the envelope is routable. An unknown
+		// connection id is a 404 rather than a silent drop.
+		tenantID, err := s.resolveTenant(connID)
+		if err != nil {
+			s.logger.Warn("Sitoo webhook for unknown connection", "connection_id", connID, "error", err)
+			http.Error(w, "unknown connection", http.StatusNotFound)
+			return
+		}
+
+		body, err := io.ReadAll(io.LimitReader(r.Body, 8<<20)) // 8 MiB cap
+		if err != nil {
+			http.Error(w, "read body", http.StatusBadRequest)
+			return
+		}
+
+		if s.publish == nil { // Run hasn't wired the publisher yet
+			http.Error(w, "not ready", http.StatusServiceUnavailable)
+			return
+		}
+
+		env := envelope.New()
+		env.TenantID = tenantID
+		env.IntegrationID = connID
+		env.ContentType = firstNonEmpty(r.Header.Get("Content-Type"), "application/json")
+		env.Source = "sitoo-consumer"
+		env.Payload = body
+		env.PayloadSize = int64(len(body))
+		env.StepHistory = []string{"sitoo-consumer"}
+		env.Metadata = map[string]interface{}{"mode": "webhook", "event_type": r.Header.Get("X-Sitoo-Event")}
+
+		if err := s.publish(r.Context(), env); err != nil {
+			s.logger.Error("publish Sitoo webhook failed", "connection_id", connID, "error", err)
+			http.Error(w, "publish failed", http.StatusInternalServerError)
+			return
+		}
+		s.logger.Info("Sitoo webhook received and published", "connection_id", connID, "bytes", len(body))
+		w.WriteHeader(http.StatusAccepted)
+	}
+}
+
+func firstNonEmpty(vals ...string) string {
+	for _, v := range vals {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}

--- a/src/cmd/sitoo-consumer/service.go
+++ b/src/cmd/sitoo-consumer/service.go
@@ -1,0 +1,432 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	_ "github.com/lib/pq"
+	"github.com/nats-io/nats.go"
+
+	"github.com/ValueRetail/vrsky/pkg/crypto"
+	"github.com/ValueRetail/vrsky/pkg/envelope"
+	"github.com/ValueRetail/vrsky/pkg/sdk"
+)
+
+const (
+	defaultBaseURL  = "https://api.mysitoo.com/v2"
+	defaultResource = "transactions" // Sitoo orders/receipts
+	defaultPageSize = 1000           // Sitoo `num`; batch 1000–5000 is optimal
+	maxRateRetries  = 5              // bounded retries on HTTP 429
+)
+
+// sitooConsumer polls the Sitoo REST API per active connection (and/or receives
+// SPI Event webhooks) and publishes the results into the pipeline. It is an SDK
+// Consumer: Configure wires deps, Run subscribes to command subjects and blocks,
+// Stop cancels pollers.
+type sitooConsumer struct {
+	sdk.BaseConsumer
+
+	db      *sql.DB
+	nc      *nats.Conn
+	publish sdk.PublishFunc
+	logger  *slog.Logger
+
+	httpClient *http.Client
+
+	// resolveTenant maps a connection id to its owning tenant (webhook routing).
+	// Defaulted in Configure to the DB lookup; tests inject a stub.
+	resolveTenant func(connID string) (string, error)
+
+	active map[string]context.CancelFunc
+	mu     sync.RWMutex
+
+	startSub *nats.Subscription
+	stopSub  *nats.Subscription
+}
+
+// SitooConfig is the per-node configuration (config.sitoo). The API password is
+// stored as `api_password_secret_id` (a secrets-vault reference); the resolver
+// replaces it with the plaintext `api_password` at connection-start time.
+type SitooConfig struct {
+	AccountID           int64  `json:"account_id"`
+	SiteID              int64  `json:"site_id"`
+	APIID               string `json:"api_id"`
+	APIPassword         string `json:"api_password"` // resolved from api_password_secret_id
+	BaseURL             string `json:"base_url"`     // optional; default https://api.mysitoo.com/v2
+	Resource            string `json:"resource"`     // e.g. transactions, warehouseitems, products
+	PollIntervalSeconds int    `json:"poll_interval_seconds"`
+	PageSize            int    `json:"page_size"` // Sitoo `num`; default 1000
+}
+
+type nodeConfig struct {
+	Type  string       `json:"type"`
+	Sitoo *SitooConfig `json:"sitoo"`
+}
+
+type node struct {
+	ID     string          `json:"id"`
+	Type   string          `json:"type"`
+	Config json.RawMessage `json:"config"`
+}
+
+type commandMessage struct {
+	ConnectionID string `json:"connection_id"`
+	TenantID     string `json:"tenant_id"`
+}
+
+// Configure wires dependencies. Called once before Run.
+func (s *sitooConsumer) Configure(ctx context.Context, res *sdk.Resources) error {
+	if res.DB == nil {
+		return errors.New("sitoo-consumer requires DATABASE_URL (per-connection config lives in the connections table)")
+	}
+	s.db = res.DB
+	s.nc = res.NATS
+	s.logger = res.Logger
+	s.active = make(map[string]context.CancelFunc)
+	if s.httpClient == nil {
+		// No redirect following: requests carry the Sitoo Basic-auth credential,
+		// which Go would forward on a same-host redirect. We only ever call the
+		// configured Sitoo host, so a redirect is unexpected — surface it.
+		s.httpClient = &http.Client{
+			Timeout:       60 * time.Second,
+			CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse },
+		}
+	}
+
+	if s.resolveTenant == nil {
+		s.resolveTenant = s.getConnectionTenant
+	}
+
+	// Real-time SPI Events (webhook mode): Sitoo POSTs event notifications to
+	// /sitoo/events/{connectionID} on the SDK auxiliary HTTP port.
+	s.RegisterHTTPHandler("/sitoo/events/", s.handleWebhook())
+
+	res.Health.SetReady(true)
+	return nil
+}
+
+// Run subscribes to the connection command subjects and blocks until ctx is
+// cancelled. Per-connection polling is driven from the command handlers.
+func (s *sitooConsumer) Run(ctx context.Context, publish sdk.PublishFunc) error {
+	s.publish = publish
+
+	startSub, err := s.nc.Subscribe("vrsky.commands.*.connection.start", s.handleStartCommand)
+	if err != nil {
+		return fmt.Errorf("subscribe start commands: %w", err)
+	}
+	s.startSub = startSub
+
+	stopSub, err := s.nc.Subscribe("vrsky.commands.*.connection.stop", s.handleStopCommand)
+	if err != nil {
+		return fmt.Errorf("subscribe stop commands: %w", err)
+	}
+	s.stopSub = stopSub
+
+	s.logger.Info("Subscribed to NATS command topics")
+	<-ctx.Done()
+	return nil
+}
+
+// Stop cancels all pollers. The SDK runner calls this after Run returns.
+func (s *sitooConsumer) Stop(ctx context.Context) error {
+	if s.startSub != nil {
+		_ = s.startSub.Unsubscribe()
+	}
+	if s.stopSub != nil {
+		_ = s.stopSub.Unsubscribe()
+	}
+	s.mu.Lock()
+	for id, cancel := range s.active {
+		s.logger.Info("Stopping Sitoo poller", "connection_id", id)
+		cancel()
+	}
+	s.active = make(map[string]context.CancelFunc)
+	s.mu.Unlock()
+	select {
+	case <-ctx.Done():
+	case <-time.After(2 * time.Second):
+	}
+	return nil
+}
+
+func (s *sitooConsumer) handleStartCommand(msg *nats.Msg) {
+	var cmd commandMessage
+	if err := json.Unmarshal(msg.Data, &cmd); err != nil {
+		s.logger.Error("parse start command", "error", err)
+		return
+	}
+	logger := s.logger.With("connection_id", cmd.ConnectionID, "tenant_id", cmd.TenantID)
+
+	s.mu.RLock()
+	_, exists := s.active[cmd.ConnectionID]
+	s.mu.RUnlock()
+	if exists {
+		logger.Warn("Sitoo poller already running")
+		return
+	}
+
+	cfg, err := s.getSitooConfig(context.Background(), cmd.ConnectionID, cmd.TenantID)
+	if err != nil {
+		logger.Debug("Not a Sitoo consumer for this connection", "error", err)
+		return
+	}
+	if cfg.AccountID == 0 || cfg.SiteID == 0 || cfg.APIID == "" || cfg.APIPassword == "" {
+		logger.Error("Sitoo config incomplete (need account_id, site_id, api_id, api_password_secret_id)")
+		return
+	}
+	// Poll interval <= 0 means webhook-only (no polling) — a valid mode.
+	if cfg.PollIntervalSeconds <= 0 {
+		logger.Info("Sitoo connection is webhook-only (no poll interval configured)")
+		return
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	s.mu.Lock()
+	s.active[cmd.ConnectionID] = cancel
+	s.mu.Unlock()
+
+	logger.Info("Starting Sitoo poller", "resource", cfg.effectiveResource(), "interval", cfg.PollIntervalSeconds)
+	go s.runPoller(ctx, cmd.ConnectionID, cmd.TenantID, cfg)
+}
+
+func (s *sitooConsumer) handleStopCommand(msg *nats.Msg) {
+	var cmd commandMessage
+	if err := json.Unmarshal(msg.Data, &cmd); err != nil {
+		s.logger.Error("parse stop command", "error", err)
+		return
+	}
+	s.mu.Lock()
+	cancel, exists := s.active[cmd.ConnectionID]
+	if exists {
+		cancel()
+		delete(s.active, cmd.ConnectionID)
+	}
+	s.mu.Unlock()
+	if exists {
+		s.logger.Info("Sitoo poller stopped", "connection_id", cmd.ConnectionID)
+	}
+}
+
+func (s *sitooConsumer) runPoller(ctx context.Context, connID, tenantID string, cfg *SitooConfig) {
+	logger := s.logger.With("connection_id", connID)
+	if err := s.fetchAndPublish(ctx, connID, tenantID, cfg, logger); err != nil && ctx.Err() == nil {
+		logger.Error("Sitoo fetch failed", "error", err)
+	}
+	ticker := time.NewTicker(time.Duration(cfg.PollIntervalSeconds) * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := s.fetchAndPublish(ctx, connID, tenantID, cfg, logger); err != nil && ctx.Err() == nil {
+				logger.Error("Sitoo fetch failed", "error", err)
+			}
+		}
+	}
+}
+
+// sitooCollection is the envelope-based list response: a totalcount plus the
+// page of items. (Exact item field names vary per resource; we pass items
+// through as raw JSON.)
+type sitooCollection struct {
+	TotalCount int               `json:"totalcount"`
+	Items      []json.RawMessage `json:"items"`
+}
+
+// fetchAndPublish pages through the configured Sitoo collection (start/num) and
+// publishes each non-empty page as one JSON-array envelope.
+func (s *sitooConsumer) fetchAndPublish(ctx context.Context, connID, tenantID string, cfg *SitooConfig, logger *slog.Logger) error {
+	pageSize := cfg.PageSize
+	if pageSize <= 0 {
+		pageSize = defaultPageSize
+	}
+	start, page, total := 0, 0, 0
+	for {
+		page++
+		reqURL := fmt.Sprintf("%s/accounts/%d/sites/%d/%s?start=%d&num=%d",
+			cfg.effectiveBaseURL(), cfg.AccountID, cfg.SiteID, cfg.effectiveResource(), start, pageSize)
+
+		body, err := s.get(ctx, cfg, reqURL)
+		if err != nil {
+			return err
+		}
+		var coll sitooCollection
+		if err := json.Unmarshal(body, &coll); err != nil {
+			return fmt.Errorf("parse Sitoo collection: %w", err)
+		}
+		if len(coll.Items) > 0 {
+			if err := s.publishItems(ctx, connID, tenantID, cfg.effectiveResource(), coll.Items); err != nil {
+				return fmt.Errorf("publish items: %w", err)
+			}
+			total += len(coll.Items)
+		}
+		// Last page when we received fewer than a full page, or reached totalcount.
+		if len(coll.Items) < pageSize || (coll.TotalCount > 0 && start+len(coll.Items) >= coll.TotalCount) {
+			break
+		}
+		start += len(coll.Items)
+	}
+	logger.Info("Sitoo fetch complete", "resource", cfg.effectiveResource(), "items", total, "pages", page)
+	return nil
+}
+
+// get performs an authenticated (HTTP Basic) GET, honouring Sitoo's 429
+// time-slot rate limit: on 429 it waits for X-Rate-Limit-Reset / Retry-After
+// and retries, up to maxRateRetries.
+func (s *sitooConsumer) get(ctx context.Context, cfg *SitooConfig, fullURL string) ([]byte, error) {
+	for attempt := 0; ; attempt++ {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, fullURL, nil)
+		if err != nil {
+			return nil, err
+		}
+		req.SetBasicAuth(cfg.APIID, cfg.APIPassword)
+		req.Header.Set("Accept", "application/json")
+
+		resp, err := s.httpClient.Do(req)
+		if err != nil {
+			return nil, err
+		}
+
+		if resp.StatusCode == http.StatusTooManyRequests {
+			_ = resp.Body.Close()
+			if attempt >= maxRateRetries {
+				return nil, fmt.Errorf("sitoo rate limit: still 429 after %d retries", maxRateRetries)
+			}
+			wait := rateLimitWait(resp.Header)
+			s.logger.Warn("Sitoo 429; backing off", "wait", wait, "attempt", attempt+1)
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(wait):
+			}
+			continue
+		}
+
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 32<<20)) // 32 MiB cap
+		_ = resp.Body.Close()
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			return nil, fmt.Errorf("sitoo %s: %s", resp.Status, strings.TrimSpace(string(body)))
+		}
+		return body, nil
+	}
+}
+
+// rateLimitWait reads Sitoo's reset hint (X-Rate-Limit-Reset is epoch seconds;
+// Retry-After is delta seconds), clamped to a sane range.
+func rateLimitWait(h http.Header) time.Duration {
+	if v := h.Get("X-Rate-Limit-Reset"); v != "" {
+		if epoch, err := strconv.ParseInt(v, 10, 64); err == nil {
+			if d := time.Until(time.Unix(epoch, 0)); d > 0 {
+				return clampWait(d)
+			}
+		}
+	}
+	if v := h.Get("Retry-After"); v != "" {
+		if secs, err := strconv.Atoi(v); err == nil && secs > 0 {
+			return clampWait(time.Duration(secs) * time.Second)
+		}
+	}
+	return 5 * time.Second
+}
+
+func clampWait(d time.Duration) time.Duration {
+	switch {
+	case d < time.Second:
+		return time.Second
+	case d > 10*time.Minute:
+		return 10 * time.Minute
+	default:
+		return d
+	}
+}
+
+func (s *sitooConsumer) publishItems(ctx context.Context, connID, tenantID, resource string, items []json.RawMessage) error {
+	payload, err := json.Marshal(items)
+	if err != nil {
+		return err
+	}
+	env := envelope.New()
+	env.TenantID = tenantID
+	env.IntegrationID = connID
+	env.ContentType = "application/json"
+	env.Source = "sitoo-consumer"
+	env.Payload = payload
+	env.PayloadSize = int64(len(payload))
+	env.StepHistory = []string{"sitoo-consumer"}
+	env.Metadata = map[string]interface{}{"resource": resource, "record_count": len(items)}
+	return s.publish(ctx, env)
+}
+
+func (c *SitooConfig) effectiveBaseURL() string {
+	if c.BaseURL != "" {
+		return strings.TrimRight(c.BaseURL, "/")
+	}
+	return defaultBaseURL
+}
+
+func (c *SitooConfig) effectiveResource() string {
+	if c.Resource != "" {
+		return strings.Trim(c.Resource, "/")
+	}
+	return defaultResource
+}
+
+// --- DB helpers ---
+
+// getSitooConfig loads the connection, resolves any *_secret_id references
+// against the secrets vault, and extracts its Sitoo consumer node config.
+// lint:tenant-ok — lookup is scoped by (id, tenant_id).
+func (s *sitooConsumer) getSitooConfig(ctx context.Context, connectionID, tenantID string) (*SitooConfig, error) {
+	var nodesJSON json.RawMessage
+	err := s.db.QueryRow(
+		`SELECT nodes FROM connections WHERE id = $1 AND tenant_id = $2`,
+		connectionID, tenantID,
+	).Scan(&nodesJSON)
+	if err != nil {
+		return nil, fmt.Errorf("connection not found: %w", err)
+	}
+
+	var nodes []node
+	if err := json.Unmarshal(nodesJSON, &nodes); err != nil {
+		return nil, fmt.Errorf("parse nodes: %w", err)
+	}
+	reader := crypto.NewSQLSecretReader(s.db)
+	for _, n := range nodes {
+		if n.Type != "consumer" {
+			continue
+		}
+		// Replace api_password_secret_id → api_password (decrypted) before parse.
+		resolved, rerr := crypto.ResolveSecretsInJSON(ctx, reader, tenantID, n.Config)
+		if rerr != nil {
+			return nil, fmt.Errorf("resolve secrets: %w", rerr)
+		}
+		var nc nodeConfig
+		if err := json.Unmarshal(resolved, &nc); err != nil {
+			continue
+		}
+		if nc.Type == "sitoo" && nc.Sitoo != nil {
+			return nc.Sitoo, nil
+		}
+	}
+	return nil, errors.New("no sitoo consumer node found")
+}
+
+// getConnectionTenant resolves the owning tenant for a connection id (used by
+// the webhook path, where Sitoo posts without a tenant context).
+// lint:tenant-ok — resolves a connection's own tenant by PK for routing.
+func (s *sitooConsumer) getConnectionTenant(connectionID string) (string, error) {
+	var tenantID string
+	err := s.db.QueryRow(`SELECT tenant_id FROM connections WHERE id = $1`, connectionID).Scan(&tenantID)
+	return tenantID, err
+}


### PR DESCRIPTION
The first connector from the Nordic-retail connector-roadmap research: a **Sitoo** source connector (cloud POS / unified commerce). Built on the SDK, modelled on `salesforce-consumer`, so it's also the reference template for the next POS connectors (Front Systems next).

## What it does
- **Poll mode** — per active connection, fetches a configurable Sitoo collection (default `transactions`/orders; also `warehouseitems`, `products`) over the REST API with **HTTP Basic auth** and **start/num pagination**, honouring Sitoo's **429 rate limit** (`X-Rate-Limit-Reset` / `Retry-After` backoff). Publishes each page as a JSON-array envelope.
- **Webhook mode** — serves `POST /sitoo/events/{connectionID}` on the SDK aux HTTP port (9260) for real-time **SPI Events** (Orders, Warehouse Transactions).
- **Credentials via the secrets vault** — `api_password_secret_id` is resolved to plaintext at connection-start (`crypto.ResolveSecretsInJSON`); no raw password on the node.
- Per-connection config from the `connections` table (node `type: "sitoo"`), driven by the standard start/stop command subjects.

## Grounded in research
API details (Basic auth, `start`/`num` pagination, `totalcount` envelope, 429 + `X-Rate-Limit-Reset`, SPI Event webhooks, object model) came from Sitoo's public developer docs — [developer.sitoo.com](https://developer.sitoo.com/). Sitoo ranked #1 for connector feasibility in the research (open docs, webhooks, full retail model).

## Files
- `src/cmd/sitoo-consumer/` — `main.go`, `service.go` (poll + auth + pagination + 429 + secret resolution), `server.go` (webhook), `Dockerfile`, tests.
- `docker-compose.yml` — `sitoo-consumer` service (WORKER_HTTP_PORT 9260, ENCRYPTION_KEY for secret resolution).
- `docs/connectors/sitoo.md` + nav + index row.

## Tests
`go test ./cmd/sitoo-consumer/...` — pagination + Basic-auth assertion, 429 retry, webhook publish / 404 unknown-connection / 405 wrong-method. `go build ./...`, `go vet`, `gofmt` clean.

## Follow-ups (noted in the doc)
- A `sitoo` **producer** (write-back → two-way inventory sync).
- Incremental/cursor polling (`modified_after`) for high-volume order streams.
- Webhook **signature verification** once the SPI Event signing scheme is confirmed.
- UI source-type wiring (config is API-settable today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)