### PR TITLE
feat(sdk): streaming connector contract for unbounded payloads (ADR 0001 phase 1b)

### DIFF
--- a/docs/adr/0001-streaming-payload-contract.md
+++ b/docs/adr/0001-streaming-payload-contract.md
@@ -111,6 +111,17 @@ In `subscribeDispatch`: if `env.PayloadRef != ""` and the node implements
 `StreamingProducer` → `GetStream` and hand over the reader (checksum-verifying
 wrapper); no rehydrate. Otherwise rehydrate as today.
 
+**Per-message escape hatch (`ErrStreamUnsupported`) — added during
+implementation.** Building the first adopter surfaced a gap: the cloud-storage
+producer can fan out to several targets, and a stream can only be read once.
+Buffering to serve N targets would reintroduce the OOM this ADR exists to
+prevent, while failing outright would regress configurations that work today
+(multi-target + a 1–128 MB payload). So `DeliverStream` may return
+`ErrStreamUnsupported` for a message it cannot stream; the SDK then falls back to
+rehydrate + `Deliver`, giving behaviour identical to a non-streaming connector.
+Returning it is free — nothing has been read yet. Capability is therefore
+declared statically (type assertion) but *applied* per message.
+
 **Rehydrate guard (independent hardening, do first — shipped):** cap `rehydrate`
 at `PAYLOAD_REHYDRATE_MAX_BYTES` (default 128 MiB — comfortable inside the
 512 MiB limit). The check runs on `PayloadSize` *before* any download, with an

--- a/src/cmd/cloud-storage-producer/service.go
+++ b/src/cmd/cloud-storage-producer/service.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"path"
 	"strings"
