### PR TITLE
Harden orchestrator worker lifecycle: always-pull + orphan GC

### DIFF
--- a/src/cmd/management-api/main.go
+++ b/src/cmd/management-api/main.go
@@ -517,21 +517,26 @@ func runOrphanedWorkerGC(ctx context.Context, k8sClient kubernetes.Interface, na
 	const tick = 5 * time.Minute
 	logger.Printf("orphaned-worker GC started (tick=%s namespace=%s)", tick, namespace)
 
-	// exists reports whether a connection is still in the DB. On any non
-	// not-found error it returns true, so a transient DB blip never deletes a
-	// live worker.
-	exists := func(connectionID string) bool {
-		if _, err := repo.GetConnection(ctx, connectionID); err != nil {
-			if _, ok := err.(*managementapi.NotFoundError); ok {
-				return false
+	sweep := func() {
+		// Bound each sweep so a hung DB/K8s call can't stall the loop forever
+		// and starve subsequent ticks.
+		sctx, cancel := context.WithTimeout(ctx, 60*time.Second)
+		defer cancel()
+
+		// exists reports whether a connection is still in the DB. On any non
+		// not-found error it returns true, so a transient DB blip (or the
+		// per-sweep timeout) never deletes a live worker.
+		exists := func(connectionID string) bool {
+			if _, err := repo.GetConnection(sctx, connectionID); err != nil {
+				if _, ok := err.(*managementapi.NotFoundError); ok {
+					return false
+				}
+				return true
 			}
 			return true
 		}
-		return true
-	}
 
-	sweep := func() {
-		n, err := orchestrator.GarbageCollectOrphanedWorkers(ctx, k8sClient, namespace, exists)
+		n, err := orchestrator.GarbageCollectOrphanedWorkers(sctx, k8sClient, namespace, exists)
 		if err != nil {
 			logger.Printf("orphaned-worker GC: %v", err)
 			return

--- a/src/cmd/management-api/main.go
+++ b/src/cmd/management-api/main.go
@@ -334,6 +334,9 @@ func setupServer(config *Config, db *sql.DB, nc *nats.Conn, logger *log.Logger, 
 				k8sClient, orchConfig, validator, orchestrator.WithNATSURLResolver(natsResolver)))
 			logger.Printf("per-connection K8s orchestrator enabled (namespace=%s registry=%s version=%s nats=%s)",
 				orchConfig.Namespace, orchConfig.ImageRegistry, orchConfig.ImageVersion, orchConfig.NATSURLs)
+			// Safety net: periodically delete worker Deployments/HPAs whose
+			// connection no longer exists (teardown failed or predates #176).
+			go runOrphanedWorkerGC(context.Background(), k8sClient, orchConfig.Namespace, repo, logger)
 		}
 	}
 
@@ -505,6 +508,50 @@ func initK8sNATSProvisioner(k8sClient kubernetes.Interface, logger *log.Logger) 
 		return nil
 	}
 	return managementapi.NewK8sNATSProvisioner(k8sClient, logger)
+}
+
+// runOrphanedWorkerGC periodically deletes orchestrator worker Deployments/HPAs
+// whose connection no longer exists in the DB — a safety net for connection
+// deletes whose teardown failed or predates #176. Blocks until ctx is cancelled.
+func runOrphanedWorkerGC(ctx context.Context, k8sClient kubernetes.Interface, namespace string, repo managementapi.Repository, logger *log.Logger) {
+	const tick = 5 * time.Minute
+	logger.Printf("orphaned-worker GC started (tick=%s namespace=%s)", tick, namespace)
+
+	// exists reports whether a connection is still in the DB. On any non
+	// not-found error it returns true, so a transient DB blip never deletes a
+	// live worker.
+	exists := func(connectionID string) bool {
+		if _, err := repo.GetConnection(ctx, connectionID); err != nil {
+			if _, ok := err.(*managementapi.NotFoundError); ok {
+				return false
+			}
+			return true
+		}
+		return true
+	}
+
+	sweep := func() {
+		n, err := orchestrator.GarbageCollectOrphanedWorkers(ctx, k8sClient, namespace, exists)
+		if err != nil {
+			logger.Printf("orphaned-worker GC: %v", err)
+			return
+		}
+		if n > 0 {
+			logger.Printf("orphaned-worker GC: removed resources for %d orphaned connection(s)", n)
+		}
+	}
+
+	sweep() // sweep once at startup
+	t := time.NewTicker(tick)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			sweep()
+		}
+	}
 }
 
 // orchestratorConfigFromEnv builds the per-connection orchestrator config (#157)

