### PR TITLE
perf(db): right-size worker connection pools for pod-per-connection fan-out

### DIFF
--- a/docs/scalability.md
+++ b/docs/scalability.md
@@ -1,0 +1,85 @@
+# VRSky Scalability — Assessment & Roadmap
+
+> Grounded in the current architecture. **Caveat:** prod has 0 real connections and
+> the cluster is cost-parked, so this is an *architectural* assessment, not an
+> empirical benchmark. A k6 load-smoke harness exists (`.github/workflows/
+> load-smoke.yml`, p99 + error-rate regression guards) but hasn't been run at
+> target scale — doing so is how we'd find the real ceiling.
+
+## Verdict
+
+The building blocks are the right ones for horizontal scale, and multi-tenancy is
+genuinely built in — not bolted on. The limits are **(1) a single PostgreSQL** and
+**(2) the pod-per-connection worker model**; neither is a rewrite.
+
+## What scales well (by design)
+
+- **Per-connection worker autoscaling** — the orchestrator gives each connection a
+  Deployment + **HPA** (`MinReplicas`/`MaxReplicas`/`TargetCPUPercent`), and NATS
+  **JetStream durable consumers load-balance across replicas**, so a connection's
+  throughput scales out.
+- **Multi-tenancy** — **per-tenant NATS instances** (`nats_instances`, migration
+  000018), tenant-scoped queries throughout (`lint:tenant-ok`), enforced **quotas**
+  (default 50 msg/s, 10 integrations, 1 GiB/tenant) + daily usage metering.
+- **Stateless control plane** — UI / filter / management-api at 2 replicas + PDB;
+  horizontally scalable, HA today.
+- **Independent connectors** — adding an integration type scales linearly.
+
+## Ceilings (priority order)
+
+### 1. Single in-cluster PostgreSQL  ← highest priority
+The management DB is one StatefulSet instance that every connection, tenant, and
+usage-metering write hits. With pod-per-connection fan-out, each worker holds a DB
+pool — connection count multiplies fast and can exhaust `max_connections`.
+
+**Fix (staged):**
+- **(a) Bound every worker's connection pool** in code — **✅ done.** Pools already
+  existed but were monolith-sized (25 open / 5 idle per worker, no idle reaping),
+  which is exactly what multiplies across pod-per-connection fan-out. Now each
+  worker defaults to a lean **6 open / 2 idle** with a **90 s `ConnMaxIdleTime`**
+  so idle pollers stop pinning connections; the control plane keeps 25/5. All
+  values are env-tunable (`DB_MAX_OPEN_CONNS`, `DB_MAX_IDLE_CONNS`,
+  `DB_CONN_MAX_LIFETIME_SECONDS`, `DB_CONN_MAX_IDLE_SECONDS`) for per-deployment
+  sizing. Caps the connection explosion; PgBouncer (b) is the next multiplier.
+- **(b) PgBouncer** (transaction pooling) in front of Postgres — one more multiplier
+  of headroom.
+- **(c) Managed Postgres** (Azure DB for PostgreSQL Flexible Server) + read replicas
+  for the read-heavy paths (usage/metrics, connection listing).
+
+### 2. Pod-per-connection orchestration
+Each connection = 1–2 pods (src/dst) + an HPA. Elegant isolation, but a practical
+ceiling around a few thousand connections/cluster (etcd/scheduler/object pressure,
+cost), and wasteful for many small or idle connections.
+
+**Fix:** a **shared multi-tenant worker-pool mode** for light connections (one
+worker process multiplexing many connections off the shared NATS subjects), keeping
+dedicated pods only for heavy/isolated ones. The connector SDK already loads
+per-connection config by ID, so a pool worker is a routing layer on top — not a
+connector rewrite. This is the biggest *architectural* lever for density + cost.
+
+### 3. In-cluster stateful services
+Postgres, MinIO, NATS all run in-cluster. For scale:
+- Storage → **Azure Blob** (the cloud-storage connector already speaks S3/Azure/GCS).
+- Postgres → managed (see #1c).
+- NATS is 3-pod HA, but per-tenant instances add pod count — consider **shared NATS
+  instances for small tenants**, dedicated for large (density vs isolation).
+
+### 4. Node capacity + Azure quota
+Currently 2× E4bds_v5 (~8% used), previously EBDSv5-quota-constrained. Real scale
+needs the **cluster autoscaler** + quota headroom.
+
+## Immediate roadmap
+
+| Step | Ceiling | Effort | Needs cluster? |
+|---|---|---|---|
+| ~~Bound worker DB pools~~ ✅ | 1a | small (code) | no — **done** |
+| PgBouncer | 1b | small (infra) | yes ← **next** |
+| Shared worker-pool mode | 2 | large (code) | for load test |
+| Managed Postgres / Blob | 1c / 3 | medium (infra + migration) | yes |
+| Run k6 at target scale | all | small | yes |
+
+## Empirical next step
+
+Run the k6 load-smoke at realistic rates + connection counts to turn this
+architectural read into measured limits — that's the only way to know the real
+ceiling and validate each fix.

--- a/src/cmd/management-api/main.go
+++ b/src/cmd/management-api/main.go
@@ -166,10 +166,15 @@ func initDatabase(dbURL string, logger *log.Logger) (*sql.DB, error) {
 		return nil, fmt.Errorf("failed to ping database: %w", err)
 	}
 
-	// Configure connection pool
-	db.SetMaxOpenConns(25)
-	db.SetMaxIdleConns(5)
-	db.SetConnMaxLifetime(5 * time.Minute)
+	// Configure connection pool. The control plane (2 replicas) serves UI/API
+	// and orchestration, so it keeps a higher ceiling than the lean per-connection
+	// workers — but all values are env-tunable so the total footprint against the
+	// single shared Postgres can be sized per deployment. ConnMaxIdleTime reaps
+	// idle connections that would otherwise be pinned until ConnMaxLifetime.
+	db.SetMaxOpenConns(envIntDefault("DB_MAX_OPEN_CONNS", 25))
+	db.SetMaxIdleConns(envIntDefault("DB_MAX_IDLE_CONNS", 5))
+	db.SetConnMaxLifetime(time.Duration(envIntDefault("DB_CONN_MAX_LIFETIME_SECONDS", 300)) * time.Second)
+	db.SetConnMaxIdleTime(time.Duration(envIntDefault("DB_CONN_MAX_IDLE_SECONDS", 90)) * time.Second)
 
 	logger.Printf("Database connected successfully")
 	return db, nil
@@ -598,4 +603,14 @@ func shutdownDrainSeconds() time.Duration {
 		}
 	}
 	return 5 * time.Second