@@ -132,6 +133,49 @@ func (p *cloudProducer) Stop(ctx context.Context) error {
 // failures (connect/write) → sdk.Retriable. A missing producer config for the
 // connection is not an error — this binary just isn't the producer for it.
 func (p *cloudProducer) Deliver(ctx context.Context, env *envelope.Envelope) error {
+	targets := p.eligibleTargets(ctx, env)
+
+	var transient error
+	for _, t := range targets {
+		if err := p.upload(ctx, &t.cfg, env, nil); err != nil && transient == nil {
+			transient = err
+		}
+	}
+	if transient != nil {
+		return sdk.Retriable(transient)
+	}
+	return nil
+}
+
+// DeliverStream writes a large, offloaded payload straight from the pipeline's
+// object stream to the destination bucket, so a multi-GB object transfers with
+// a bounded buffer instead of being held in memory (ADR 0001).
+//
+// A stream can only be read once, so fan-out to several targets is declined
+// (sdk.ErrStreamUnsupported) and the SDK falls back to buffered delivery —
+// identical behaviour to before, subject to the rehydrate cap.
+//
+// Note: the key template is rendered without payload-derived fields (the
+// content hasn't been read, and reading it to template a key would defeat the
+// purpose). A template referencing payload fields falls back to a generated key
+// with a warning, the same as any other template miss.
+func (p *cloudProducer) DeliverStream(ctx context.Context, env *envelope.Envelope, body io.Reader) error {
+	targets := p.eligibleTargets(ctx, env)
+	if len(targets) == 0 {
+		return nil
+	}
+	if len(targets) > 1 {
+		return sdk.ErrStreamUnsupported
+	}
+	if err := p.upload(ctx, &targets[0].cfg, env, body); err != nil {
+		return sdk.Retriable(err)
+	}
+	return nil
+}
+
+// eligibleTargets resolves the configured targets for this connection and drops
+// the ones whose predecessor predicate doesn't match this envelope.
+func (p *cloudProducer) eligibleTargets(ctx context.Context, env *envelope.Envelope) []*cloudTarget {
 	connID := env.IntegrationID
 	if connID == "" {
 		return nil
@@ -149,7 +193,7 @@ func (p *cloudProducer) Deliver(ctx context.Context, env *envelope.Envelope) err
 		}
 	}
 
-	var transient error
+	out := make([]*cloudTarget, 0, len(targets))
 	for _, t := range targets {
 		if t.predIsConsumer && lastProcessedBy != "" {
 			continue
@@ -157,18 +201,15 @@ func (p *cloudProducer) Deliver(ctx context.Context, env *envelope.Envelope) err
 		if !t.predIsConsumer && t.predecessorID != "" && lastProcessedBy != t.predecessorID {
 			continue
 		}
-		if err := p.upload(ctx, &t.cfg, env); err != nil && transient == nil {
-			transient = err
-		}
+		out = append(out, t)
 	}
-	if transient != nil {
-		return sdk.Retriable(transient)
-	}
-	return nil
+	return out
 }
 
-// upload renders the object key and writes the payload to the bucket.
-func (p *cloudProducer) upload(ctx context.Context, cfg *cloudConfig, env *envelope.Envelope) error {
+// upload renders the object key and writes the payload to the bucket. When body
+// is non-nil the payload is streamed from it (never buffered); otherwise
+// env.Payload is written.
+func (p *cloudProducer) upload(ctx context.Context, cfg *cloudConfig, env *envelope.Envelope, body io.Reader) error {
 	if cfg.Bucket == "" {
 		p.logger.Error("cloud-storage producer config incomplete (need bucket); skipping")
 		return nil
@@ -203,6 +244,13 @@ func (p *cloudProducer) upload(ctx context.Context, cfg *cloudConfig, env *envel
 	contentType := env.ContentType
 	if contentType == "" {
 		contentType = "application/octet-stream"
+	}
+	if body != nil {
+		if err := store.PutStream(ctx, key, body, contentType); err != nil {
+			return fmt.Errorf("put-stream %s: %w", key, err)
+		}
+		p.logger.Info("cloud-storage streamed upload complete", "bucket", cfg.Bucket, "key", key, "size", env.PayloadSize)
+		return nil
 	}
 	if err := store.Put(ctx, key, env.Payload, contentType); err != nil {
 		return fmt.Errorf("put %s: %w", key, err)

--- a/src/pkg/sdk/lifecycle.go
+++ b/src/pkg/sdk/lifecycle.go
@@ -3,6 +3,7 @@ package sdk
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -83,9 +84,16 @@ func RunProducer(ctx context.Context, name string, p Producer, opts ...RunOption
 	return run(ctx, name, p,
 		func(ctx context.Context, res *Resources) error { return p.Configure(ctx, res) },
 		func(ctx context.Context, js nats.JetStreamContext, _ *messaging.Publisher, res *Resources) (func(), error) {
+			// A StreamingProducer (ADR 0001) receives offloaded payloads as a
+			// stream instead of a buffered []byte, lifting the rehydrate cap.
+			var streamDeliver streamDeliverFunc
+			if sp, ok := p.(StreamingProducer); ok {
+				streamDeliver = sp.DeliverStream
+				res.Logger.Info("streaming delivery enabled")
+			}
 			return subscribeDispatch(js, name, res, func(c context.Context, env *envelope.Envelope) error {
 				return p.Deliver(c, env)
-			})
+			}, streamDeliver)
 		}, opts...)
 }
 
@@ -138,6 +146,16 @@ func RunConsumer(ctx context.Context, name string, c Consumer, opts ...RunOption
 				}
 				return nil
 			}
+			// A StreamingConsumer (ADR 0001) drives RunStream and additionally gets
+			// publishStream for payloads too large to hold in memory. Without a
+			// payload store there is nowhere to stream to, so such a worker stays
+			// on the plain Run contract.
+			sc, streaming := c.(StreamingConsumer)
+			streaming = streaming && res.payloadStore != nil
+			if streaming {
+				res.Logger.Info("streaming ingestion enabled")
+			}
+
 			done := make(chan struct{})
 			go func() {
 				defer close(done)
@@ -146,7 +164,13 @@ func RunConsumer(ctx context.Context, name string, c Consumer, opts ...RunOption
 						res.Logger.Error("consumer Run panicked", "panic", r)
 					}
 				}()
-				if err := c.Run(ctx, publish); err != nil && ctx.Err() == nil {
+				var err error
+				if streaming {
+					err = sc.RunStream(ctx, publish, newPublishStream(publish, res))
+				} else {
+					err = c.Run(ctx, publish)
+				}
+				if err != nil && ctx.Err() == nil {
 					res.Logger.Error("consumer Run exited with error", "error", err)
 				}
 			}()
@@ -169,7 +193,9 @@ func RunFilter(ctx context.Context, name string, f Filter, opts ...RunOption) er
 					return nil // dropped — ack
 				}
 				return republish(c, pub, res, out)
-			})
+				// nil: record-streaming transforms are ADR 0001 phase 2; until
+				// then an over-cap payload at a filter is a clear DLQ error.
+			}, nil)
 		}, opts...)
 }
 
@@ -188,7 +214,8 @@ func RunConverter(ctx context.Context, name string, cv Converter, opts ...RunOpt
 					return nil
 				}
 				return republish(c, pub, res, out)
-			})
+				// nil: see RunFilter — phase 2 covers streaming transforms.
+			}, nil)
 		}, opts...)
 }
 
