### PR TITLE
a11y: keyboard-operable edge context menu + panel resizer

### DIFF
--- a/ui/src/pages/PipelineBuilder.tsx
+++ b/ui/src/pages/PipelineBuilder.tsx
@@ -63,6 +63,13 @@ export default function PipelineBuilder() {
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null)
   const [selectedEdgeId, setSelectedEdgeId] = useState<string | null>(null)
   const [edgeContextMenu, setEdgeContextMenu] = useState<{ edgeId: string; x: number; y: number } | null>(null)
+  // Keyboard: Escape closes the edge context menu (works regardless of focus).
+  useEffect(() => {
+    if (!edgeContextMenu) return
+    const onEsc = (e: KeyboardEvent) => { if (e.key === 'Escape') setEdgeContextMenu(null) }
+    document.addEventListener('keydown', onEsc)
+    return () => document.removeEventListener('keydown', onEsc)
+  }, [edgeContextMenu])
   const [isLoading, setIsLoading] = useState(false)
   const [paletteOpen, setPaletteOpen] = useState(true)
   const [sidebarWidth, setSidebarWidth] = useState(320)
@@ -1200,9 +1207,14 @@ export default function PipelineBuilder() {
               minWidth: '140px',
               overflow: 'hidden',
             }}
+            role="menu"
+            aria-label="Edge actions"
+            tabIndex={-1}
             onClick={(e) => e.stopPropagation()}
+            onKeyDown={(e) => e.stopPropagation()}
           >
             <button
+              role="menuitem"
               onClick={() => handleEdgeDelete(edgeContextMenu.edgeId)}
               style={{
                 width: '100%',
@@ -1228,7 +1240,11 @@ export default function PipelineBuilder() {
 
         {/* Click overlay to close context menu */}
         {edgeContextMenu && (
+          // Full-canvas click-catcher that dismisses the menu on an outside click;
+          // keyboard users dismiss via Escape (listener above). aria-hidden since
+          // it's decorative and intentionally not keyboard-focusable.
           <div
+            aria-hidden="true"
             style={{
               position: 'absolute',
               top: 0,
@@ -1604,9 +1620,25 @@ export default function PipelineBuilder() {
           overflowY: 'auto',
           zIndex: 40
         }}>
-          {/* Resize handle */}
+          {/* Resize handle — ARIA APG window-splitter: a focusable separator with
+              aria-valuenow + arrow-key resize. jsx-a11y treats role=separator as
+              noninteractive and doesn't model the splitter pattern, so its two
+              noninteractive rules are disabled for this element only. */}
+          {/* eslint-disable jsx-a11y/no-noninteractive-element-interactions, jsx-a11y/no-noninteractive-tabindex */}
           <div
             onMouseDown={handleResizeStart}
+            role="separator"
+            aria-orientation="vertical"
+            aria-label="Resize property panel"
+            aria-valuenow={sidebarWidth}
+            aria-valuemin={280}
+            aria-valuemax={800}
+            tabIndex={0}
+            onKeyDown={(e) => {
+              // Match the drag: dragging the handle left widens the panel.
+              if (e.key === 'ArrowLeft') { e.preventDefault(); setSidebarWidth((w) => Math.min(800, w + 16)) }
+              else if (e.key === 'ArrowRight') { e.preventDefault(); setSidebarWidth((w) => Math.max(280, w - 16)) }
+            }}
             style={{
               position: 'absolute',
               left: 0,
@@ -1619,6 +1651,7 @@ export default function PipelineBuilder() {
             onMouseEnter={(e) => { (e.target as HTMLElement).style.backgroundColor = '#3b82f6' }}
             onMouseLeave={(e) => { if (!isResizing.current) (e.target as HTMLElement).style.backgroundColor = 'transparent' }}
           />
+          {/* eslint-enable jsx-a11y/no-noninteractive-element-interactions, jsx-a11y/no-noninteractive-tabindex */}
           <PropertyEditor
             node={selectedNode}
             onUpdate={updateNodeConfig}


### PR DESCRIPTION
Features 2 & 3 of the pipeline-canvas keyboard-nav work (after the treeview, #184). Clears the last of the clickable-`<div>` a11y findings.

## Edge context menu
- `role="menu"` (focusable, `tabIndex=-1`) + `role="menuitem"` on the action.
- **Escape closes it** via a document `keydown` listener (works regardless of where focus is — the menu is right-click/mouse-triggered).
- The click-outside backdrop is `aria-hidden` + decorative — keyboard dismissal is Escape, not a focusable full-canvas overlay.

## Property-panel resizer
- Implemented as the **ARIA APG window-splitter**: `role="separator"` + `aria-orientation`/`aria-valuenow`/`min`/`max` + `tabIndex`, with **Left/Right arrow keys** resizing the panel (matching the drag direction, clamped 280–800px).
- jsx-a11y doesn't model *focusable* separators, so its two `no-noninteractive-*` rules are disabled **for that one element**, with a rationale comment.

`tsc -b` clean; PipelineBuilder has zero remaining `jsx-a11y` findings (only the 2 intentional `no-autofocus` warnings remain repo-wide).

## Independent of #184
This touches only `PipelineBuilder.tsx`; the treeview PR (#184) touches `PropertyEditor.tsx` + `a11y.ts` — they merge in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)