+}
+
+// envIntDefault reads an integer env var, falling back to def when unset or unparseable.
+func envIntDefault(key string, def int) int {
+	if v := os.Getenv(key); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			return n
+		}
+	}
+	return def
 }

--- a/src/pkg/sdk/lifecycle.go
+++ b/src/pkg/sdk/lifecycle.go
@@ -477,9 +477,18 @@ func openDB(dsn string) (*sql.DB, error) {
 	if err != nil {
 		return nil, err
 	}
-	db.SetMaxOpenConns(25)
-	db.SetMaxIdleConns(5)
-	db.SetConnMaxLifetime(5 * time.Minute)
+	// Pool sizing is lean by DEFAULT because of the pod-per-connection model:
+	// each connection runs its own worker pod, and every worker holds its own
+	// pool against the single shared Postgres. A worker's DB work is light and
+	// sequential (load config on start, throttled last_payload writes), so a
+	// small ceiling is plenty — and 6 open × N workers is what keeps the total
+	// under Postgres `max_connections` as connection count grows. ConnMaxIdleTime
+	// reaps connections that idle pollers would otherwise pin indefinitely.
+	// All tunable via env for per-deployment sizing (e.g. heavier control-plane).
+	db.SetMaxOpenConns(envInt("DB_MAX_OPEN_CONNS", 6))
+	db.SetMaxIdleConns(envInt("DB_MAX_IDLE_CONNS", 2))
+	db.SetConnMaxLifetime(time.Duration(envInt("DB_CONN_MAX_LIFETIME_SECONDS", 300)) * time.Second)
+	db.SetConnMaxIdleTime(time.Duration(envInt("DB_CONN_MAX_IDLE_SECONDS", 90)) * time.Second)
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	if err := db.PingContext(ctx); err != nil {


### PR DESCRIPTION
## What

Right-sizes the database connection pools for the pod-per-connection worker model. Addresses **scalability ceiling #1a** (`docs/scalability.md`).

## Why

Pools already existed but were monolith-sized — **25 open / 5 idle per worker, with no idle reaping**. Under pod-per-connection fan-out (each connection = its own worker pod, each holding its own pool against the single shared Postgres), that's exactly what multiplies out and exhausts `max_connections`. Idle pollers also pinned up to 5 connections until the 5-minute lifetime cap.

## Changes

- **Worker SDK** (`pkg/sdk/lifecycle.go`) — lean defaults of **6 open / 2 idle**. A worker's DB work is light and sequential (config load on start + throttled `last_payload` writes), so a small ceiling is plenty, and `6 × N workers` is what keeps the total under Postgres limits as connection count grows.
- **Idle reaping** — added `SetConnMaxIdleTime` (default **90s**) in both the SDK and management-api; neither had it before.
- **Control plane** (`cmd/management-api`) — keeps **25 / 5** (2 replicas serving UI/API + orchestration) but gains idle reaping.
- **Env-tunable** — `DB_MAX_OPEN_CONNS`, `DB_MAX_IDLE_CONNS`, `DB_CONN_MAX_LIFETIME_SECONDS`, `DB_CONN_MAX_IDLE_SECONDS` for per-deployment sizing.
- **Doc** — `docs/scalability.md` marks 1a done; PgBouncer (1b) flagged next.

## Caveat

This **caps** the explosion but doesn't eliminate it — `6 × hundreds of workers` still climbs. It buys headroom and makes density tunable. **PgBouncer (1b)** is the real multiplier and is the next step.

## Verification

`go build`, `go vet`, and `go test ./pkg/sdk/...` all pass. No behavior change beyond pool sizing; defaults differ per component and only take effect where each `openDB`/`initDatabase` runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)