### PR TITLE
fix(envelope): generate an ID in New() — dedup and claim-check keys depend on it

### DIFF
--- a/src/pkg/envelope/envelope.go
+++ b/src/pkg/envelope/envelope.go
@@ -3,6 +3,8 @@ package envelope
 import (
 	"encoding/json"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 // Envelope represents a message as it flows through the VRSky pipeline.
@@ -41,9 +43,17 @@ type Envelope struct {
 	LastError  string `json:"last_error,omitempty"`
 }
 
-// New creates a new envelope with a generated ID and timestamps
+// New creates a new envelope with a generated ID and timestamps.
+//
+// The ID is not decoration. It is the JetStream dedup key (Nats-Msg-Id) and the
+// object key for claim-check payload offload (spill/<tenant>/<connection>/<id>),
+// so an envelope without one loses duplicate suppression AND collides with every
+// other offloaded payload on its connection. Callers may overwrite ID with their
+// own stable identifier (that is how a source's natural key gets dedup); they
+// must not clear it.
 func New() *Envelope {
 	return &Envelope{
+		ID:          uuid.NewString(),
 		CreatedAt:   time.Now(),
 		ExpiresAt:   time.Now().Add(15 * time.Minute), // 15-minute TTL by default
 		RetryCount:  0,

--- a/src/pkg/envelope/envelope_test.go
+++ b/src/pkg/envelope/envelope_test.go
@@ -1,0 +1,46 @@
+package envelope
+
+import "testing"
+
+// The envelope ID is the JetStream dedup key and the claim-check object key, so
+// "every new envelope has a unique ID" is a correctness invariant, not a nicety:
+// an empty ID disables duplicate suppression and makes every offloaded payload
+// on a connection collide at spill/<tenant>/<connection>/.
+func TestNew_GeneratesUniqueID(t *testing.T) {
+	seen := make(map[string]bool, 100)
+	for i := 0; i < 100; i++ {
+		e := New()
+		if e.ID == "" {
+			t.Fatal("New() must generate an ID")
+		}
+		if seen[e.ID] {
+			t.Fatalf("duplicate ID generated: %s", e.ID)
+		}
+		seen[e.ID] = true
+	}
+}
+
+func TestNew_IDSurvivesRoundTrip(t *testing.T) {
+	e := New()
+	e.TenantID = "tenant-x"
+	b, err := Marshal(e)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	got, err := Unmarshal(b)
+	if err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if got.ID != e.ID {
+		t.Errorf("ID = %q after round-trip, want %q", got.ID, e.ID)
+	}
+}
+
+// Callers may substitute a source's natural key so dedup keys off it.
+func TestNew_IDIsOverridable(t *testing.T) {
+	e := New()
+	e.ID = "order-42"
+	if e.ID != "order-42" {
+		t.Errorf("ID = %q", e.ID)
+	}
+}


### PR DESCRIPTION
Found while implementing the next ADR 0001 adopter. `envelope.New()`'s doc comment has **always** promised "a generated ID" — the implementation never generated one.

**14 connectors** call `New()` and never set `ID` themselves (only the `pkg/io` inputs do), so their envelopes travel with `ID: ""`.

## Two consequences

**1. JetStream dedup is silently disabled** for those connectors. `Publisher.Publish` only sets the `Nats-Msg-Id` header when `msgID != ""`, so duplicate suppression simply never engages. Pre-existing, quiet, easy to miss.

**2. Claim-check payload offload collides — and this one is new.** The spill object key is `spill/<tenant>/<connection>/<id>` (#187). With an empty ID, **every offloaded payload on a connection writes to the same key**, so a second large object overwrites one still in flight. This is reachable now that the offload store is configured for workers — a live bug for any of those 14 connectors handling payloads over the inline threshold.

Worth noting: the checksum added in #191 turns that collision into a **loud** failure (mismatch → retriable → DLQ) instead of silently wrong data downstream. That's the integrity check earning its keep — but the collision itself still has to go.

## Fix

`New()` generates a UUID. Connectors wanting dedup keyed on a source's natural identifier still override `ID` afterwards — that's the intended pattern, now documented on `New()` along with why *clearing* it isn't an option.

## Verification

- 3 new tests: uniqueness across 100 envelopes, ID survives marshal round-trip, ID remains overridable.
- **Full-repo sweep: 56 packages pass.** The three `pkg/io` file-producer failures are **pre-existing and environmental** (macOS `/var` → `/private/var` symlink tripping the path-traversal guard) — confirmed byte-identical on a clean tree with my changes stashed, so they are not from this PR.

Part of #187 — and a prerequisite for the remaining streaming adopters, since `publishStream` requires a non-empty ID to key the object.

🤖 Generated with [Claude Code](https://claude.com/claude-code)