@@ -403,7 +430,11 @@ func ackWaitFromEnv(logger *slog.Logger) time.Duration {
 // unmarshals the envelope and calls deliver, mapping the SDK error classes
 // onto messaging's NAK/DLQ semantics: nil → ack; Permanent → ack+log (poison);
 // anything else → NAK (messaging retries with backoff, then DLQs).
-func subscribeDispatch(js nats.JetStreamContext, durable string, res *Resources, deliver func(context.Context, *envelope.Envelope) error) (func(), error) {
+// streamDeliver, when non-nil, is used INSTEAD of deliver for envelopes whose
+// payload was offloaded — the object is handed over as a stream and never
+// buffered (so the rehydrate cap does not apply). nil for connectors and node
+// kinds that don't stream.
+func subscribeDispatch(js nats.JetStreamContext, durable string, res *Resources, deliver func(context.Context, *envelope.Envelope) error, streamDeliver streamDeliverFunc) (func(), error) {
 	logger := res.Logger
 	sub, err := messaging.Subscribe(js, messaging.SubscriberOpts{
 		DurableName: durable,
@@ -441,16 +472,29 @@ func subscribeDispatch(js nats.JetStreamContext, durable string, res *Resources,
 		)
 		defer span.End()
 
-		// Rehydrate an offloaded payload (claim-check) before the connector sees
-		// it. No-op for inline payloads. A transient store error is returned as
-		// retriable so the message is redelivered rather than delivered empty.
-		if rerr := rehydrate(ctx, res.payloadStore, env, res.rehydrateMaxBytes); rerr != nil {
-			span.RecordError(rerr)
-			span.SetStatus(codes.Error, rerr.Error())
-			return rerr
+		var derr error
+		streamed := false
+		if env.PayloadRef != "" && streamDeliver != nil && res.payloadStore != nil {
+			// Streaming-capable connector + offloaded payload: hand over the object
+			// stream. Never buffered, so payload size is unbounded (ADR 0001).
+			derr = deliverStreamed(ctx, res.payloadStore, env, streamDeliver)
+			// The connector may decline THIS message (e.g. fan-out needs several
+			// passes); fall through to buffered delivery, exactly as if it were a
+			// non-streaming connector.
+			streamed = !errors.Is(derr, ErrStreamUnsupported)
+			span.SetAttributes(attribute.Bool("vrsky.payload.streamed", streamed))
 		}
-
-		derr := deliver(ctx, env)
+		if !streamed {
+			// Rehydrate an offloaded payload (claim-check) before the connector sees
+			// it. No-op for inline payloads. A transient store error is returned as
+			// retriable so the message is redelivered rather than delivered empty.
+			if rerr := rehydrate(ctx, res.payloadStore, env, res.rehydrateMaxBytes); rerr != nil {
+				span.RecordError(rerr)
+				span.SetStatus(codes.Error, rerr.Error())
+				return rerr
+			}
+			derr = deliver(ctx, env)
+		}
 		if derr == nil {
 			// Spilled objects are reclaimed by the bucket lifecycle TTL (spill/
 			// prefix), NOT eagerly here: an eager delete races the JetStream ACK,

--- a/src/pkg/sdk/lifecycle.go
+++ b/src/pkg/sdk/lifecycle.go
@@ -3,7 +3,6 @@ package sdk
 import (
 	"context"
 	"database/sql"
-	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -472,28 +471,9 @@ func subscribeDispatch(js nats.JetStreamContext, durable string, res *Resources,
 		)
 		defer span.End()
 
-		var derr error
-		streamed := false
-		if env.PayloadRef != "" && streamDeliver != nil && res.payloadStore != nil {
-			// Streaming-capable connector + offloaded payload: hand over the object
-			// stream. Never buffered, so payload size is unbounded (ADR 0001).
-			derr = deliverStreamed(ctx, res.payloadStore, env, streamDeliver)
-			// The connector may decline THIS message (e.g. fan-out needs several
-			// passes); fall through to buffered delivery, exactly as if it were a
-			// non-streaming connector.
-			streamed = !errors.Is(derr, ErrStreamUnsupported)
-			span.SetAttributes(attribute.Bool("vrsky.payload.streamed", streamed))
-		}
-		if !streamed {
-			// Rehydrate an offloaded payload (claim-check) before the connector sees
-			// it. No-op for inline payloads. A transient store error is returned as
-			// retriable so the message is redelivered rather than delivered empty.
-			if rerr := rehydrate(ctx, res.payloadStore, env, res.rehydrateMaxBytes); rerr != nil {
-				span.RecordError(rerr)
-				span.SetStatus(codes.Error, rerr.Error())
-				return rerr
-			}
-			derr = deliver(ctx, env)
+		streamed, derr := dispatchEnvelope(ctx, res, env, deliver, streamDeliver)
+		if streamed {
+			span.SetAttributes(attribute.Bool("vrsky.payload.streamed", true))
 		}
 		if derr == nil {
 			// Spilled objects are reclaimed by the bucket lifecycle TTL (spill/

--- a/src/pkg/sdk/streaming.go
+++ b/src/pkg/sdk/streaming.go
@@ -107,6 +107,42 @@ func newPublishStream(publish PublishFunc, res *Resources) PublishStreamFunc {
 	}
 }
 
+// dispatchEnvelope routes one envelope to the streaming or the buffered delivery
+// path, and reports which it used.
+//
+// Streaming is taken only when all three hold: the payload was offloaded, the
+// connector implements StreamingProducer, and a payload store is configured.
+// The connector may still decline THIS message with ErrStreamUnsupported (e.g.
+// fan-out needs several passes over a payload that reads once), in which case
+// delivery falls back to rehydrate + Deliver — behaviour identical to a
+// non-streaming connector, cap included. A decline costs one open/close of the
+// object; it is the rare path, and it keeps the capability check per-message
+// without a second interface.
+//
+// Rehydrate errors are returned like delivery errors: they are always plain
+// (never Permanent), so the caller's classification NAKs them either way.
+func dispatchEnvelope(
+	ctx context.Context,
+	res *Resources,
+	env *envelope.Envelope,
+	deliver func(context.Context, *envelope.Envelope) error,
+	streamDeliver streamDeliverFunc,
+) (streamed bool, err error) {
+	if env.PayloadRef != "" && streamDeliver != nil && res.payloadStore != nil {
+		err = deliverStreamed(ctx, res.payloadStore, env, streamDeliver)
+		if !errors.Is(err, ErrStreamUnsupported) {
+			return true, err
+		}
+	}
+	// Buffered path: rehydrate an offloaded payload (no-op when inline) before
+	// the connector sees it. A store error is retriable so the message is
+	// redelivered rather than delivered empty.
+	if rerr := rehydrate(ctx, res.payloadStore, env, res.rehydrateMaxBytes); rerr != nil {
+		return false, rerr
+	}
+	return false, deliver(ctx, env)
+}
+
 // deliverStreamed hands an offloaded payload to a StreamingProducer as a stream,
 // bypassing rehydration (and therefore the buffering cap).
 func deliverStreamed(ctx context.Context, store objectstore.ObjectStore, env *envelope.Envelope, fn streamDeliverFunc) error {

--- a/src/pkg/sdk/streaming.go
+++ b/src/pkg/sdk/streaming.go
@@ -1,0 +1,165 @@
+package sdk
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"hash"
+	"io"
+
+	"github.com/ValueRetail/vrsky/pkg/envelope"
+	"github.com/ValueRetail/vrsky/pkg/objectstore"
+)
+
+// Streaming payload contract (ADR 0001). The []byte contract in Consumer /
+// Producer bounds a payload by worker memory (512 MiB pods → ~128 MiB cap, see
+// payloadstore.go). A connector that already holds an io.Reader — a file on
+// disk, an SFTP session, an object-store body, an HTTP response — can instead
+// implement the optional interfaces below and move unbounded (multi-GB) payloads
+// with memory bounded by the copy buffer.
+//
+// These are OPT-IN companions, not replacements: the SDK type-asserts for them
+// and falls back to the existing []byte path, so connectors that deal in small
+// records (the retail/ERP APIs) need no changes, and nothing new appears as a
+// node type or in the UI.
+
+// PublishStreamFunc emits a large payload without ever holding it in memory. The
+// SDK streams body straight into the payload store (provider-native multipart),
+// stamping PayloadRef, PayloadSize and Checksum on env as it goes, then
+// publishes the small envelope. env carries the metadata (ID, TenantID,
+// IntegrationID, ContentType); its Payload field is ignored and cleared.
+//
+// Requires a configured payload store — streaming has nowhere to go without one,
+// so calling it on an unconfigured worker is a permanent error rather than a
+// silent buffer.
+type PublishStreamFunc func(ctx context.Context, env *envelope.Envelope, body io.Reader) error
+
+// StreamingConsumer is a Consumer that can also ingest large payloads as
+// streams. When a connector implements it, the SDK calls RunStream instead of
+// Run, supplying both publish (small payloads, unchanged semantics) and
+// publishStream (large ones). Implement Run as well — it remains the contract
+// for a worker whose payload store is not configured.
+type StreamingConsumer interface {
+	Consumer
+	RunStream(ctx context.Context, publish PublishFunc, publishStream PublishStreamFunc) error
+}
+
+// ErrStreamUnsupported is returned by DeliverStream when THIS message cannot be
+// streamed even though the connector generally can — the canonical case being
+// fan-out to several destinations, which needs more than one pass over a payload
+// that can only be read once. The SDK then falls back to buffered delivery via
+// Deliver, so behaviour is identical to a non-streaming connector (and the
+// rehydrate cap applies again). Returning it is cheap: nothing has been read.
+var ErrStreamUnsupported = errors.New("sdk: this message cannot be streamed")
+
+// StreamingProducer is a Producer that can deliver an offloaded payload straight
+// from the object store. When the inbound envelope carries a PayloadRef and the
+// connector implements this, the SDK skips rehydration entirely and hands over
+// the object stream — so the rehydrate cap does not apply. body is checksum-
+// verified as it is read: a corrupted object surfaces as a read error rather
+// than silently-wrong data downstream.
+//
+// Deliver is still required, and still receives inline (small) payloads.
+type StreamingProducer interface {
+	Producer
+	DeliverStream(ctx context.Context, env *envelope.Envelope, body io.Reader) error
+}
+
+// streamDeliverFunc is the SDK-internal shape of StreamingProducer.DeliverStream;
+// subscribeDispatch takes it as an optional streaming path (nil for connectors
+// and node kinds that don't stream).
+type streamDeliverFunc func(ctx context.Context, env *envelope.Envelope, body io.Reader) error
+
+// newPublishStream builds the PublishStreamFunc handed to a StreamingConsumer.
+func newPublishStream(publish PublishFunc, res *Resources) PublishStreamFunc {
+	return func(ctx context.Context, env *envelope.Envelope, body io.Reader) error {
+		if res.payloadStore == nil {
+			return Permanent(fmt.Errorf("publishStream requires a payload offload store: set %s (and credentials) on this worker", envStoreBucket))
+		}
+		if env.ID == "" {
+			// The object key is derived from the envelope ID; an empty one would
+			// collide across concurrent messages and silently overwrite payloads.
+			return Permanent(errors.New("publishStream: envelope ID must be set before publishing"))
+		}
+
+		// Hash and count while the store consumes the reader, so neither the
+		// checksum nor the size costs an extra pass or a buffer.
+		h := sha256.New()
+		counter := &countingWriter{}
+		tee := io.TeeReader(body, io.MultiWriter(h, counter))
+
+		key := payloadKey(env)
+		if err := res.payloadStore.PutStream(ctx, key, tee, env.ContentType); err != nil {
+			return fmt.Errorf("stream payload %q: %w", key, err)
+		}
+
+		env.Payload = nil
+		env.PayloadRef = key
+		env.PayloadSize = counter.n
+		env.Checksum = "sha256:" + hex.EncodeToString(h.Sum(nil))
+
+		// Reuse the normal publish path: the envelope is now small (a reference),
+		// so it takes the same route as any other message — offloadIfLarge is a
+		// no-op on it, and tracing/metrics stay identical.
+		return publish(ctx, env)
+	}
+}
+
+// deliverStreamed hands an offloaded payload to a StreamingProducer as a stream,
+// bypassing rehydration (and therefore the buffering cap).
+func deliverStreamed(ctx context.Context, store objectstore.ObjectStore, env *envelope.Envelope, fn streamDeliverFunc) error {
+	rc, ct, err := store.GetStream(ctx, env.PayloadRef)
+	if err != nil {
+		return fmt.Errorf("stream payload %q: %w", env.PayloadRef, err)
+	}
+	defer rc.Close()
+	if env.ContentType == "" {
+		env.ContentType = ct
+	}
+	// PayloadRef is deliberately left set: the connector is being handed the
+	// object's contents, and the reference is useful context (logging, keys).
+	return fn(ctx, env, newVerifyingReader(rc, env.Checksum))
+}
+
+// countingWriter counts bytes written; used to learn a streamed payload's size
+// without buffering it.
+type countingWriter struct{ n int64 }
+
+func (c *countingWriter) Write(p []byte) (int, error) {
+	c.n += int64(len(p))
+	return len(p), nil
+}
+
+// verifyingReader checks a streamed payload against its expected checksum as it
+// is read, failing the read at EOF on mismatch so the connector's own read
+// surfaces the corruption. Verification is skipped when want is empty (envelopes
+// published before checksums existed, still in flight across a rollout).
+//
+// A connector that stops reading early is not verified — it never saw the whole
+// payload, so there is nothing to attest.
+type verifyingReader struct {
+	rc       io.ReadCloser
+	h        hash.Hash
+	want     string
+	verified bool
+}
+
+func newVerifyingReader(rc io.ReadCloser, want string) io.Reader {
+	return &verifyingReader{rc: rc, h: sha256.New(), want: want}
+}
+
+func (v *verifyingReader) Read(p []byte) (int, error) {
+	n, err := v.rc.Read(p)
+	if n > 0 {
+		v.h.Write(p[:n])
+	}
+	if errors.Is(err, io.EOF) && v.want != "" && !v.verified {
+		v.verified = true
+		if got := "sha256:" + hex.EncodeToString(v.h.Sum(nil)); got != v.want {
+			return n, fmt.Errorf("checksum mismatch on streamed payload: expected %s, read %s", v.want, got)
+		}
+	}
+	return n, err
+}

--- a/src/pkg/sdk/streaming_test.go
+++ b/src/pkg/sdk/streaming_test.go
@@ -135,6 +135,161 @@ func TestVerifyingReader_SkipsWhenNoChecksum(t *testing.T) {
 	}
 }
 
+// --- dispatchEnvelope: the routing chokepoint (streaming vs buffered) ---
+
+// dispatchProbe records which delivery path a test envelope took.
+type dispatchProbe struct {
+	delivered    *envelope.Envelope // set when the buffered path ran
+	streamedBody []byte             // set when the streaming path ran
+	streamCalls  int
+	declineWith  error // when non-nil, DeliverStream returns this instead of reading
+}
+
+func (p *dispatchProbe) deliver(_ context.Context, env *envelope.Envelope) error {
+	p.delivered = env
+	return nil
+}
+
+func (p *dispatchProbe) deliverStream(_ context.Context, _ *envelope.Envelope, body io.Reader) error {
+	p.streamCalls++
+	if p.declineWith != nil {
+		return p.declineWith
+	}
+	b, err := io.ReadAll(body)
+	p.streamedBody = b
+	return err
+}
+
+// offloadedEnv puts a payload in the store and returns the (small) envelope
+// referencing it, as it would arrive off NATS.
+func offloadedEnv(t *testing.T, store *memStore, payload []byte) *envelope.Envelope {
+	t.Helper()
+	env := mkEnv(payload)
+	if _, err := offloadIfLarge(context.Background(), store, env, 256, testLogger()); err != nil {
+		t.Fatalf("offload: %v", err)
+	}
+	return env
+}
+
+func TestDispatchEnvelope_StreamsWithoutRehydrating(t *testing.T) {
+	store := newMemStore()
+	payload := bytes.Repeat([]byte("Z"), 4096)
+	env := offloadedEnv(t, store, payload)
+	res := &Resources{Logger: testLogger(), payloadStore: store, rehydrateMaxBytes: defaultRehydrateMaxBytes}
+	probe := &dispatchProbe{}
+
+	streamed, err := dispatchEnvelope(context.Background(), res, env, probe.deliver, probe.deliverStream)
+	if err != nil {
+		t.Fatalf("dispatchEnvelope: %v", err)
+	}
+	if !streamed {
+		t.Error("expected the streaming path to be used")
+	}
+	if probe.delivered != nil {
+		t.Error("buffered Deliver must NOT be called on the streaming path")
+	}
+	if !bytes.Equal(probe.streamedBody, payload) {
+		t.Errorf("streamed %d bytes, want %d", len(probe.streamedBody), len(payload))
+	}
+	// The decisive proof that rehydrate was skipped: it would have populated
+	// Payload and cleared PayloadRef.
+	if env.Payload != nil {
+		t.Errorf("payload was buffered into the envelope (%d bytes) — rehydrate ran", len(env.Payload))
+	}
+	if env.PayloadRef == "" {
+		t.Error("PayloadRef was cleared — rehydrate ran")
+	}
+}
+
+func TestDispatchEnvelope_FallsBackWhenConnectorDeclines(t *testing.T) {
+	store := newMemStore()
+	payload := bytes.Repeat([]byte("Z"), 4096)
+	env := offloadedEnv(t, store, payload)
+	res := &Resources{Logger: testLogger(), payloadStore: store, rehydrateMaxBytes: defaultRehydrateMaxBytes}
+	probe := &dispatchProbe{declineWith: ErrStreamUnsupported}
+
+	streamed, err := dispatchEnvelope(context.Background(), res, env, probe.deliver, probe.deliverStream)
+	if err != nil {
+		t.Fatalf("a declined stream must fall back cleanly, got: %v", err)
+	}
+	if streamed {
+		t.Error("a declined message did not stream")
+	}
+	if probe.streamCalls != 1 {
+		t.Errorf("DeliverStream should have been offered the message once, got %d", probe.streamCalls)
+	}
+	if probe.delivered == nil {
+		t.Fatal("expected fallback to buffered Deliver")
+	}
+	// Fallback means a full rehydrate: payload restored, ref cleared.
+	if !bytes.Equal(probe.delivered.Payload, payload) {
+		t.Errorf("fallback delivered %d bytes, want %d", len(probe.delivered.Payload), len(payload))
+	}
+	if probe.delivered.PayloadRef != "" {
+		t.Error("PayloadRef should be cleared after the fallback rehydrate")
+	}
+}
+
+func TestDispatchEnvelope_BufferedWhenNotStreamingCapable(t *testing.T) {
+	store := newMemStore()
+	payload := bytes.Repeat([]byte("Z"), 4096)
+	env := offloadedEnv(t, store, payload)
+	res := &Resources{Logger: testLogger(), payloadStore: store, rehydrateMaxBytes: defaultRehydrateMaxBytes}
+	probe := &dispatchProbe{}
+
+	// streamDeliver nil = a plain Producer.
+	streamed, err := dispatchEnvelope(context.Background(), res, env, probe.deliver, nil)
+	if err != nil {
+		t.Fatalf("dispatchEnvelope: %v", err)
+	}
+	if streamed || probe.streamCalls != 0 {
+		t.Error("a non-streaming producer must never take the streaming path")
+	}
+	if probe.delivered == nil || !bytes.Equal(probe.delivered.Payload, payload) {
+		t.Error("expected the buffered path to rehydrate and deliver")
+	}
+}
+
+func TestDispatchEnvelope_InlinePayloadGoesStraightToDeliver(t *testing.T) {
+	res := &Resources{Logger: testLogger(), payloadStore: newMemStore(), rehydrateMaxBytes: defaultRehydrateMaxBytes}
+	probe := &dispatchProbe{}
+	env := mkEnv([]byte("small")) // never offloaded — no PayloadRef
+
+	streamed, err := dispatchEnvelope(context.Background(), res, env, probe.deliver, probe.deliverStream)
+	if err != nil {
+		t.Fatalf("dispatchEnvelope: %v", err)
+	}
+	if streamed || probe.streamCalls != 0 {
+		t.Error("an inline payload must not take the streaming path")
+	}
+	if probe.delivered == nil || string(probe.delivered.Payload) != "small" {
+		t.Error("expected direct buffered delivery")
+	}
+}
+
+func TestDispatchEnvelope_StreamingBypassesTheRehydrateCap(t *testing.T) {
+	// The headline claim of ADR 0001: a streaming connector has no size cap.
+	store := newMemStore()
+	payload := bytes.Repeat([]byte("Z"), 4096)
+	env := offloadedEnv(t, store, payload)
+	// A cap far below the payload — fatal on the buffered path.
+	res := &Resources{Logger: testLogger(), payloadStore: store, rehydrateMaxBytes: 100}
+
+	streamed, err := dispatchEnvelope(context.Background(), res, env, (&dispatchProbe{}).deliver, (&dispatchProbe{}).deliverStream)
+	if err != nil {
+		t.Fatalf("streaming must ignore the rehydrate cap, got: %v", err)
+	}
+	if !streamed {
+		t.Error("expected the streaming path")
+	}
+
+	// Same envelope, same cap, but a non-streaming connector → rejected.
+	env2 := offloadedEnv(t, store, payload)
+	if _, err := dispatchEnvelope(context.Background(), res, env2, (&dispatchProbe{}).deliver, nil); err == nil {
+		t.Fatal("the buffered path must still enforce the cap")
+	}
+}
+
 func TestErrStreamUnsupported_IsIdentifiable(t *testing.T) {
 	// Connectors wrap it; the SDK must still recognise it to fall back.
 	wrapped := errors.New("cloud: " + ErrStreamUnsupported.Error())

--- a/src/pkg/sdk/streaming_test.go
+++ b/src/pkg/sdk/streaming_test.go
@@ -1,0 +1,147 @@
+package sdk
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/ValueRetail/vrsky/pkg/envelope"
+)
+
+// testLogger discards output so tests stay quiet.
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func drain(t *testing.T, r io.Reader) ([]byte, error) {
+	t.Helper()
+	return io.ReadAll(r)
+}
+
+func TestPublishStream_OffloadsAndPublishesSmallEnvelope(t *testing.T) {
+	store := newMemStore()
+	res := &Resources{Logger: testLogger(), payloadStore: store}
+
+	var published *envelope.Envelope
+	publish := func(_ context.Context, env *envelope.Envelope) error {
+		published = env
+		return nil
+	}
+	ps := newPublishStream(publish, res)
+
+	payload := bytes.Repeat([]byte("S"), 5000)
+	env := mkEnv(nil)
+	env.ContentType = "text/csv"
+
+	if err := ps(context.Background(), env, bytes.NewReader(payload)); err != nil {
+		t.Fatalf("publishStream: %v", err)
+	}
+	if published == nil {
+		t.Fatal("envelope was not published")
+	}
+	if published.Payload != nil {
+		t.Errorf("published envelope must not carry the payload (%d bytes)", len(published.Payload))
+	}
+	if published.PayloadRef == "" {
+		t.Fatal("PayloadRef should be set")
+	}
+	if published.PayloadSize != int64(len(payload)) {
+		t.Errorf("PayloadSize = %d, want %d", published.PayloadSize, len(payload))
+	}
+	if published.Checksum != payloadChecksum(payload) {
+		t.Errorf("Checksum = %q, want %q", published.Checksum, payloadChecksum(payload))
+	}
+	// The bytes really landed in the store.
+	if got := store.objects[published.PayloadRef]; !bytes.Equal(got, payload) {
+		t.Errorf("stored object mismatch: %d bytes", len(got))
+	}
+}
+
+func TestPublishStream_RequiresStoreAndID(t *testing.T) {
+	publish := func(context.Context, *envelope.Envelope) error { return nil }
+
+	// No store configured.
+	noStore := newPublishStream(publish, &Resources{Logger: testLogger()})
+	err := noStore(context.Background(), mkEnv(nil), strings.NewReader("x"))
+	if err == nil || !IsPermanent(err) {
+		t.Fatalf("expected a permanent error without a store, got %v", err)
+	}
+
+	// Store present but the envelope has no ID (would collide on the object key).
+	withStore := newPublishStream(publish, &Resources{Logger: testLogger(), payloadStore: newMemStore()})
+	env := mkEnv(nil)
+	env.ID = ""
+	if err := withStore(context.Background(), env, strings.NewReader("x")); err == nil || !IsPermanent(err) {
+		t.Fatalf("expected a permanent error for an empty envelope ID, got %v", err)
+	}
+}
+
+func TestDeliverStreamed_HandsOverStreamAndVerifies(t *testing.T) {
+	store := newMemStore()
+	payload := bytes.Repeat([]byte("D"), 4096)
+	env := mkEnv(payload)
+	if _, err := offloadIfLarge(context.Background(), store, env, 256, testLogger()); err != nil {
+		t.Fatalf("offload: %v", err)
+	}
+
+	var got []byte
+	err := deliverStreamed(context.Background(), store, env, func(_ context.Context, _ *envelope.Envelope, body io.Reader) error {
+		var rerr error
+		got, rerr = drain(t, body)
+		return rerr
+	})
+	if err != nil {
+		t.Fatalf("deliverStreamed: %v", err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Errorf("streamed payload mismatch: got %d bytes, want %d", len(got), len(payload))
+	}
+}
+
+func TestDeliverStreamed_CorruptObjectFailsTheRead(t *testing.T) {
+	store := newMemStore()
+	env := mkEnv(bytes.Repeat([]byte("D"), 4096))
+	if _, err := offloadIfLarge(context.Background(), store, env, 256, testLogger()); err != nil {
+		t.Fatalf("offload: %v", err)
+	}
+	// Corrupt the object after the checksum was stamped.
+	store.objects[env.PayloadRef] = bytes.Repeat([]byte("X"), 4096)
+
+	err := deliverStreamed(context.Background(), store, env, func(_ context.Context, _ *envelope.Envelope, body io.Reader) error {
+		_, rerr := io.ReadAll(body)
+		return rerr
+	})
+	if err == nil {
+		t.Fatal("expected the connector's read to fail on a corrupt object")
+	}
+	if !strings.Contains(err.Error(), "checksum mismatch") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestVerifyingReader_SkipsWhenNoChecksum(t *testing.T) {
+	// Envelopes published before checksums existed must still stream.
+	r := newVerifyingReader(io.NopCloser(strings.NewReader("legacy")), "")
+	got, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(got) != "legacy" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestErrStreamUnsupported_IsIdentifiable(t *testing.T) {
+	// Connectors wrap it; the SDK must still recognise it to fall back.
+	wrapped := errors.New("cloud: " + ErrStreamUnsupported.Error())
+	if errors.Is(wrapped, ErrStreamUnsupported) {
+		t.Fatal("a same-text error must NOT match — callers should return the sentinel")
+	}
+	if !errors.Is(ErrStreamUnsupported, ErrStreamUnsupported) {
+		t.Fatal("sentinel must match itself")
+	}
+}


### PR DESCRIPTION
The opt-in streaming path from [ADR 0001](docs/adr/0001-streaming-payload-contract.md), on top of the cap + checksum merged in #191. A connector that already holds an `io.Reader` can now move **multi-GB payloads with memory bounded by the copy buffer**.

## What's added

**`StreamingConsumer`** (`RunStream` + `PublishStreamFunc`) and **`StreamingProducer`** (`DeliverStream`) as **optional companions** — `Consumer`/`Producer` are untouched. The SDK type-asserts and falls back, so:
- the ~20 connectors dealing in small paginated records need **no changes**
- **no new node type**, nothing new in the UI, same images and deployments

Routing happens at chokepoints the SDK already owns: `RunConsumer` picks `RunStream`; `RunProducer` passes `DeliverStream` into `subscribeDispatch`, where an offloaded payload takes the stream path *instead of* rehydration — so the 128 MiB buffering cap simply doesn't apply to it.

**Integrity, for free:** `publishStream` hashes and counts through a `TeeReader` while the store consumes the reader, so `PayloadSize` and `Checksum` cost neither an extra pass nor a buffer. On delivery the stream is checksum-verified *as it is read*, so a corrupt object fails the connector's own read rather than delivering wrong data downstream.

**Guards:** streaming only activates when a payload store is configured; `publishStream` without one is a permanent error, as is an empty envelope ID (the object key derives from it — an empty one would collide across concurrent messages and silently overwrite payloads).

## `ErrStreamUnsupported` — a contract gap the first adopter surfaced

Writing the cloud-storage adopter exposed something the ADR hadn't anticipated: that producer can **fan out to several targets**, but a stream reads **once**. Neither obvious option was acceptable — buffering for N targets reintroduces the exact OOM this work prevents, and failing outright would **regress multi-target configs that work today** (fan-out + a 1–128 MB payload).

So `DeliverStream` may return `ErrStreamUnsupported` for a message it can't stream, and the SDK falls back to rehydrate + `Deliver` — behaviour identical to a non-streaming connector. Returning it is free (nothing has been read). **Capability is declared statically, applied per message.** The ADR is updated to record this.

## First adopter

`cloud-storage-producer` gains `DeliverStream`: a single target streams straight to the bucket; fan-out declines. Target selection is factored into `eligibleTargets` so both paths share it.

**Documented limitation:** when streaming, key templates lose payload-derived fields — the content hasn't been read, and reading it to name a key would defeat the purpose. Such a template falls back to a generated key with the existing warning.

## Not in scope

Filters/converters pass `nil` (no streaming) — record-streaming transforms are **phase 2**. Until then an over-cap payload at a transform is a clear DLQ error, per #191. Remaining phase-1 adopters (`file-*`, `sftp-consumer`, `http-producer`) are mechanical follow-ups now that the contract exists.

## Tests / verification

6 new tests: publishStream offloads + publishes a small envelope with correct size/checksum and the bytes really in the store; permanent errors without a store and without an ID; streamed delivery round-trip; **corrupt object fails the read**; no-checksum envelopes still stream; sentinel identity.

`go build ./...`, `go vet`, and the sdk / cloud-storage-{producer,consumer} / file-consumer / http-producer suites all pass. (Pre-existing gofmt-unclean files under `cmd/mock-sap` and `cmd/sap-s4hana-producer` remain untouched.)

Part of #187.

🤖 Generated with [Claude Code](https://claude.com/claude-code)