### PR TITLE
Pre-deploy live sampling for retail connectors (Sitoo, BC, Visma, Brightpearl)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -830,6 +830,10 @@ services:
       # Must match management-api's ENCRYPTION_KEY — decrypts client_secret
       # (client_secret_secret_id) at connection-start time.
       ENCRYPTION_KEY: "${ENCRYPTION_KEY:-0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef}"
+      # Aux HTTP port the SDK serves /sample-data on (UI's pre-deploy preview).
+      WORKER_HTTP_PORT: "9310"
+    ports:
+      - "127.0.0.1:9310:9310"
     depends_on:
       nats:
         condition: service_healthy
@@ -850,6 +854,10 @@ services:
       DATABASE_URL: "postgres://postgres:management_password@postgres-management:5432/management_db?sslmode=disable"
       LOG_LEVEL: "info"
       ENCRYPTION_KEY: "${ENCRYPTION_KEY:-0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef}"
+      # Aux HTTP port the SDK serves /sample-data on (UI's pre-deploy preview).
+      WORKER_HTTP_PORT: "9320"
+    ports:
+      - "127.0.0.1:9320:9320"
     depends_on:
       nats:
         condition: service_healthy

--- a/src/cmd/brightpearl-consumer/consumer_test.go
+++ b/src/cmd/brightpearl-consumer/consumer_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"log/slog"
@@ -106,5 +107,35 @@ func TestWebhook(t *testing.T) {
 	h(rec3, httptest.NewRequest(http.MethodGet, "/brightpearl/events/c9", nil))
 	if rec3.Code != http.StatusMethodNotAllowed {
 		t.Errorf("GET = %d, want 405", rec3.Code)
+	}
+}
+
+// TestSampleData_Brightpearl exercises the pre-deploy /sample-data aux endpoint,
+// including unwrapping the {"response": …} envelope.
+func TestSampleData_Brightpearl(t *testing.T) {
+	apiSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{"response":[{"id":1,"total":"10.00"},{"id":2,"total":"20.00"}]}`)
+	}))
+	defer apiSrv.Close()
+
+	c := &brightpearlConsumer{httpClient: http.DefaultClient}
+	body := fmt.Sprintf(`{"app_ref":"app","staff_token":"tok","base_url":%q,"resource":"/order-service/order"}`, apiSrv.URL)
+	req := httptest.NewRequest(http.MethodPost, "/sample-data/", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	c.handleSampleData()(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d", w.Code)
+	}
+	var resp struct {
+		OK    bool          `json:"ok"`
+		Data  []interface{} `json:"data"`
+		Error string        `json:"error"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !resp.OK || len(resp.Data) != 2 {
+		t.Fatalf("want ok+2 records, got ok=%v n=%d err=%q", resp.OK, len(resp.Data), resp.Error)
 	}
 }

--- a/src/cmd/brightpearl-consumer/server.go
+++ b/src/cmd/brightpearl-consumer/server.go
@@ -1,12 +1,116 @@
 package main
 
 import (
+	"encoding/json"
 	"io"
 	"net/http"
 	"strings"
 
+	"github.com/ValueRetail/vrsky/pkg/crypto"
 	"github.com/ValueRetail/vrsky/pkg/envelope"
 )
+
+const brightpearlSampleLimit = 5
+
+// handleSampleData GETs the configured Brightpearl resource and returns up to
+// brightpearlSampleLimit records, reusing the poller's auth + fetch path. It
+// unwraps the {"response": …} envelope and normalises arrays/objects to a list.
+// Registered in Configure on the SDK aux HTTP port for the UI's pre-deploy
+// "show data structure" preview.
+func (c *brightpearlConsumer) handleSampleData() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
+		w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		if r.Method != http.MethodPost {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		writeErr := func(msg string) {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"ok": false, "error": msg})
+		}
+
+		raw, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+		if err != nil {
+			writeErr("read request body: " + err.Error())
+			return
+		}
+		var meta struct {
+			TenantID string `json:"tenant_id"`
+		}
+		_ = json.Unmarshal(raw, &meta)
+		cfgJSON := json.RawMessage(raw)
+		if meta.TenantID != "" && c.db != nil {
+			if resolved, rerr := crypto.ResolveSecretsInJSON(r.Context(), crypto.NewSQLSecretReader(c.db), meta.TenantID, cfgJSON); rerr == nil {
+				cfgJSON = resolved
+			}
+		}
+
+		var cfg BrightpearlConfig
+		if err := json.Unmarshal(cfgJSON, &cfg); err != nil {
+			writeErr("invalid Brightpearl config: " + err.Error())
+			return
+		}
+		if cfg.AppRef == "" || cfg.StaffToken == "" {
+			writeErr("set the app reference and staff token first")
+			return
+		}
+		if cfg.baseURL() == "" {
+			writeErr("set the datacenter and account code (or base_url) first")
+			return
+		}
+		if cfg.Resource == "" {
+			writeErr("set the resource first")
+			return
+		}
+
+		body, err := c.get(r.Context(), &cfg)
+		if err != nil {
+			writeErr(err.Error())
+			return
+		}
+		// Unwrap the {"response": …} envelope when present.
+		var wrapper struct {
+			Response json.RawMessage `json:"response"`
+		}
+		payload := body
+		if json.Unmarshal(body, &wrapper) == nil && len(wrapper.Response) > 0 {
+			payload = wrapper.Response
+		}
+
+		out := make([]interface{}, 0, brightpearlSampleLimit)
+		if strings.HasPrefix(strings.TrimSpace(string(payload)), "[") {
+			var arr []json.RawMessage
+			if err := json.Unmarshal(payload, &arr); err != nil {
+				writeErr("parse Brightpearl array: " + err.Error())
+				return
+			}
+			for i, rec := range arr {
+				if i >= brightpearlSampleLimit {
+					break
+				}
+				var v interface{}
+				if json.Unmarshal(rec, &v) == nil {
+					out = append(out, v)
+				}
+			}
+		} else {
+			var v interface{}
+			if err := json.Unmarshal(payload, &v); err != nil {
+				writeErr("parse Brightpearl response: " + err.Error())
+				return
+			}
+			out = append(out, v)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"ok": true, "data": out})
+	}
+}
 
 // handleWebhook receives Brightpearl webhook notifications. Brightpearl POSTs to
 // /brightpearl/events/{connectionID}; the body is published into the pipeline.

