### PR TITLE
fix(objectstore): stream Azure Copy to avoid OOM on large blobs (#187)

### DIFF
--- a/src/pkg/objectstore/azure.go
+++ b/src/pkg/objectstore/azure.go
@@ -156,16 +156,22 @@ func (a *azureStore) Delete(ctx context.Context, key string) error {
 	return nil
 }
 
-// Copy implements after_action=move via download+upload. Azure's server-side
-// copy (StartCopyFromURL) needs a SAS-signed source URL; for pipeline-sized
-// objects a read+write round-trip is simpler and the only caller is the move
-// after-action.
+// Copy implements after_action=move via a streamed download+upload. Azure's
+// server-side copy (StartCopyFromURL) needs a SAS-signed source URL and, for
+// large blobs, an async poll-until-complete loop, so a client-side round-trip is
+// simpler and the only caller is the move after-action. Unlike the previous
+// buffered Get+Put, this streams source→dest so a multi-GB blob is bounded to a
+// small buffer instead of being held whole in memory (which would OOM the worker).
 func (a *azureStore) Copy(ctx context.Context, srcKey, dstKey string) error {
-	body, ct, err := a.Get(ctx, srcKey)
+	rc, ct, err := a.GetStream(ctx, srcKey)
 	if err != nil {
 		return err
 	}
-	return a.Put(ctx, dstKey, body, ct)
+	defer rc.Close()
+	if err := a.PutStream(ctx, dstKey, rc, ct); err != nil {
+		return fmt.Errorf("azure copy %q->%q: %w", srcKey, dstKey, err)
+	}
+	return nil
 }
 
 // Close is a no-op: the azblob client holds no resources requiring release.


### PR DESCRIPTION
## What

The Azure backend's `Copy` (used by `after_action=move`) did a **buffered `Get`+`Put`** — the whole blob loaded into memory. For a multi-GB `move` that OOMs the worker.

## Fix

Stream `source→dest` via `GetStream`→`PutStream` (Azure `DownloadStream` → `UploadStream`), so the copy is bounded to a small buffer regardless of blob size. S3 and GCS already do native server-side copy; this brings Azure to memory-safe parity **without** the SAS-signed-URL + async poll-until-complete complexity that Azure's server-side `StartCopyFromURL` requires for large blobs.

## Notes

- Behavior is unchanged: dest = copy of src, content type preserved.
- The live-backend integration round-trip (`-tags=integration`, Azurite) already exercises `Copy`.
- Builds on the streaming `ObjectStore` methods added in #189.

Part of #187 (large-payload handling). Remaining follow-ups: presigned URLs and the streaming connector contract for true unbounded multi-GB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)