--- a/src/pkg/orchestrator/deployment.go
+++ b/src/pkg/orchestrator/deployment.go
@@ -178,11 +178,13 @@ func buildDeployment(node *managementapi.Node, graph *ExecutionGraph, config *Or
 						{
 							Name:  "component",
 							Image: containerImage,
-							// IfNotPresent so pre-pulled / k3d-imported images run
-							// without a registry round-trip (and unreachable
-							// registries don't ErrImagePull). Matches the platform's
-							// other manifests; redeploys use a new image tag/digest.
-							ImagePullPolicy: corev1.PullIfNotPresent,
+							// Always: per-connection workers are pinned to a moving
+							// :latest tag (WORKER_IMAGE_VERSION), so IfNotPresent
+							// would let a worker landing on a node with a stale
+							// cached :latest run old code after a platform redeploy
+							// (#175 follow-up). A worker starts once per connection
+							// start, so the extra registry pull is cheap.
+							ImagePullPolicy: corev1.PullAlways,
 							Ports: []corev1.ContainerPort{
 								{
 									Name:          "http",

--- a/src/pkg/orchestrator/gc.go
+++ b/src/pkg/orchestrator/gc.go
@@ -1,0 +1,63 @@
+package orchestrator
+
+import (
+	"context"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// GarbageCollectOrphanedWorkers deletes orchestrator-spawned worker Deployments
+// (and their HorizontalPodAutoscalers) whose connection no longer exists in the
+// control-plane DB. It is a safety net for connection deletes whose orchestrator
+// teardown failed — or predate the teardown fix (#175/#176): without it, an
+// orphaned worker crash-loops forever (observed in prod: 2 connections leaked 8
+// objects that crash-looped ~3 days).
+//
+// Every orchestrator worker carries app=vrsky + pipeline=<connectionID> labels.
+// `exists` reports whether a connection ID is still present in the DB; on a
+// lookup error it MUST return true, so a transient DB blip never deletes live
+// workers. Returns the number of connections whose resources were removed.
+func GarbageCollectOrphanedWorkers(ctx context.Context, k8s kubernetes.Interface, namespace string, exists func(connectionID string) bool) (int, error) {
+	deployClient := k8s.AppsV1().Deployments(namespace)
+	hpaClient := k8s.AutoscalingV2().HorizontalPodAutoscalers(namespace)
+
+	// All orchestrator-spawned workers carry app=vrsky (LabelAppValue); the
+	// standing services use app=vrsky-<name>, so this selector is exact.
+	sel := BuildLabelSelector(map[string]string{LabelApp: LabelAppValue})
+	deployments, err := deployClient.List(ctx, metav1.ListOptions{LabelSelector: sel})
+	if err != nil {
+		return 0, fmt.Errorf("list worker deployments: %w", err)
+	}
+
+	// Unique connection IDs across the worker deployments (each connection has a
+	// src + dst worker, so dedupe before checking the DB).
+	connIDs := make(map[string]struct{})
+	for i := range deployments.Items {
+		if cid := deployments.Items[i].Labels[LabelPipeline]; cid != "" {
+			connIDs[cid] = struct{}{}
+		}
+	}
+
+	removed := 0
+	for cid := range connIDs {
+		if exists(cid) {
+			continue
+		}
+		// Orphan: delete every Deployment + HPA for this connection.
+		connSel := BuildLabelSelector(GetDeploymentLabelsForConnection(cid))
+		if ds, lerr := deployClient.List(ctx, metav1.ListOptions{LabelSelector: connSel}); lerr == nil {
+			for i := range ds.Items {
+				_ = deployClient.Delete(ctx, ds.Items[i].Name, metav1.DeleteOptions{})
+			}
+		}
+		if hs, lerr := hpaClient.List(ctx, metav1.ListOptions{LabelSelector: connSel}); lerr == nil {
+			for i := range hs.Items {
+				_ = hpaClient.Delete(ctx, hs.Items[i].Name, metav1.DeleteOptions{})
+			}
+		}
+		removed++
+	}
+	return removed, nil
+}

--- a/src/pkg/orchestrator/gc.go
+++ b/src/pkg/orchestrator/gc.go
@@ -26,16 +26,26 @@ func GarbageCollectOrphanedWorkers(ctx context.Context, k8s kubernetes.Interface
 	// All orchestrator-spawned workers carry app=vrsky (LabelAppValue); the
 	// standing services use app=vrsky-<name>, so this selector is exact.
 	sel := BuildLabelSelector(map[string]string{LabelApp: LabelAppValue})
+
+	// Collect candidate connection IDs from BOTH Deployments and HPAs — a
+	// partial teardown can leave an orphaned HPA with its Deployment already
+	// gone, and it must still be discovered + cleaned up.
+	connIDs := make(map[string]struct{})
 	deployments, err := deployClient.List(ctx, metav1.ListOptions{LabelSelector: sel})
 	if err != nil {
 		return 0, fmt.Errorf("list worker deployments: %w", err)
 	}
-
-	// Unique connection IDs across the worker deployments (each connection has a
-	// src + dst worker, so dedupe before checking the DB).
-	connIDs := make(map[string]struct{})
 	for i := range deployments.Items {
 		if cid := deployments.Items[i].Labels[LabelPipeline]; cid != "" {
+			connIDs[cid] = struct{}{}
+		}
+	}
+	hpas, err := hpaClient.List(ctx, metav1.ListOptions{LabelSelector: sel})
+	if err != nil {
+		return 0, fmt.Errorf("list worker HPAs: %w", err)
+	}
+	for i := range hpas.Items {
+		if cid := hpas.Items[i].Labels[LabelPipeline]; cid != "" {
 			connIDs[cid] = struct{}{}
 		}
 	}

--- a/src/pkg/orchestrator/gc_test.go
+++ b/src/pkg/orchestrator/gc_test.go
@@ -73,6 +73,26 @@ func TestGarbageCollectOrphanedWorkers(t *testing.T) {
 	}
 }
 
+// TestGarbageCollectOrphanedWorkers_OrphanHPAOnly: a partial teardown can leave
+// an orphaned HPA with its Deployment already gone. The GC must still discover
+// the connection (from the HPA label) and delete the HPA.
+func TestGarbageCollectOrphanedWorkers_OrphanHPAOnly(t *testing.T) {
+	client := fake.NewSimpleClientset(
+		gcWorkerHPA("vrsky-D-src", "D", "src"), // HPA present, no Deployment
+	)
+	removed, err := GarbageCollectOrphanedWorkers(context.Background(), client, gcNS, func(string) bool { return false })
+	if err != nil {
+		t.Fatalf("GC error: %v", err)
+	}
+	if removed != 1 {
+		t.Fatalf("removed = %d, want 1 (orphan discovered via its HPA)", removed)
+	}
+	hpas, _ := client.AutoscalingV2().HorizontalPodAutoscalers(gcNS).List(context.Background(), metav1.ListOptions{})
+	if len(hpas.Items) != 0 {
+		t.Errorf("orphan HPA not deleted: %d remain", len(hpas.Items))
+	}
+}
+
 // TestGarbageCollectOrphanedWorkers_DBErrorKeepsWorkers: when `exists` can't
 // confirm a connection is gone (returns true on error), workers are kept.
 func TestGarbageCollectOrphanedWorkers_DBErrorKeepsWorkers(t *testing.T) {

--- a/src/pkg/orchestrator/gc_test.go
+++ b/src/pkg/orchestrator/gc_test.go
@@ -1,0 +1,91 @@
+package orchestrator
+
+import (
+	"context"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+const gcNS = "vrsky-platform"
+
+func gcWorkerDeploy(name, connID, nodeID string) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: gcNS, Labels: buildLabels(connID, nodeID, "consumer", "tenant-1")},
+	}
+}
+
+func gcWorkerHPA(name, connID, nodeID string) *autoscalingv2.HorizontalPodAutoscaler {
+	return &autoscalingv2.HorizontalPodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: gcNS, Labels: buildLabels(connID, nodeID, "consumer", "tenant-1")},
+	}
+}
+
+// TestGarbageCollectOrphanedWorkers: a connection still in the DB keeps its
+// workers; an orphaned connection (gone from the DB) has its Deployments + HPAs
+// deleted; a standing service (app=vrsky-<name>) is never touched.
+func TestGarbageCollectOrphanedWorkers(t *testing.T) {
+	objs := []runtime.Object{
+		// Live connection A — kept.
+		gcWorkerDeploy("vrsky-A-src", "A", "src"),
+		gcWorkerDeploy("vrsky-A-dst", "A", "dst"),
+		gcWorkerHPA("vrsky-A-src", "A", "src"),
+		// Orphan connection B — removed.
+		gcWorkerDeploy("vrsky-B-src", "B", "src"),
+		gcWorkerHPA("vrsky-B-src", "B", "src"),
+		// A standing service (app=vrsky-management-api) — must be untouched.
+		&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "vrsky-management-api", Namespace: gcNS, Labels: map[string]string{LabelApp: "vrsky-management-api"}}},
+	}
+	client := fake.NewSimpleClientset(objs...)
+	exists := func(connID string) bool { return connID == "A" } // B is the orphan
+
+	removed, err := GarbageCollectOrphanedWorkers(context.Background(), client, gcNS, exists)
+	if err != nil {
+		t.Fatalf("GC error: %v", err)
+	}
+	if removed != 1 {
+		t.Fatalf("removed = %d, want 1 (connection B only)", removed)
+	}
+
+	deps, _ := client.AppsV1().Deployments(gcNS).List(context.Background(), metav1.ListOptions{})
+	got := map[string]bool{}
+	for i := range deps.Items {
+		got[deps.Items[i].Name] = true
+	}
+	for _, keep := range []string{"vrsky-A-src", "vrsky-A-dst", "vrsky-management-api"} {
+		if !got[keep] {
+			t.Errorf("expected %q to survive GC, but it was deleted", keep)
+		}
+	}
+	if got["vrsky-B-src"] {
+		t.Error("orphan B deployment was not deleted")
+	}
+
+	hpas, _ := client.AutoscalingV2().HorizontalPodAutoscalers(gcNS).List(context.Background(), metav1.ListOptions{})
+	for i := range hpas.Items {
+		if hpas.Items[i].Name == "vrsky-B-src" {
+			t.Error("orphan B HPA was not deleted")
+		}
+	}
+}
+
+// TestGarbageCollectOrphanedWorkers_DBErrorKeepsWorkers: when `exists` can't
+// confirm a connection is gone (returns true on error), workers are kept.
+func TestGarbageCollectOrphanedWorkers_DBErrorKeepsWorkers(t *testing.T) {
+	client := fake.NewSimpleClientset(
+		gcWorkerDeploy("vrsky-C-src", "C", "src"),
+		gcWorkerHPA("vrsky-C-src", "C", "src"),
+	)
+	// Simulate a DB blip: exists conservatively returns true for everything.
+	removed, err := GarbageCollectOrphanedWorkers(context.Background(), client, gcNS, func(string) bool { return true })
+	if err != nil {
+		t.Fatalf("GC error: %v", err)
+	}
+	if removed != 0 {
+		t.Fatalf("removed = %d, want 0 (nothing deleted when existence is uncertain)", removed)
+	}
+}


