### PR TITLE
fix: tear down orchestrator k8s resources on connection delete (#175)

### DIFF
--- a/src/pkg/managementapi/handler.go
+++ b/src/pkg/managementapi/handler.go
@@ -489,6 +489,21 @@ func (h *Handler) DeleteConnection(w http.ResponseWriter, r *http.Request) {
 		_ = h.repo.UpdateConnectionStatus(ctx, id, "stopped", nil)
 	}
 
+	// Tear down any orchestrator-spawned K8s resources (Deployments + HPAs) so a
+	// delete never orphans crash-looping workers (#175). The NATS stop above only
+	// stops standing connectors' in-process pollers; graph/orchestrator-based
+	// connections run as per-connection Deployments that must be removed via the
+	// orchestrator (mirrors StopConnection). Best-effort: a teardown failure must
+	// not block the delete (orphans can still be GC'd), and we attempt it
+	// regardless of status since a partially-stopped connection can still hold
+	// live k8s resources.
+	if len(conn.Nodes) > 0 && h.orchestratorFactory != nil {
+		orch := h.orchestratorFactory(conn)
+		if terr := orch.StopPipeline(ctx, conn); terr != nil {
+			slog.Default().Error("connection delete: orchestrator teardown failed", "connection", id, "error", terr)
+		}
+	}
+
 	// Delete connection (cascade delete events)
 	if err := h.repo.DeleteConnection(ctx, id); err != nil {
 		if _, ok := err.(*NotFoundError); ok {

--- a/src/pkg/managementapi/handler_test.go
+++ b/src/pkg/managementapi/handler_test.go
@@ -384,6 +384,64 @@ func TestDeleteConnection_Valid(t *testing.T) {
 	}
 }
 
+// fakeOrchestrator records StopPipeline invocations so a test can assert that
+// deleting a graph-based connection tears down its k8s resources (#175).
+type fakeOrchestrator struct {
+	stopCalls   int
+	stoppedConn string
+}
+
+func (f *fakeOrchestrator) StartPipeline(_ context.Context, _ *Connection) error { return nil }
+func (f *fakeOrchestrator) StopPipeline(_ context.Context, conn *Connection) error {
+	f.stopCalls++
+	f.stoppedConn = conn.ID
+	return nil
+}
+func (f *fakeOrchestrator) GetPipelineStatus(_ context.Context, _ *Connection) (map[string]string, error) {
+	return map[string]string{}, nil
+}
+
+// TestDeleteConnection_TearsDownOrchestratorResources asserts that deleting a
+// graph-based connection invokes the orchestrator teardown (StopPipeline), so
+// per-connection Deployments + HPAs aren't orphaned (#175). Before the fix,
+// delete only published a NATS stop and never called the orchestrator.
+func TestDeleteConnection_TearsDownOrchestratorResources(t *testing.T) {
+	handler, mockRepo := setupTestHandler()
+	ctx := contextWithTenant("tenant-1")
+
+	fake := &fakeOrchestrator{}
+	handler.SetOrchestratorFactory(func(_ *Connection) PipelineOrchestrator { return fake })
+
+	conn := &Connection{
+		ID:       "graph-conn",
+		TenantID: "tenant-1",
+		Name:     "graph-connection",
+		Status:   "stopped",
+		Nodes:    []*Node{{ID: "src", Type: "consumer"}},
+	}
+	mockRepo.connections["graph-conn"] = conn
+
+	r := httptest.NewRequest("DELETE", "/api/v1/connections/graph-conn", nil)
+	r = r.WithContext(ctx)
+	r.SetPathValue("id", "graph-conn")
+	w := httptest.NewRecorder()
+
+	handler.DeleteConnection(w, r)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("expected status 204, got %d", w.Code)
+	}
+	if fake.stopCalls != 1 {
+		t.Errorf("expected orchestrator StopPipeline to be called once on delete, got %d", fake.stopCalls)
+	}
+	if fake.stoppedConn != "graph-conn" {
+		t.Errorf("expected teardown for graph-conn, got %q", fake.stoppedConn)
+	}
+	if _, err := mockRepo.GetConnection(ctx, "graph-conn"); err == nil {
+		t.Error("expected connection to be deleted from repo")
+	}
+}
+
 // Test StartConnection
 func TestStartConnection_Valid(t *testing.T) {
 	handler, mockRepo := setupTestHandler()


### PR DESCRIPTION
Closes #175.

## Problem
`DELETE /api/v1/connections/{id}` deleted the DB row but never tore down the orchestrator-spawned Kubernetes resources for graph/orchestrator-based connections. It only published a NATS `connection.stop` (which stops *standing* connectors' in-process pollers), so per-connection **Deployments + HPAs were orphaned** and crash-looped indefinitely.

**Observed in prod (2026-08-13):** 2 deleted connections left 4 Deployments + 4 HPAs + 4 pods in CrashLoopBackOff for ~3 days (800+ restarts). Cleaned up manually.

## Fix
`DeleteConnection` now calls the orchestrator teardown (`orch.StopPipeline`) before deleting the DB row — mirroring `StopConnection`. Best-effort: a teardown failure is logged but doesn't block the delete (orphans can still be GC'd), and it runs regardless of status since a partially-stopped connection can still hold live k8s resources.

## Test
`TestDeleteConnection_TearsDownOrchestratorResources` — a fake orchestrator asserts `StopPipeline` is invoked once on delete of a graph-based connection (would be 0 before the fix). Full `pkg/managementapi` suite green.

## Follow-up (not in this PR)
A periodic reconcile/GC that removes orchestrator Deployments/HPAs whose `connection_id` label has no matching DB row would self-heal orphans if teardown ever fails — noted in #175.

🤖 Generated with [Claude Code](https://claude.com/claude-code)