### PR TITLE
ADR 0001 + phase 1a: bound payload rehydration, verify offloaded payloads

### DIFF
--- a/docs/adr/0001-streaming-payload-contract.md
+++ b/docs/adr/0001-streaming-payload-contract.md
@@ -1,6 +1,6 @@
 # ADR 0001 — Streaming payload contract for unbounded (multi-GB) transfers
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-08-24
 - **Relates to:** #187 (large-payload handling), PR #189 (claim-check + streaming
   object I/O), PR #190 (Azure Copy streaming)
@@ -111,16 +111,29 @@ In `subscribeDispatch`: if `env.PayloadRef != ""` and the node implements
 `StreamingProducer` → `GetStream` and hand over the reader (checksum-verifying
 wrapper); no rehydrate. Otherwise rehydrate as today.
 
-**Rehydrate guard (independent hardening, do first):** cap `rehydrate` at
-`PAYLOAD_REHYDRATE_MAX_BYTES` (default 128 MiB — comfortable inside the 512 MiB
-limit). Beyond the cap, return a *permanent* error ("payload too large for
-non-streaming connector X") → DLQ with a clear message, replacing today's
-OOM-kill loop. This alone converts the failure mode from opaque to explicit and
-is worth shipping even before any connector opts in.
+**Rehydrate guard (independent hardening, do first — shipped):** cap `rehydrate`
+at `PAYLOAD_REHYDRATE_MAX_BYTES` (default 128 MiB — comfortable inside the
+512 MiB limit). The check runs on `PayloadSize` *before* any download, with an
+`io.LimitReader` bound on the read itself in case the declared size understates
+the object. This replaces today's OOM-kill loop with an explicit error, and is
+worth shipping before any connector opts in.
 
-**Integrity:** add `Checksum string` (`sha256:<hex>`) to the envelope, computed
-during offload, verified on rehydrate and on `DeliverStream` (via a verifying
-reader that errors on Close if the digest mismatches).
+*Error classification:* the over-cap error is returned bare, so it rides the
+SDK's **default Retriable** classification, and the envelope reaches the **DLQ**
+after the retry budget. This is deliberate and contradicts an earlier draft of
+this ADR that said "permanent": `sdk.Permanent` **acks and drops** the message
+(see `pkg/sdk/errors.go`), and silently discarding a customer payload is
+unacceptable for an integration platform. Retries are cheap here because the
+rejection happens without downloading, and a DLQ'd envelope keeps its
+`PayloadRef` so an operator can inspect it and replay once a streaming-capable
+connector is in place (within the spill object's 1-day TTL).
+
+**Integrity (shipped with the guard):** `Checksum string` (`sha256:<hex>`) on the
+envelope, computed during offload and verified on rehydrate. Empty checksums are
+skipped so envelopes in flight across a rollout still deliver. When streaming
+lands, `DeliverStream` verifies via a wrapping reader that errors on Close if the
+digest mismatches, and offload computes the digest with a `TeeReader` rather than
+over a buffer.
 
 **First adopters** (they already hold an `io.Reader` from disk or network, so
 this is deleting buffering, not adding machinery): cloud-storage consumer +

--- a/docs/adr/0001-streaming-payload-contract.md
+++ b/docs/adr/0001-streaming-payload-contract.md
@@ -1,0 +1,184 @@
+# ADR 0001 — Streaming payload contract for unbounded (multi-GB) transfers
+
+- **Status:** Proposed
+- **Date:** 2026-08-24
+- **Relates to:** #187 (large-payload handling), PR #189 (claim-check + streaming
+  object I/O), PR #190 (Azure Copy streaming)
+
+## Context
+
+PR #189 lifted the *message-bus* ceiling: payloads over 256 KiB are offloaded to
+object storage (claim-check) and only a `PayloadRef` rides NATS, so message size
+no longer bounds payload size. But the connector contract is still `[]byte`:
+
+```go
+type Consumer interface  { Run(ctx, publish PublishFunc) error }            // publishes *envelope.Envelope
+type Producer interface  { Deliver(ctx, env *envelope.Envelope) error }     // env.Payload []byte
+type Filter interface    { Evaluate(ctx, env) (keep bool, out *Envelope, error) }
+type Converter interface { Convert(ctx, env) (*Envelope, error) }
+```
+
+The SDK `rehydrate` does `io.ReadAll` before every deliver, and consumers build
+`env.Payload` in memory before every publish. So the whole payload is
+materialized **twice per hop** (connector buffer + envelope), plus parsing
+overhead. Per-connection workers run with a **512 MiB memory limit**
+(`orchestrator.MemoryLimit`), which puts the practical payload ceiling around
+100–200 MB — far short of the multi-GB requirement, and a payload past that
+doesn't fail cleanly: the worker OOM-kills mid-message and the message retries
+into the same wall.
+
+The principle from #187 stands: **pass by reference, move by streaming, never
+hold the whole payload in bus or memory** — and never build our own
+chunk/split-and-reassemble protocol (provider-native multipart inside
+`PutStream` is fine; it's the storage layer's implementation detail).
+
+## Decision drivers
+
+1. Multi-GB files must flow source → destination with bounded worker memory.
+2. ~20 existing connectors must keep working unchanged — most (retail/ERP APIs:
+   Sitoo, Brightpearl, Business Central, Visma, SAP, Salesforce) deal in
+   paginated JSON that is *correctly* small; forcing streams on them is pure
+   churn.
+3. Filters/converters are in-memory JSON transforms and **cannot** hold
+   multi-GB payloads; whatever we do must give them a *predictable* behavior,
+   not a silent OOM.
+4. Today an oversized payload fails by OOM-kill; any outcome must be an
+   explicit, observable error instead.
+
+## Options considered
+
+### A. Big-bang: change all four interfaces to `io.Reader`
+
+Every connector rewritten; transforms gain a streaming signature they mostly
+can't honor (a JSON-tree converter fundamentally needs the document). Massive
+churn for a capability only edge connectors (file, SFTP, cloud-storage, HTTP)
+can use. **Rejected.**
+
+### B. Opt-in streaming capability, detected by type assertion  ← chosen
+
+Keep the existing interfaces untouched. Add *optional* companion interfaces; the
+SDK type-asserts at the chokepoints it already owns (the publish closure and
+`subscribeDispatch`) and switches to the streaming path only when both the
+connector opts in **and** a payload store is configured. Everything else runs
+the existing inline/rehydrate path.
+
+### C. No rehydrate: hand connectors the `PayloadRef` and let them fetch
+
+Every connector grows objectstore plumbing, credentials leak into connector
+code, and the SDK loses the single place where offload policy (thresholds,
+checksums, cleanup) lives. **Rejected.**
+
+## Decision
+
+Option B, in three phases. Phase 1 is the substance; 2 and 3 are follow-ups
+that become mechanical once 1 exists.
+
+### Phase 1 — streaming edges (consumer + producer)
+
+**Consumer side** — a streaming-capable consumer implements:
+
+```go
+// PublishStreamFunc streams a large payload into the pipeline. The SDK uploads
+// body to the spill store (provider-native multipart; TeeReader-sha256 for the
+// checksum), stamps PayloadRef/PayloadSize/Checksum, and publishes the small
+// envelope. The payload never exists in worker memory beyond the copy buffer.
+type PublishStreamFunc func(ctx context.Context, env *envelope.Envelope, body io.Reader) error
+
+type StreamingConsumer interface {
+    Consumer
+    RunStream(ctx context.Context, publish PublishFunc, publishStream PublishStreamFunc) error
+}
+```
+
+`RunConsumer` type-asserts: a `StreamingConsumer` gets `RunStream` (with the
+plain `publish` still available for its small payloads); everyone else gets
+`Run` exactly as today. `publishStream` on a worker with no payload store
+configured returns a permanent error at first use — streaming is meaningless
+inline, and this surfaces the misconfiguration instead of buffering.
+
+**Producer side:**
+
+```go
+type StreamingProducer interface {
+    Producer
+    // DeliverStream is called instead of Deliver when the payload is offloaded.
+    // body streams from the spill store; env.Payload is nil.
+    DeliverStream(ctx context.Context, env *envelope.Envelope, body io.Reader) error
+}
+```
+
+In `subscribeDispatch`: if `env.PayloadRef != ""` and the node implements
+`StreamingProducer` → `GetStream` and hand over the reader (checksum-verifying
+wrapper); no rehydrate. Otherwise rehydrate as today.
+
+**Rehydrate guard (independent hardening, do first):** cap `rehydrate` at
+`PAYLOAD_REHYDRATE_MAX_BYTES` (default 128 MiB — comfortable inside the 512 MiB
+limit). Beyond the cap, return a *permanent* error ("payload too large for
+non-streaming connector X") → DLQ with a clear message, replacing today's
+OOM-kill loop. This alone converts the failure mode from opaque to explicit and
+is worth shipping even before any connector opts in.
+
+**Integrity:** add `Checksum string` (`sha256:<hex>`) to the envelope, computed
+during offload, verified on rehydrate and on `DeliverStream` (via a verifying
+reader that errors on Close if the digest mismatches).
+
+**First adopters** (they already hold an `io.Reader` from disk or network, so
+this is deleting buffering, not adding machinery): cloud-storage consumer +
+producer, file consumer + producer, SFTP consumer, http-producer. Retail/ERP
+API connectors don't change.
+
+### Phase 2 — record-streaming transforms
+
+Filters/converters get a predictable policy for offloaded payloads **now**, and
+a streaming capability **later**:
+
+- **Default (phase 1):** a `PayloadRef` envelope reaching a plain
+  filter/converter is rehydrated under the same 128 MiB cap → beyond it,
+  permanent error → DLQ ("transform does not support payloads this large").
+  Predictable, observable, no silent skip.
+- **Explicit bypass:** per-node config `"large_payloads": "passthrough"`
+  forwards over-cap envelopes untouched (ref and all) for pipelines where the
+  transform is only meant for the small records. Opt-in only — silently
+  skipping a transform is a correctness decision the user must make.
+- **Phase 2 proper:** `StreamingTransformer` for *record-oriented* formats
+  (NDJSON, CSV): SDK streams spill-object → record iterator → per-record
+  Evaluate/Convert → streamed new spill object, memory bounded by record size.
+  Only per-record transforms qualify; anything cross-record (sort, aggregate,
+  whole-document JSONPath) stays small-payload-only by nature — that's a
+  documented product boundary, not a TODO.
+
+### Phase 3 — presigned URLs (zero-copy edges)
+
+`PresignGet`/`PresignPut` on `ObjectStore` (S3 presign / Azure SAS / GCS signed
+URLs), so an external system uploads or downloads **directly** against the
+store and even the edge worker never carries the bytes. Valuable but orthogonal
+— it changes who moves the bytes, not the contract — hence last.
+
+## Consequences
+
+**Positive**
+- Multi-GB transfers with worker memory bounded by the multipart buffer
+  (~5–16 MiB), on 512 MiB pods, no interface breakage, no connector churn
+  outside the edge connectors that benefit.
+- Oversized payloads become explicit DLQ errors instead of OOM-kill loops —
+  strictly better operability even for pipelines that never opt in.
+- Checksums close the integrity gap flagged in #187.
+
+**Negative / accepted**
+- Two delivery paths (inline vs streaming) live in the SDK forever; the
+  chokepoints are already centralized, which contains the cost.
+- Transforms on huge payloads are constrained by design (per-record streaming
+  or explicit passthrough). This is honest: no architecture makes a
+  whole-document JSON transform of a 5 GB payload cheap.
+- The 1-day `spill/` TTL bounds end-to-end pipeline latency for offloaded
+  payloads; fine against the 15-minute envelope TTL, but a future "park large
+  files for a day" feature would need its own prefix and rule.
+
+## Test plan
+
+- Unit: type-assertion routing (streaming vs plain, both sides), rehydrate cap
+  → permanent error, checksum mismatch → error, passthrough config.
+- Integration (`-tags=integration`, MinIO): consumer→spill→producer round-trip
+  of a synthetic ~100 MB payload asserting the envelope on the bus stays under
+  1 KB; multi-GB verified manually against the TEST env (per the standing rule:
+  validate in TEST before prod).

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,4 +34,6 @@ JetStream; large payloads spill to object storage.
 Architecture and internals — [NATS architecture](NATS_ARCHITECTURE.md),
 [observability](OBSERVABILITY.md), [tracing](TRACING.md),
 [load benchmarks](LOAD.md), [OAuth framework](oauth-framework.md),
-[connector SDK](sdk/README.md).
+[connector SDK](sdk/README.md), [scalability](scalability.md).
+
+Design decisions — [ADR 0001: streaming payload contract](adr/0001-streaming-payload-contract.md).

--- a/src/pkg/envelope/envelope.go
+++ b/src/pkg/envelope/envelope.go
@@ -18,6 +18,11 @@ type Envelope struct {
 	PayloadRef  string `json:"payload_ref,omitempty"` // MinIO reference for large payloads
 	PayloadSize int64  `json:"payload_size"`
 	ContentType string `json:"content_type"`
+	// Checksum is "sha256:<hex>" of the payload, set when the payload is
+	// offloaded (PayloadRef) and verified when it is read back, so corruption or
+	// a mismatched object is caught rather than delivered. Empty for inline
+	// payloads and for envelopes written before checksums existed.
+	Checksum string `json:"checksum,omitempty"`
 
 	// Pipeline tracking
 	Source      string   `json:"source"`       // Component that created this envelope

--- a/src/pkg/sdk/base.go
+++ b/src/pkg/sdk/base.go
@@ -36,8 +36,9 @@ type Resources struct {
 	// payloadStore + inlineMaxBytes drive the large-payload claim-check (see
 	// payloadstore.go). Unexported so connectors don't couple to them — only the
 	// SDK publish/consume path uses them. payloadStore is nil when unconfigured.
-	payloadStore   objectstore.ObjectStore
-	inlineMaxBytes int
+	payloadStore      objectstore.ObjectStore
+	inlineMaxBytes    int
+	rehydrateMaxBytes int64
 }
 
 // healthToggle is the narrow slice of the health server connectors may touch.

--- a/src/pkg/sdk/lifecycle.go
+++ b/src/pkg/sdk/lifecycle.go
@@ -299,12 +299,13 @@ func run(ctx context.Context, name string, c interface{}, configure func(context
 	}
 
 	res := &Resources{
-		Logger:         logger,
-		DB:             db,
-		NATS:           nc,
-		Health:         &healthToggle{setReady: setReady, addCheck: addCheck},
-		payloadStore:   payloadStore,
-		inlineMaxBytes: inlineMaxFromEnv(),
+		Logger:            logger,
+		DB:                db,
+		NATS:              nc,
+		Health:            &healthToggle{setReady: setReady, addCheck: addCheck},
+		payloadStore:      payloadStore,
+		inlineMaxBytes:    inlineMaxFromEnv(),
+		rehydrateMaxBytes: rehydrateMaxFromEnv(),
 	}
 
 	if err := configure(ctx, res); err != nil {
@@ -443,7 +444,7 @@ func subscribeDispatch(js nats.JetStreamContext, durable string, res *Resources,
 		// Rehydrate an offloaded payload (claim-check) before the connector sees
 		// it. No-op for inline payloads. A transient store error is returned as
 		// retriable so the message is redelivered rather than delivered empty.
-		if rerr := rehydrate(ctx, res.payloadStore, env); rerr != nil {
+		if rerr := rehydrate(ctx, res.payloadStore, env, res.rehydrateMaxBytes); rerr != nil {
 			span.RecordError(rerr)
 			span.SetStatus(codes.Error, rerr.Error())
 			return rerr

--- a/src/pkg/sdk/lifecycle.go
+++ b/src/pkg/sdk/lifecycle.go
@@ -304,8 +304,8 @@ func run(ctx context.Context, name string, c interface{}, configure func(context
 		NATS:              nc,
 		Health:            &healthToggle{setReady: setReady, addCheck: addCheck},
 		payloadStore:      payloadStore,
-		inlineMaxBytes:    inlineMaxFromEnv(),
-		rehydrateMaxBytes: rehydrateMaxFromEnv(),
+		inlineMaxBytes:    inlineMaxFromEnv(logger),
+		rehydrateMaxBytes: rehydrateMaxFromEnv(logger),
 	}
 
 	if err := configure(ctx, res); err != nil {

--- a/src/pkg/sdk/payloadstore.go
+++ b/src/pkg/sdk/payloadstore.go
@@ -3,6 +3,8 @@ package sdk
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"log/slog"
@@ -25,8 +27,17 @@ import (
 // connector payload contract to become a stream (io.Reader). See #187.
 const defaultInlineMaxBytes = 256 * 1024
 
+// defaultRehydrateMaxBytes bounds how much an offloaded payload may be buffered
+// back into memory for a connector that speaks []byte. Worker pods run with a
+// 512 MiB limit (orchestrator.MemoryLimit), so 128 MiB leaves comfortable room
+// for the envelope copy and parsing overhead. Past this the payload is rejected
+// rather than OOM-killing the worker; a streaming-capable connector (ADR 0001)
+// bypasses this path entirely and has no such limit.
+const defaultRehydrateMaxBytes = 128 * 1024 * 1024
+
 const (
 	envInlineMax      = "PAYLOAD_INLINE_MAX_BYTES"
+	envRehydrateMax   = "PAYLOAD_REHYDRATE_MAX_BYTES"
 	envStoreProvider  = "PAYLOAD_STORE_PROVIDER"
 	envStoreBucket    = "PAYLOAD_STORE_BUCKET"
 	envStoreEndpoint  = "PAYLOAD_STORE_ENDPOINT"
@@ -79,6 +90,20 @@ func inlineMaxFromEnv() int {
 	return envInt(envInlineMax, defaultInlineMaxBytes)
 }
 
+// rehydrateMaxFromEnv resolves the buffering cap (PAYLOAD_REHYDRATE_MAX_BYTES),
+// defaulting to 128 MiB. A non-positive value disables the cap (unbounded
+// buffering — only sensible if worker memory has been raised to match).
+func rehydrateMaxFromEnv() int64 {
+	return int64(envInt(envRehydrateMax, defaultRehydrateMaxBytes))
+}
+
+// payloadChecksum is the canonical "sha256:<hex>" digest stamped on offloaded
+// payloads and verified when they are read back.
+func payloadChecksum(b []byte) string {
+	sum := sha256.Sum256(b)
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
 // payloadKey is the object key an offloaded payload is stored under. Tenant- and
 // connection-scoped, unique per envelope so concurrent workers never collide.
 func payloadKey(env *envelope.Envelope) string {
@@ -106,6 +131,7 @@ func offloadIfLarge(ctx context.Context, store objectstore.ObjectStore, env *env
 		return false, fmt.Errorf("offload payload %q: %w", key, err)
 	}
 	env.PayloadSize = int64(len(env.Payload))
+	env.Checksum = payloadChecksum(env.Payload)
 	env.PayloadRef = key
 	env.Payload = nil
 	return true, nil
@@ -115,21 +141,50 @@ func offloadIfLarge(ctx context.Context, store objectstore.ObjectStore, env *env
 // connector sees it, and clears the reference. No-op when the payload is inline.
 // A missing/unreadable object is returned as an error so the message is retried
 // (the object may be transiently unavailable) rather than delivered empty.
-func rehydrate(ctx context.Context, store objectstore.ObjectStore, env *envelope.Envelope) error {
+func rehydrate(ctx context.Context, store objectstore.ObjectStore, env *envelope.Envelope, maxBytes int64) error {
 	if env.PayloadRef == "" {
 		return nil
 	}
 	if store == nil {
 		return fmt.Errorf("envelope %s references offloaded payload %q but no offload store is configured", env.ID, env.PayloadRef)
 	}
+	// Reject BEFORE downloading: buffering a payload this large would OOM-kill
+	// the worker, and no retry can change that. Returning a plain error rides the
+	// SDK's default Retriable classification ON PURPOSE — Permanent would ack and
+	// silently drop a customer payload, whereas exhausting the (cheap, since we
+	// reject without downloading) retries routes the envelope to the DLQ, where
+	// an operator can inspect it and replay once a streaming-capable connector is
+	// in place. The spilled object outlives the message (1-day lifecycle TTL), so
+	// replay within that window recovers the data.
+	if maxBytes > 0 && env.PayloadSize > maxBytes {
+		return fmt.Errorf("payload %q is %d bytes, over the %d-byte rehydrate cap (%s): this connector buffers payloads in memory; use a streaming-capable connector or raise the cap",
+			env.PayloadRef, env.PayloadSize, maxBytes, envRehydrateMax)
+	}
 	rc, ct, err := store.GetStream(ctx, env.PayloadRef)
 	if err != nil {
 		return fmt.Errorf("rehydrate payload %q: %w", env.PayloadRef, err)
 	}
 	defer rc.Close()
-	body, err := io.ReadAll(rc)
+	// PayloadSize is envelope metadata and may understate the object, so bound
+	// the read itself too (+1 byte to detect an over-cap object).
+	var src io.Reader = rc
+	if maxBytes > 0 {
+		src = io.LimitReader(rc, maxBytes+1)
+	}
+	body, err := io.ReadAll(src)
 	if err != nil {
 		return fmt.Errorf("rehydrate read %q: %w", env.PayloadRef, err)
+	}
+	if maxBytes > 0 && int64(len(body)) > maxBytes {
+		return fmt.Errorf("object %q exceeds the %d-byte rehydrate cap (%s) despite a declared size of %d",
+			env.PayloadRef, maxBytes, envRehydrateMax, env.PayloadSize)
+	}
+	// Verify integrity across the offload hop. Skipped when the envelope carries
+	// no checksum (inline-era envelopes still in flight during a rollout).
+	if env.Checksum != "" {
+		if got := payloadChecksum(body); got != env.Checksum {
+			return fmt.Errorf("checksum mismatch for %q: envelope declares %s, object is %s", env.PayloadRef, env.Checksum, got)
+		}
 	}
 	env.Payload = body
 	// Fall back to the store's content type if the envelope didn't carry one, so

--- a/src/pkg/sdk/payloadstore.go
+++ b/src/pkg/sdk/payloadstore.go
@@ -8,7 +8,9 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"math"
 	"os"
+	"strconv"
 
 	"github.com/ValueRetail/vrsky/pkg/envelope"
 	"github.com/ValueRetail/vrsky/pkg/objectstore"
@@ -83,18 +85,46 @@ func openPayloadStore(ctx context.Context, logger *slog.Logger) (objectstore.Obj
 	return store, nil
 }
 
+// envBytes resolves a byte-size setting from the environment.
+//
+// Parsed as int64 rather than through envInt: these are memory limits an
+// operator may legitimately set above 2 GiB, and int is not guaranteed to be
+// 64-bit. A malformed value is logged and falls back to the default rather than
+// being swallowed — somebody raising a cap needs to find out that their value
+// did not take effect, and finding out from a warning beats finding out from a
+// payload that is still being rejected.
+func envBytes(key string, def int64, logger *slog.Logger) int64 {
+	raw := os.Getenv(key)
+	if raw == "" {
+		return def
+	}
+	n, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil {
+		logger.Warn("invalid byte-size setting; falling back to the default",
+			"env", key, "value", raw, "default", def, "error", err)
+		return def
+	}
+	return n
+}
+
 // inlineMaxFromEnv resolves the inline payload limit (PAYLOAD_INLINE_MAX_BYTES),
 // defaulting to 256 KiB. A non-positive value disables offload (everything stays
 // inline), which is the pre-claim-check behavior.
-func inlineMaxFromEnv() int {
-	return envInt(envInlineMax, defaultInlineMaxBytes)
+func inlineMaxFromEnv(logger *slog.Logger) int {
+	// Compared against len(payload), so it lives in an int. Clamped rather than
+	// truncated: a wrapped negative here would silently disable offload.
+	n := envBytes(envInlineMax, defaultInlineMaxBytes, logger)
+	if n > math.MaxInt {
+		return math.MaxInt
+	}
+	return int(n)
 }
 
 // rehydrateMaxFromEnv resolves the buffering cap (PAYLOAD_REHYDRATE_MAX_BYTES),
 // defaulting to 128 MiB. A non-positive value disables the cap (unbounded
 // buffering — only sensible if worker memory has been raised to match).
-func rehydrateMaxFromEnv() int64 {
-	return int64(envInt(envRehydrateMax, defaultRehydrateMaxBytes))
+func rehydrateMaxFromEnv(logger *slog.Logger) int64 {
+	return envBytes(envRehydrateMax, defaultRehydrateMaxBytes, logger)
 }
 
 // payloadChecksum is the canonical "sha256:<hex>" digest stamped on offloaded
@@ -148,14 +178,18 @@ func rehydrate(ctx context.Context, store objectstore.ObjectStore, env *envelope
 	if store == nil {
 		return fmt.Errorf("envelope %s references offloaded payload %q but no offload store is configured", env.ID, env.PayloadRef)
 	}
-	// Reject BEFORE downloading: buffering a payload this large would OOM-kill
-	// the worker, and no retry can change that. Returning a plain error rides the
-	// SDK's default Retriable classification ON PURPOSE — Permanent would ack and
-	// silently drop a customer payload, whereas exhausting the (cheap, since we
-	// reject without downloading) retries routes the envelope to the DLQ, where
-	// an operator can inspect it and replay once a streaming-capable connector is
-	// in place. The spilled object outlives the message (1-day lifecycle TTL), so
-	// replay within that window recovers the data.
+	// Rejection happens in two stages. The declared size is checked first, so an
+	// honestly-labelled oversized payload costs nothing to refuse; but
+	// PayloadSize is envelope metadata and may be absent or understated, so the
+	// read below is bounded as well. Either way the worker never buffers a
+	// payload this large, which is the OOM no retry could fix.
+	//
+	// Returning a plain error rides the SDK's default Retriable classification ON
+	// PURPOSE — Permanent would ack and silently drop a customer payload, whereas
+	// exhausting the retries routes the envelope to the DLQ, where an operator can
+	// inspect it and replay once a streaming-capable connector is in place. The
+	// spilled object outlives the message (1-day lifecycle TTL), so replay within
+	// that window recovers the data.
 	if maxBytes > 0 && env.PayloadSize > maxBytes {
 		return fmt.Errorf("payload %q is %d bytes, over the %d-byte rehydrate cap (%s): this connector buffers payloads in memory; use a streaming-capable connector or raise the cap",
 			env.PayloadRef, env.PayloadSize, maxBytes, envRehydrateMax)

--- a/src/pkg/sdk/payloadstore_test.go
+++ b/src/pkg/sdk/payloadstore_test.go
@@ -289,3 +289,83 @@ func TestOffloadIfLarge_ThresholdDisabled(t *testing.T) {
 		t.Fatal("offload should be disabled when inlineMax <= 0")
 	}
 }
+
+// captureLogs returns a logger writing into buf, so a test can assert that a
+// misconfiguration was actually reported and not just quietly corrected.
+func captureLogs(buf *bytes.Buffer) *slog.Logger {
+	return slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+}
+
+func TestEnvBytes_MissingUsesDefault(t *testing.T) {
+	var buf bytes.Buffer
+	if got := envBytes("SDK_TEST_ABSENT_BYTES", 4096, captureLogs(&buf)); got != 4096 {
+		t.Fatalf("envBytes = %d, want 4096", got)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("an unset variable should not warn, logged: %s", buf.String())
+	}
+}
+
+// A cap an operator cannot express as an int32 is the whole reason this parses
+// as int64. 8 GiB is a plausible value for a worker with the memory to match.
+func TestEnvBytes_ParsesValuesBeyondInt32(t *testing.T) {
+	const eightGiB = int64(8) * 1024 * 1024 * 1024
+
+	var buf bytes.Buffer
+	t.Setenv(envRehydrateMax, "8589934592")
+
+	if got := rehydrateMaxFromEnv(captureLogs(&buf)); got != eightGiB {
+		t.Fatalf("rehydrateMaxFromEnv = %d, want %d", got, eightGiB)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("a valid value should not warn, logged: %s", buf.String())
+	}
+}
+
+// The failure mode this guards against: an operator raises the cap, fat-fingers
+// the value, and the worker goes on rejecting payloads at the old limit with
+// nothing in the logs to explain why.
+func TestEnvBytes_InvalidValueWarnsAndFallsBack(t *testing.T) {
+	for _, bad := range []string{"128MiB", "not-a-number", "12.5", "99999999999999999999999"} {
+		t.Run(bad, func(t *testing.T) {
+			var buf bytes.Buffer
+			t.Setenv(envRehydrateMax, bad)
+
+			got := rehydrateMaxFromEnv(captureLogs(&buf))
+			if got != defaultRehydrateMaxBytes {
+				t.Fatalf("got %d, want the default %d", got, int64(defaultRehydrateMaxBytes))
+			}
+
+			logged := buf.String()
+			if !strings.Contains(logged, envRehydrateMax) || !strings.Contains(logged, bad) {
+				t.Errorf("warning should name the variable and the offending value, got: %q", logged)
+			}
+		})
+	}
+}
+
+func TestInlineMaxFromEnv_InvalidValueWarnsAndFallsBack(t *testing.T) {
+	var buf bytes.Buffer
+	t.Setenv(envInlineMax, "256KiB")
+
+	if got := inlineMaxFromEnv(captureLogs(&buf)); got != defaultInlineMaxBytes {
+		t.Fatalf("got %d, want the default %d", got, defaultInlineMaxBytes)
+	}
+	if !strings.Contains(buf.String(), envInlineMax) {
+		t.Errorf("warning should name the variable, got: %q", buf.String())
+	}
+}
+
+// A negative value is a deliberate "switch this off", not a mistake, so it is
+// passed through rather than warned about.
+func TestEnvBytes_NegativeIsHonoured(t *testing.T) {
+	var buf bytes.Buffer
+	t.Setenv(envRehydrateMax, "-1")
+
+	if got := rehydrateMaxFromEnv(captureLogs(&buf)); got != -1 {
+		t.Fatalf("got %d, want -1 (cap disabled)", got)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("disabling the cap should not warn, logged: %s", buf.String())
+	}
+}

--- a/src/pkg/sdk/payloadstore_test.go
+++ b/src/pkg/sdk/payloadstore_test.go
@@ -20,6 +20,7 @@ type memStore struct {
 	objects map[string][]byte
 	ctByKey map[string]string // optional per-key content type
 	puts    int
+	gets    int
 }
 
 func newMemStore() *memStore { return &memStore{objects: map[string][]byte{}} }
@@ -48,6 +49,7 @@ func (m *memStore) Put(_ context.Context, key string, body []byte, _ string) err
 func (m *memStore) GetStream(_ context.Context, key string) (io.ReadCloser, string, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	m.gets++
 	b, ok := m.objects[key]
 	if !ok {
 		return nil, "", io.ErrUnexpectedEOF
@@ -101,7 +103,7 @@ func TestOffloadRehydrate_LargePayloadRoundTrips(t *testing.T) {
 
 	// The (small) envelope is what would ride NATS — verify the offloaded object
 	// is retrievable and rehydrate restores the exact bytes.
-	if err := rehydrate(context.Background(), store, env); err != nil {
+	if err := rehydrate(context.Background(), store, env, defaultRehydrateMaxBytes); err != nil {
 		t.Fatalf("rehydrate: %v", err)
 	}
 	if !bytes.Equal(env.Payload, big) {
@@ -146,7 +148,7 @@ func TestOffloadIfLarge_NoStoreKeepsInline(t *testing.T) {
 
 func TestRehydrate_RefButNoStoreErrors(t *testing.T) {
 	env := &envelope.Envelope{ID: "e", PayloadRef: "spill/t/c/e"}
-	err := rehydrate(context.Background(), nil, env)
+	err := rehydrate(context.Background(), nil, env, defaultRehydrateMaxBytes)
 	if err == nil {
 		t.Fatal("expected error when a ref is set but no store is configured")
 	}
@@ -163,11 +165,115 @@ func TestRehydrate_FillsContentTypeFromStore(t *testing.T) {
 	store.objects[ref] = []byte("a,b\n1,2\n")
 	env := &envelope.Envelope{ID: "env-1", PayloadRef: ref}
 
-	if err := rehydrate(context.Background(), store, env); err != nil {
+	if err := rehydrate(context.Background(), store, env, defaultRehydrateMaxBytes); err != nil {
 		t.Fatalf("rehydrate: %v", err)
 	}
 	if env.ContentType != "text/csv" {
 		t.Errorf("ContentType = %q, want text/csv (from store)", env.ContentType)
+	}
+}
+
+func TestOffload_StampsChecksum(t *testing.T) {
+	store := newMemStore()
+	payload := bytes.Repeat([]byte("A"), 1000)
+	env := mkEnv(payload)
+	if _, err := offloadIfLarge(context.Background(), store, env, 256, slog.Default()); err != nil {
+		t.Fatalf("offloadIfLarge: %v", err)
+	}
+	want := payloadChecksum(payload)
+	if env.Checksum != want {
+		t.Errorf("Checksum = %q, want %q", env.Checksum, want)
+	}
+	if !strings.HasPrefix(env.Checksum, "sha256:") {
+		t.Errorf("checksum should be sha256-prefixed, got %q", env.Checksum)
+	}
+}
+
+func TestRehydrate_RejectsOverCapBeforeDownload(t *testing.T) {
+	store := newMemStore()
+	env := mkEnv(bytes.Repeat([]byte("A"), 1000))
+	if _, err := offloadIfLarge(context.Background(), store, env, 256, slog.Default()); err != nil {
+		t.Fatalf("offloadIfLarge: %v", err)
+	}
+	// Cap below the payload size → rejected without reading the object.
+	before := store.gets
+	err := rehydrate(context.Background(), store, env, 500)
+	if err == nil {
+		t.Fatal("expected an over-cap rehydrate to fail")
+	}
+	if !strings.Contains(err.Error(), "rehydrate cap") {
+		t.Errorf("error should explain the cap, got: %v", err)
+	}
+	if store.gets != before {
+		t.Errorf("over-cap payload should be rejected without downloading (gets went %d→%d)", before, store.gets)
+	}
+	// The envelope must stay intact so the DLQ entry still points at the object.
+	if env.PayloadRef == "" {
+		t.Error("PayloadRef should be preserved on rejection")
+	}
+}
+
+func TestRehydrate_CapDisabledAllowsAnySize(t *testing.T) {
+	store := newMemStore()
+	env := mkEnv(bytes.Repeat([]byte("A"), 1000))
+	if _, err := offloadIfLarge(context.Background(), store, env, 256, slog.Default()); err != nil {
+		t.Fatalf("offloadIfLarge: %v", err)
+	}
+	if err := rehydrate(context.Background(), store, env, 0); err != nil {
+		t.Fatalf("cap<=0 disables the limit, got: %v", err)
+	}
+	if len(env.Payload) != 1000 {
+		t.Errorf("payload not restored: %d bytes", len(env.Payload))
+	}
+}
+
+func TestRehydrate_BoundsReadWhenPayloadSizeUnderstatesObject(t *testing.T) {
+	store := newMemStore()
+	const ref = "spill/tenant-x/conn-1/env-1"
+	store.objects[ref] = bytes.Repeat([]byte("A"), 1000)
+	// Envelope lies: claims 10 bytes, object is 1000. The cap must still hold.
+	env := &envelope.Envelope{ID: "env-1", PayloadRef: ref, PayloadSize: 10}
+
+	err := rehydrate(context.Background(), store, env, 500)
+	if err == nil {
+		t.Fatal("expected the read-side bound to reject an understated payload")
+	}
+	if !strings.Contains(err.Error(), "exceeds") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestRehydrate_ChecksumMismatchIsDetected(t *testing.T) {
+	store := newMemStore()
+	env := mkEnv(bytes.Repeat([]byte("A"), 1000))
+	if _, err := offloadIfLarge(context.Background(), store, env, 256, slog.Default()); err != nil {
+		t.Fatalf("offloadIfLarge: %v", err)
+	}
+	// Corrupt the stored object behind the envelope's back.
+	store.objects[env.PayloadRef] = bytes.Repeat([]byte("B"), 1000)
+
+	err := rehydrate(context.Background(), store, env, defaultRehydrateMaxBytes)
+	if err == nil {
+		t.Fatal("expected a checksum mismatch to be detected")
+	}
+	if !strings.Contains(err.Error(), "checksum mismatch") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestRehydrate_NoChecksumStillWorks(t *testing.T) {
+	// Envelopes published before checksums existed (or by an older worker during
+	// a rollout) carry no checksum — they must still rehydrate.
+	store := newMemStore()
+	const ref = "spill/tenant-x/conn-1/legacy"
+	store.objects[ref] = []byte("legacy-payload")
+	env := &envelope.Envelope{ID: "legacy", PayloadRef: ref, PayloadSize: 14}
+
+	if err := rehydrate(context.Background(), store, env, defaultRehydrateMaxBytes); err != nil {
+		t.Fatalf("rehydrate without checksum should succeed: %v", err)
+	}
+	if string(env.Payload) != "legacy-payload" {
+		t.Errorf("payload = %q", env.Payload)
 	}
 }
 


### PR DESCRIPTION
Two commits: the design decision for the last piece of #187, plus its first implementation slice — the hardening that pays off **independently of any streaming connector**.

## 1. ADR 0001 — streaming payload contract (`831304f`)

[`docs/adr/0001-streaming-payload-contract.md`](docs/adr/0001-streaming-payload-contract.md) (Accepted). #189 lifted the *message-bus* ceiling, but the `[]byte` connector contract + `io.ReadAll` rehydrate still materialize payloads whole in memory; against the **512 MiB worker limit** the practical ceiling is ~100–200 MB, failing by OOM-kill.

**Decision:** opt-in streaming via type assertion — existing interfaces untouched, connectors add a `RunStream`/`DeliverStream` method, the SDK routes at chokepoints it already owns. **No new node type; nothing new in the UI.** Rejected: big-bang `io.Reader` interfaces (churn across ~20 connectors whose paginated-JSON payloads are correctly small) and handing `PayloadRef`s to connectors (objectstore coupling everywhere).

Phases: **1** streaming edges + this hardening → **2** record-streaming transforms → **3** presigned URLs.

## 2. Phase 1a — rehydrate cap + checksum (`1f36ca6`)

**Cap** (`PAYLOAD_REHYDRATE_MAX_BYTES`, default 128 MiB): size is checked *before* downloading, with an `io.LimitReader` bound on the read in case `PayloadSize` understates the object. This **lowers no ceiling** — today a 500 MB payload already fails, just by OOM-kill loop. It makes the existing, unpredictable limit explicit and tunable.

**Checksum**: envelope gains `Checksum` (`sha256:<hex>`), stamped on offload and verified on rehydrate — closes the integrity gap in #187. Empty checksums are skipped so envelopes from an older worker mid-rollout still deliver.

### One decision worth reviewing

The over-cap error is returned **bare**, so it rides the SDK's default **Retriable** path and the envelope lands in the **DLQ**. That looks odd — retrying can't succeed — but `sdk.Permanent` **acks and drops** the message ([errors.go](src/pkg/sdk/errors.go)), and silently discarding a customer payload is unacceptable for an integration platform. Retries cost nothing (rejection happens without downloading), and a DLQ'd envelope keeps its `PayloadRef`, so an operator can inspect and replay it once a streaming connector exists — within the spill object's 1-day TTL. The ADR originally said "permanent"; corrected there too.

## Tests / verification

7 new unit tests: checksum stamped / verified / mismatch-detected / absent-still-works; over-cap rejected **without downloading** (asserted via a get counter) and with `PayloadRef` preserved for the DLQ; read-side bound when `PayloadSize` lies; `cap<=0` disables.

`go build ./...`, `go vet`, and the sdk / messaging / cloud-storage / file-consumer suites all pass. (Two pre-existing gofmt-unclean files under `cmd/mock-sap` and `cmd/sap-s4hana-producer` are untouched by this PR.)

Part of #187.

🤖 Generated with [Claude Code](https://claude.com/claude-code)