### PR DESCRIPTION
Follow-up hardening to the orchestrator-teardown fix (#175 / #176). Two reliability fixes for orchestrator-spawned per-connection workers.

## 1. Worker image-pull staleness
`imagePullPolicy: IfNotPresent` → **`Always`**. Per-connection workers are pinned to a moving `:latest` tag (`WORKER_IMAGE_VERSION=latest`), so `IfNotPresent` let a worker landing on a node with a stale cached `:latest` run **old code** after a platform redeploy. A worker starts once per connection start, so the extra registry pull is negligible.

## 2. Orphaned-worker garbage collection
A periodic sweep (every 5 min, in management-api when `ORCHESTRATOR_MODE=k8s`) deletes worker Deployments/HPAs whose connection no longer exists in the DB. Safety net for a connection delete whose teardown failed or predates #176.

**Why:** in prod we found 2 deleted connections that had leaked 8 objects (Deployments + HPAs) crash-looping for ~3 days. #176 fixes the *delete path*; this GC self-heals anything that still slips through.

- Identifies workers by their `app=vrsky` + `pipeline=<connectionID>` labels (standing services use `app=vrsky-<name>`, so they're never matched).
- **Conservative:** a DB lookup error makes `exists` return true, so a transient DB blip never deletes a live worker.

## Tests
`gc_test.go` (fake clientset): keeps a live connection's workers, deletes an orphan's Deployment + HPA, never touches a standing service, and keeps workers when connection existence is uncertain. `go build ./...`, `go vet`, orchestrator + managementapi suites all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)