--- a/src/cmd/brightpearl-consumer/service.go
+++ b/src/cmd/brightpearl-consumer/service.go
@@ -89,6 +89,7 @@ func (c *brightpearlConsumer) Configure(ctx context.Context, res *sdk.Resources)
 		c.resolveTenant = c.getConnectionTenant
 	}
 	c.RegisterHTTPHandler("/brightpearl/events/", c.handleWebhook())
+	c.RegisterHTTPHandler("/sample-data/", c.handleSampleData())
 	res.Health.SetReady(true)
 	return nil
 }

--- a/src/cmd/business-central-consumer/consumer_test.go
+++ b/src/cmd/business-central-consumer/consumer_test.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"testing"
 
@@ -94,5 +95,42 @@ func TestEntityURL(t *testing.T) {
 	want := "https://host/api/v2.0/companies(GUID)/salesOrders?$filter=status+eq+%27Open%27"
 	if got != want {
 		t.Errorf("entityURL = %q\nwant %q", got, want)
+	}
+}
+
+// TestSampleData_BC exercises the pre-deploy /sample-data aux endpoint: it must
+// acquire a token, GET the first OData page, and return the records as {ok,data}.
+func TestSampleData_BC(t *testing.T) {
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{"access_token":"tok-abc","expires_in":3600}`)
+	}))
+	defer tokenSrv.Close()
+	apiSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{"value":[{"number":"C1","displayName":"Acme"},{"number":"C2","displayName":"Beta"}]}`)
+	}))
+	defer apiSrv.Close()
+
+	c := &bcConsumer{httpClient: http.DefaultClient}
+	body := fmt.Sprintf(`{"client_id":"id","client_secret":"sec","api_base_url":%q,"token_url":%q,"company_id":"GUID","entity":"customers"}`, apiSrv.URL, tokenSrv.URL)
+	req := httptest.NewRequest(http.MethodPost, "/sample-data/", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	c.handleSampleData()(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d", w.Code)
+	}
+	var resp struct {
+		OK    bool          `json:"ok"`
+		Data  []interface{} `json:"data"`
+		Error string        `json:"error"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !resp.OK {
+		t.Fatalf("ok=false error=%q", resp.Error)
+	}
+	if len(resp.Data) != 2 {
+		t.Fatalf("want 2 records, got %d: %s", len(resp.Data), w.Body.String())
 	}
 }

--- a/src/cmd/business-central-consumer/server.go
+++ b/src/cmd/business-central-consumer/server.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+
+	"github.com/ValueRetail/vrsky/pkg/crypto"
+	"github.com/ValueRetail/vrsky/pkg/oauthcc"
+)
+
+// Aux HTTP handler served on the SDK auxiliary HTTP port (WORKER_HTTP_PORT).
+// Registered in Configure. Lets the UI's filter/converter "show data structure"
+// preview fetch a live sample from Business Central before the pipeline is
+// deployed — no data has to flow through first.
+
+const bcSampleLimit = 5
+
+// handleSampleData GETs the first OData page for the posted BC config and
+// returns up to bcSampleLimit records, reusing the poller's auth + fetch path.
+func (c *bcConsumer) handleSampleData() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
+		w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		if r.Method != http.MethodPost {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		writeErr := func(msg string) {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"ok": false, "error": msg})
+		}
+
+		raw, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+		if err != nil {
+			writeErr("read request body: " + err.Error())
+			return
+		}
+		// tenant_id (optional) resolves <field>_secret_id references for a saved
+		// connection; a freshly-typed config carries plaintext and resolves to
+		// itself. Best-effort: plaintext still works when resolution is skipped.
+		var meta struct {
+			TenantID string `json:"tenant_id"`
+		}
+		_ = json.Unmarshal(raw, &meta)
+		cfgJSON := json.RawMessage(raw)
+		if meta.TenantID != "" && c.db != nil {
+			if resolved, rerr := crypto.ResolveSecretsInJSON(r.Context(), crypto.NewSQLSecretReader(c.db), meta.TenantID, cfgJSON); rerr == nil {
+				cfgJSON = resolved
+			}
+		}
+
+		var cfg BCConfig
+		if err := json.Unmarshal(cfgJSON, &cfg); err != nil {
+			writeErr("invalid Business Central config: " + err.Error())
+			return
+		}
+		if cfg.ClientID == "" || cfg.ClientSecret == "" {
+			writeErr("set the client ID and client secret first")
+			return
+		}
+		if cfg.APIBaseURL == "" && (cfg.AADTenantID == "" || cfg.CompanyID == "") {
+			writeErr("set the AAD tenant ID and company ID (or api_base_url) first")
+			return
+		}
+
+		tok := oauthcc.New(cfg.effectiveTokenURL(), cfg.ClientID, cfg.ClientSecret, cfg.effectiveScope()).WithHTTPClient(c.httpClient)
+		body, err := c.get(r.Context(), tok, cfg.entityURL())
+		if err != nil {
+			writeErr(err.Error())
+			return
+		}
+		var p odataPage
+		if err := json.Unmarshal(body, &p); err != nil {
+			writeErr("parse OData page: " + err.Error())
+			return
+		}
+		records := p.Value
+		if len(records) > bcSampleLimit {
+			records = records[:bcSampleLimit]
+		}
+		out := make([]interface{}, 0, len(records))
+		for _, rec := range records {
+			var v interface{}
+			if err := json.Unmarshal(rec, &v); err == nil {
+				out = append(out, v)
+			}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"ok": true, "data": out})
+	}
+}

--- a/src/cmd/business-central-consumer/service.go
+++ b/src/cmd/business-central-consumer/service.go
@@ -96,6 +96,8 @@ func (c *bcConsumer) Configure(ctx context.Context, res *sdk.Resources) error {
 	if c.httpClient == nil {
 		c.httpClient = &http.Client{Timeout: 60 * time.Second}
 	}
+	// Aux endpoint for the UI's pre-deploy "show data structure" preview.
+	c.RegisterHTTPHandler("/sample-data/", c.handleSampleData())
 	res.Health.SetReady(true)
 	return nil
 }

--- a/src/cmd/sitoo-consumer/consumer_test.go
+++ b/src/cmd/sitoo-consumer/consumer_test.go
@@ -156,3 +156,32 @@ func TestWebhook_PublishesBody(t *testing.T) {
 		t.Errorf("GET status = %d, want 405", rec3.Code)
 	}
 }
+
+// TestSampleData_Sitoo exercises the pre-deploy /sample-data aux endpoint.
+func TestSampleData_Sitoo(t *testing.T) {
+	apiSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{"totalcount":2,"items":[{"transactionid":1,"total":"10.00"},{"transactionid":2,"total":"20.00"}]}`)
+	}))
+	defer apiSrv.Close()
+
+	c := &sitooConsumer{httpClient: http.DefaultClient}
+	body := fmt.Sprintf(`{"api_id":"id","api_password":"pw","account_id":1,"site_id":2,"base_url":%q,"resource":"transactions"}`, apiSrv.URL)
+	req := httptest.NewRequest(http.MethodPost, "/sample-data/", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	c.handleSampleData()(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d", w.Code)
+	}
+	var resp struct {
+		OK    bool          `json:"ok"`
+		Data  []interface{} `json:"data"`
+		Error string        `json:"error"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !resp.OK || len(resp.Data) != 2 {
+		t.Fatalf("want ok+2 records, got ok=%v n=%d err=%q", resp.OK, len(resp.Data), resp.Error)
+	}
+}

--- a/src/cmd/sitoo-consumer/server.go
+++ b/src/cmd/sitoo-consumer/server.go
@@ -1,12 +1,97 @@
 package main
 
 import (
+	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
 
+	"github.com/ValueRetail/vrsky/pkg/crypto"
 	"github.com/ValueRetail/vrsky/pkg/envelope"
 )
+
+const sitooSampleLimit = 5
+
+// handleSampleData GETs the first page of the configured Sitoo resource and
+// returns up to sitooSampleLimit items, reusing the poller's Basic-auth fetch.
+// Registered in Configure on the SDK aux HTTP port for the UI's pre-deploy
+// "show data structure" preview.
+func (s *sitooConsumer) handleSampleData() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
+		w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		if r.Method != http.MethodPost {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		writeErr := func(msg string) {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"ok": false, "error": msg})
+		}
+
+		raw, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+		if err != nil {
+			writeErr("read request body: " + err.Error())
+			return
+		}
+		var meta struct {
+			TenantID string `json:"tenant_id"`
+		}
+		_ = json.Unmarshal(raw, &meta)
+		cfgJSON := json.RawMessage(raw)
+		if meta.TenantID != "" && s.db != nil {
+			if resolved, rerr := crypto.ResolveSecretsInJSON(r.Context(), crypto.NewSQLSecretReader(s.db), meta.TenantID, cfgJSON); rerr == nil {
+				cfgJSON = resolved
+			}
+		}
+
+		var cfg SitooConfig
+		if err := json.Unmarshal(cfgJSON, &cfg); err != nil {
+			writeErr("invalid Sitoo config: " + err.Error())
+			return
+		}
+		if cfg.APIID == "" || cfg.APIPassword == "" {
+			writeErr("set the API ID and API password first")
+			return
+		}
+		if cfg.AccountID == 0 || cfg.SiteID == 0 {
+			writeErr("set the account ID and site ID first")
+			return
+		}
+
+		reqURL := fmt.Sprintf("%s/accounts/%d/sites/%d/%s?start=0&num=%d",
+			cfg.effectiveBaseURL(), cfg.AccountID, cfg.SiteID, cfg.effectiveResource(), sitooSampleLimit)
+		body, err := s.get(r.Context(), &cfg, reqURL)
+		if err != nil {
+			writeErr(err.Error())
+			return
+		}
+		var coll sitooCollection
+		if err := json.Unmarshal(body, &coll); err != nil {
+			writeErr("parse Sitoo collection: " + err.Error())
+			return
+		}
+		items := coll.Items
+		if len(items) > sitooSampleLimit {
+			items = items[:sitooSampleLimit]
+		}
+		out := make([]interface{}, 0, len(items))
+		for _, rec := range items {
+			var v interface{}
+			if json.Unmarshal(rec, &v) == nil {
+				out = append(out, v)
+			}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"ok": true, "data": out})
+	}
+}
 
 // handleWebhook serves Sitoo SPI Event notifications (real-time mode). Sitoo is
 // configured to POST events to /sitoo/events/{connectionID}; each request body

--- a/src/cmd/sitoo-consumer/service.go
+++ b/src/cmd/sitoo-consumer/service.go
@@ -110,6 +110,7 @@ func (s *sitooConsumer) Configure(ctx context.Context, res *sdk.Resources) error
 	// Real-time SPI Events (webhook mode): Sitoo POSTs event notifications to
 	// /sitoo/events/{connectionID} on the SDK auxiliary HTTP port.
 	s.RegisterHTTPHandler("/sitoo/events/", s.handleWebhook())
+	s.RegisterHTTPHandler("/sample-data/", s.handleSampleData())
 
 	res.Health.SetReady(true)
 	return nil

--- a/src/cmd/visma-consumer/consumer_test.go
+++ b/src/cmd/visma-consumer/consumer_test.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"testing"
 
@@ -98,5 +99,38 @@ func TestFetchAndPublish_SingleObjectWrapped(t *testing.T) {
 	var recs []map[string]any
 	if err := json.Unmarshal((*got)[0].Payload, &recs); err != nil || len(recs) != 1 {
 		t.Errorf("single object not wrapped into a 1-element array: %v / %d", err, len(recs))
+	}
+}
+
+// TestSampleData_Visma exercises the pre-deploy /sample-data aux endpoint.
+func TestSampleData_Visma(t *testing.T) {
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{"access_token":"tok-abc","expires_in":3600}`)
+	}))
+	defer tokenSrv.Close()
+	apiSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `[{"orderNumber":"SO-1","customer":"Acme"},{"orderNumber":"SO-2","customer":"Beta"}]`)
+	}))
+	defer apiSrv.Close()
+
+	c := &vismaConsumer{httpClient: http.DefaultClient}
+	body := fmt.Sprintf(`{"client_id":"id","client_secret":"sec","base_url":%q,"token_url":%q,"scope":"s","resource":"SalesOrders"}`, apiSrv.URL, tokenSrv.URL)
+	req := httptest.NewRequest(http.MethodPost, "/sample-data/", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	c.handleSampleData()(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d", w.Code)
+	}
+	var resp struct {
+		OK    bool          `json:"ok"`
+		Data  []interface{} `json:"data"`
+		Error string        `json:"error"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !resp.OK || len(resp.Data) != 2 {
+		t.Fatalf("want ok+2 records, got ok=%v n=%d err=%q", resp.OK, len(resp.Data), resp.Error)
 	}
 }

--- a/src/cmd/visma-consumer/server.go
+++ b/src/cmd/visma-consumer/server.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/ValueRetail/vrsky/pkg/crypto"
+	"github.com/ValueRetail/vrsky/pkg/oauthcc"
+)
+
+// Aux HTTP handler served on the SDK auxiliary HTTP port (WORKER_HTTP_PORT).
+// Registered in Configure. Lets the UI's filter/converter "show data structure"
+// preview fetch a live sample from Visma.net before the pipeline is deployed.
+
+const vismaSampleLimit = 5
+
+// handleSampleData GETs the configured resource and returns up to
+// vismaSampleLimit records, reusing the poller's auth + fetch path. Visma
+// returns either a JSON array or a single object; both normalise to a list.
+func (c *vismaConsumer) handleSampleData() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
+		w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		if r.Method != http.MethodPost {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		writeErr := func(msg string) {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"ok": false, "error": msg})
+		}
+
+		raw, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+		if err != nil {
+			writeErr("read request body: " + err.Error())
+			return
+		}
+		var meta struct {
+			TenantID string `json:"tenant_id"`
+		}
+		_ = json.Unmarshal(raw, &meta)
+		cfgJSON := json.RawMessage(raw)
+		if meta.TenantID != "" && c.db != nil {
+			if resolved, rerr := crypto.ResolveSecretsInJSON(r.Context(), crypto.NewSQLSecretReader(c.db), meta.TenantID, cfgJSON); rerr == nil {
+				cfgJSON = resolved
+			}
+		}
+
+		var cfg VismaConfig
+		if err := json.Unmarshal(cfgJSON, &cfg); err != nil {
+			writeErr("invalid Visma config: " + err.Error())
+			return
+		}
+		if cfg.ClientID == "" || cfg.ClientSecret == "" {
+			writeErr("set the client ID and client secret first")
+			return
+		}
+		if cfg.BaseURL == "" || cfg.Resource == "" {
+			writeErr("set the base URL and resource first")
+			return
+		}
+
+		tok := oauthcc.New(cfg.effectiveTokenURL(), cfg.ClientID, cfg.ClientSecret, cfg.Scope).WithHTTPClient(c.httpClient)
+		body, err := c.get(r.Context(), &cfg, tok)
+		if err != nil {
+			writeErr(err.Error())
+			return
+		}
+
+		out := make([]interface{}, 0, vismaSampleLimit)
+		if strings.HasPrefix(strings.TrimSpace(string(body)), "[") {
+			var arr []json.RawMessage
+			if err := json.Unmarshal(body, &arr); err != nil {
+				writeErr("parse Visma array: " + err.Error())
+				return
+			}
+			for i, rec := range arr {
+				if i >= vismaSampleLimit {
+					break
+				}
+				var v interface{}
+				if json.Unmarshal(rec, &v) == nil {
+					out = append(out, v)
+				}
+			}
+		} else {
+			var v interface{}
+			if err := json.Unmarshal(body, &v); err != nil {
+				writeErr("parse Visma object: " + err.Error())
+				return
+			}
+			out = append(out, v)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"ok": true, "data": out})
+	}
+}

--- a/src/cmd/visma-consumer/service.go
+++ b/src/cmd/visma-consumer/service.go
@@ -86,6 +86,8 @@ func (c *vismaConsumer) Configure(ctx context.Context, res *sdk.Resources) error
 	if c.httpClient == nil {
 		c.httpClient = &http.Client{Timeout: 60 * time.Second}
 	}
+	// Aux endpoint for the UI's pre-deploy "show data structure" preview.
+	c.RegisterHTTPHandler("/sample-data/", c.handleSampleData())
 	res.Health.SetReady(true)
 	return nil
 }

--- a/ui/src/components/Pipeline/PropertyEditor.tsx
+++ b/ui/src/components/Pipeline/PropertyEditor.tsx
@@ -2070,11 +2070,50 @@ function FilterConfig({
         } else {
           setDataError(result.error || 'Salesforce query failed')
         }
+      } else if (consumerType === 'sitoo') {
+        const sc = (consumerConfig?.sitoo as Record<string, unknown>) || {}
+        if (!sc.api_id || !sc.account_id || !sc.site_id) { setDataError('Set the Sitoo API ID, account ID and site ID first'); return }
+        const resp = await fetch('http://localhost:9260/sample-data/', {
+          method: 'POST', headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ ...sc, tenant_id: currentTenant?.id }),
+        })
+        const result = await resp.json()
+        if (result.ok) { setSampleData(result.data); setExpandedPaths(new Set(collectPaths(result.data, '', 0, 3))) }
+        else { setDataError(result.error || 'No Sitoo data to sample yet') }
+      } else if (consumerType === 'business_central') {
+        const bc = (consumerConfig?.business_central as Record<string, unknown>) || {}
+        if (!bc.client_id || !bc.client_secret) { setDataError('Set the Business Central client ID and secret first'); return }
+        const resp = await fetch('http://localhost:9310/sample-data/', {
+          method: 'POST', headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ ...bc, tenant_id: currentTenant?.id }),
+        })
+        const result = await resp.json()
+        if (result.ok) { setSampleData(result.data); setExpandedPaths(new Set(collectPaths(result.data, '', 0, 3))) }
+        else { setDataError(result.error || 'No Business Central data to sample yet') }
+      } else if (consumerType === 'visma') {
+        const vc = (consumerConfig?.visma as Record<string, unknown>) || {}
+        if (!vc.client_id || !vc.base_url || !vc.resource) { setDataError('Set the Visma client ID, base URL and resource first'); return }
+        const resp = await fetch('http://localhost:9320/sample-data/', {
+          method: 'POST', headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ ...vc, tenant_id: currentTenant?.id }),
+        })
+        const result = await resp.json()
+        if (result.ok) { setSampleData(result.data); setExpandedPaths(new Set(collectPaths(result.data, '', 0, 3))) }
+        else { setDataError(result.error || 'No Visma data to sample yet') }
+      } else if (consumerType === 'brightpearl') {
+        const bp = (consumerConfig?.brightpearl as Record<string, unknown>) || {}
+        if (!bp.app_ref || !bp.staff_token || !bp.resource) { setDataError('Set the Brightpearl app ref, staff token and resource first'); return }
+        const resp = await fetch('http://localhost:9280/sample-data/', {
+          method: 'POST', headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ ...bp, tenant_id: currentTenant?.id }),
+        })
+        const result = await resp.json()
+        if (result.ok) { setSampleData(result.data); setExpandedPaths(new Set(collectPaths(result.data, '', 0, 3))) }
+        else { setDataError(result.error || 'No Brightpearl data to sample yet') }
       } else {
-        // Remaining types — the retail/ERP connectors (Sitoo, Front Systems,
-        // Business Central, Visma, Brightpearl) plus http webhooks — can't be
-        // sampled pre-deploy (push-only or no test endpoint yet), so read the
-        // deployed connection's last payload once data has flowed through once.
+        // Remaining types — Front Systems (push-only, webhook) + http webhooks —
+        // can't be sampled pre-deploy, so read the deployed connection's last
+        // payload once data has flowed through once.
         const connId = deployedConnectionId
         if (!connId) { setDataError('Deploy the pipeline and send data through once, then load the structure'); return }
         const { default: apiClient } = await import('../../services/api')
@@ -2676,8 +2715,33 @@ function ConverterConfig({
         })
         const data = await resp.json()
         setPreviewInput(data.ok ? JSON.stringify(data.data, null, 2) : '// Error: ' + (data.error || 'No objects under the prefix yet'))
+      } else if (consumerType === 'sitoo') {
+        const sc = (consumerConfig.sitoo as Record<string, unknown>) || {}
+        if (!sc.api_id || !sc.account_id || !sc.site_id) { setPreviewInput('// Set the Sitoo API ID, account ID and site ID first'); return }
+        const resp = await fetch('http://localhost:9260/sample-data/', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ ...sc, tenant_id: currentTenant?.id }) })
+        const data = await resp.json()
+        setPreviewInput(data.ok ? JSON.stringify(data.data, null, 2) : '// Error: ' + (data.error || 'No Sitoo data yet'))
+      } else if (consumerType === 'business_central') {
+        const bc = (consumerConfig.business_central as Record<string, unknown>) || {}
+        if (!bc.client_id || !bc.client_secret) { setPreviewInput('// Set the Business Central client ID and secret first'); return }
+        const resp = await fetch('http://localhost:9310/sample-data/', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ ...bc, tenant_id: currentTenant?.id }) })
+        const data = await resp.json()
+        setPreviewInput(data.ok ? JSON.stringify(data.data, null, 2) : '// Error: ' + (data.error || 'No Business Central data yet'))
+      } else if (consumerType === 'visma') {
+        const vc = (consumerConfig.visma as Record<string, unknown>) || {}
+        if (!vc.client_id || !vc.base_url || !vc.resource) { setPreviewInput('// Set the Visma client ID, base URL and resource first'); return }
+        const resp = await fetch('http://localhost:9320/sample-data/', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ ...vc, tenant_id: currentTenant?.id }) })
+        const data = await resp.json()
+        setPreviewInput(data.ok ? JSON.stringify(data.data, null, 2) : '// Error: ' + (data.error || 'No Visma data yet'))
+      } else if (consumerType === 'brightpearl') {
+        const bp = (consumerConfig.brightpearl as Record<string, unknown>) || {}
+        if (!bp.app_ref || !bp.staff_token || !bp.resource) { setPreviewInput('// Set the Brightpearl app ref, staff token and resource first'); return }
+        const resp = await fetch('http://localhost:9280/sample-data/', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ ...bp, tenant_id: currentTenant?.id }) })
+        const data = await resp.json()
+        setPreviewInput(data.ok ? JSON.stringify(data.data, null, 2) : '// Error: ' + (data.error || 'No Brightpearl data yet'))
       } else {
-        // http / webhook and others: only a deployed connection has a sample.
+        // Front Systems (push-only) + http webhooks: only a deployed connection
+        // has a sample.
         if (!deployedConnectionId) {
           setPreviewInput('// Deploy the pipeline and send data once, then fetch the sample')
           return

--- a/ui/src/components/Pipeline/PropertyEditor.tsx
+++ b/ui/src/components/Pipeline/PropertyEditor.tsx
@@ -2082,7 +2082,7 @@ function FilterConfig({
         else { setDataError(result.error || 'No Sitoo data to sample yet') }
       } else if (consumerType === 'business_central') {
         const bc = (consumerConfig?.business_central as Record<string, unknown>) || {}
-        if (!bc.client_id || !bc.client_secret) { setDataError('Set the Business Central client ID and secret first'); return }
+        if (!bc.client_id || (!bc.client_secret && !bc.client_secret_secret_id)) { setDataError('Set the Business Central client ID and secret first'); return }
         const resp = await fetch('http://localhost:9310/sample-data/', {
           method: 'POST', headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ ...bc, tenant_id: currentTenant?.id }),
@@ -2102,7 +2102,7 @@ function FilterConfig({
         else { setDataError(result.error || 'No Visma data to sample yet') }
       } else if (consumerType === 'brightpearl') {
         const bp = (consumerConfig?.brightpearl as Record<string, unknown>) || {}
-        if (!bp.app_ref || !bp.staff_token || !bp.resource) { setDataError('Set the Brightpearl app ref, staff token and resource first'); return }
+        if (!bp.app_ref || (!bp.staff_token && !bp.staff_token_secret_id) || !bp.resource) { setDataError('Set the Brightpearl app ref, staff token and resource first'); return }
         const resp = await fetch('http://localhost:9280/sample-data/', {
           method: 'POST', headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ ...bp, tenant_id: currentTenant?.id }),
@@ -2723,7 +2723,7 @@ function ConverterConfig({
         setPreviewInput(data.ok ? JSON.stringify(data.data, null, 2) : '// Error: ' + (data.error || 'No Sitoo data yet'))
       } else if (consumerType === 'business_central') {
         const bc = (consumerConfig.business_central as Record<string, unknown>) || {}
-        if (!bc.client_id || !bc.client_secret) { setPreviewInput('// Set the Business Central client ID and secret first'); return }
+        if (!bc.client_id || (!bc.client_secret && !bc.client_secret_secret_id)) { setPreviewInput('// Set the Business Central client ID and secret first'); return }
         const resp = await fetch('http://localhost:9310/sample-data/', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ ...bc, tenant_id: currentTenant?.id }) })
         const data = await resp.json()
         setPreviewInput(data.ok ? JSON.stringify(data.data, null, 2) : '// Error: ' + (data.error || 'No Business Central data yet'))
@@ -2735,7 +2735,7 @@ function ConverterConfig({
         setPreviewInput(data.ok ? JSON.stringify(data.data, null, 2) : '// Error: ' + (data.error || 'No Visma data yet'))
       } else if (consumerType === 'brightpearl') {
         const bp = (consumerConfig.brightpearl as Record<string, unknown>) || {}
-        if (!bp.app_ref || !bp.staff_token || !bp.resource) { setPreviewInput('// Set the Brightpearl app ref, staff token and resource first'); return }
+        if (!bp.app_ref || (!bp.staff_token && !bp.staff_token_secret_id) || !bp.resource) { setPreviewInput('// Set the Brightpearl app ref, staff token and resource first'); return }
         const resp = await fetch('http://localhost:9280/sample-data/', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ ...bp, tenant_id: currentTenant?.id }) })
         const data = await resp.json()
         setPreviewInput(data.ok ? JSON.stringify(data.data, null, 2) : '// Error: ' + (data.error || 'No Brightpearl data yet'))

--- a/ui/src/components/Pipeline/schemaDiscovery.ts
+++ b/ui/src/components/Pipeline/schemaDiscovery.ts
@@ -167,7 +167,7 @@ export async function discoverSchema(
 
     case 'business_central': {
       const bc = (consumerConfig.business_central as Record<string, unknown>) || {}
-      if (!bc.client_id || !bc.client_secret) throw new Error('Set the Business Central client ID and secret first')
+      if (!bc.client_id || (!bc.client_secret && !bc.client_secret_secret_id)) throw new Error('Set the Business Central client ID and secret first')
       const data = await postJSON('http://localhost:9310/sample-data/', { ...bc, tenant_id: opts?.tenantId })
       if (!data.ok) throw new Error((data.error as string) || 'No Business Central data to sample yet')
       return inferSchema(data.data)
@@ -183,7 +183,7 @@ export async function discoverSchema(
 
     case 'brightpearl': {
       const bp = (consumerConfig.brightpearl as Record<string, unknown>) || {}
-      if (!bp.app_ref || !bp.staff_token || !bp.resource) throw new Error('Set the Brightpearl app ref, staff token and resource first')
+      if (!bp.app_ref || (!bp.staff_token && !bp.staff_token_secret_id) || !bp.resource) throw new Error('Set the Brightpearl app ref, staff token and resource first')
       const data = await postJSON('http://localhost:9280/sample-data/', { ...bp, tenant_id: opts?.tenantId })
       if (!data.ok) throw new Error((data.error as string) || 'No Brightpearl data to sample yet')
       return inferSchema(data.data)

--- a/ui/src/components/Pipeline/schemaDiscovery.ts
+++ b/ui/src/components/Pipeline/schemaDiscovery.ts
@@ -157,9 +157,41 @@ export async function discoverSchema(
       return inferSchema(data.data)
     }
 
+    case 'sitoo': {
+      const sc = (consumerConfig.sitoo as Record<string, unknown>) || {}
+      if (!sc.api_id || !sc.account_id || !sc.site_id) throw new Error('Set the Sitoo API ID, account ID and site ID first')
+      const data = await postJSON('http://localhost:9260/sample-data/', { ...sc, tenant_id: opts?.tenantId })
+      if (!data.ok) throw new Error((data.error as string) || 'No Sitoo data to sample yet')
+      return inferSchema(data.data)
+    }
+
+    case 'business_central': {
+      const bc = (consumerConfig.business_central as Record<string, unknown>) || {}
+      if (!bc.client_id || !bc.client_secret) throw new Error('Set the Business Central client ID and secret first')
+      const data = await postJSON('http://localhost:9310/sample-data/', { ...bc, tenant_id: opts?.tenantId })
+      if (!data.ok) throw new Error((data.error as string) || 'No Business Central data to sample yet')
+      return inferSchema(data.data)
+    }
+
+    case 'visma': {
+      const vc = (consumerConfig.visma as Record<string, unknown>) || {}
+      if (!vc.client_id || !vc.base_url || !vc.resource) throw new Error('Set the Visma client ID, base URL and resource first')
+      const data = await postJSON('http://localhost:9320/sample-data/', { ...vc, tenant_id: opts?.tenantId })
+      if (!data.ok) throw new Error((data.error as string) || 'No Visma data to sample yet')
+      return inferSchema(data.data)
+    }
+
+    case 'brightpearl': {
+      const bp = (consumerConfig.brightpearl as Record<string, unknown>) || {}
+      if (!bp.app_ref || !bp.staff_token || !bp.resource) throw new Error('Set the Brightpearl app ref, staff token and resource first')
+      const data = await postJSON('http://localhost:9280/sample-data/', { ...bp, tenant_id: opts?.tenantId })
+      if (!data.ok) throw new Error((data.error as string) || 'No Brightpearl data to sample yet')
+      return inferSchema(data.data)
+    }
+
     default: {
-      // http / webhook (and the retail/ERP connectors without a test endpoint
-      // yet): the only sample is a deployed connection's last payload.
+      // Front Systems (push-only) + http/webhook: the only sample is a deployed
+      // connection's last payload.
       if (!opts?.deployedConnectionId) {
         throw new Error('Deploy the pipeline and send data once, then discover the schema')
       }


### PR DESCRIPTION
Completes the retail-connector follow-up to the SAP/SFTP/cloud pre-deploy live sampling (#174).

## What
Adds `POST /sample-data/` aux endpoints to the four **pollable** retail connectors, so the UI's filter/converter "show data structure" preview fetches a live sample **without deploying**. Each reuses the poller's own auth + fetch path and resolves `<field>_secret_id` via `tenant_id` when present.

| Connector | Port | Auth / fetch |
|---|---|---|
| Business Central | 9310 (new aux server) | OAuth2 client-creds → OData `value` |
| Visma | 9320 (new aux server) | OAuth2 client-creds → REST array/object |
| Sitoo | 9260 (existing webhook server) | Basic auth → `{items}` collection |
| Brightpearl | 9280 (existing webhook server) | staff-app headers → `{"response":…}` (unwrapped) |

UI: `fetchSampleData` (filter) + converter preview + `discoverSchema` branches for all four.

## Not included (by design)
**Front Systems is push-only** — it registers event webhooks and receives data via callback; there's no poll/data-fetch endpoint. Like http/webhook, it can't be sampled pre-deploy, so it stays on the deploy + `last_payload` fallback.

## Validation
- **httptest unit tests** per connector (token acquisition, fetch, parse, `{ok,data}` response).
- **Container smoke test**: rebuilt all four in docker-compose; every `/sample-data` endpoint is live on its port and returns its validation JSON.
- `go build ./...`, `go vet`, the four connector test packages, and UI `tsc -b` all green.

No prod creds or data were needed: the prod `connections` table is empty, so record shapes come from each connector's own parsing code + existing test fixtures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)