### PR TITLE
feat(cloud-storage): stream large objects on ingest (completes storage→storage multi-GB)

### DIFF
--- a/src/cmd/cloud-storage-consumer/service.go
+++ b/src/cmd/cloud-storage-consumer/service.go
@@ -384,7 +384,10 @@ func (s *cloudConsumer) ingestObject(ctx context.Context, connID, tenantID strin
 // multi-GB object transfers with a bounded buffer instead of being read into
 // memory whole. Returns the payload size and whether the streaming path was used.
 func (s *cloudConsumer) fetchAndPublish(ctx context.Context, connID, tenantID string, store objectstore.ObjectStore, cfg *cloudConfig, key string) (int64, bool, error) {
-	if s.publishStream == nil {
+	// inlineMax <= 0 means the SDK has offload switched off entirely (everything
+	// travels inline), so streaming here would contradict that configuration —
+	// and a negative value would panic when sizing the peek buffer below.
+	if s.publishStream == nil || s.inlineMax <= 0 {
 		data, ct, err := store.Get(ctx, key)
 		if err != nil {
 			return 0, false, fmt.Errorf("get: %w", err)

--- a/src/cmd/cloud-storage-consumer/service.go
+++ b/src/cmd/cloud-storage-consumer/service.go
@@ -1,11 +1,13 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"path"
 	"strings"
@@ -32,6 +34,13 @@ type cloudConsumer struct {
 	nc      *nats.Conn
 	publish sdk.PublishFunc
 	logger  *slog.Logger
+
+	// publishStream is non-nil only when the SDK selected the streaming path
+	// (ADR 0001) — i.e. this worker has a payload store. inlineMax is the size
+	// above which the SDK would offload anyway, so it's the point where reading
+	// the object into memory stops being worthwhile.
+	publishStream sdk.PublishStreamFunc
+	inlineMax     int
 
 	// newStore opens an ObjectStore. Defaulted to objectstore.New in Configure;
 	// tests inject a fake so the poller runs without a live bucket.
@@ -90,6 +99,7 @@ func (s *cloudConsumer) Configure(ctx context.Context, res *sdk.Resources) error
 	s.db = res.DB
 	s.nc = res.NATS
 	s.logger = res.Logger
+	s.inlineMax = res.InlineMaxBytes()
 	s.active = make(map[string]context.CancelFunc)
 	if s.newStore == nil {
 		s.newStore = objectstore.New
@@ -101,6 +111,15 @@ func (s *cloudConsumer) Configure(ctx context.Context, res *sdk.Resources) error
 	s.RegisterHTTPHandler("/sample-data/", s.handleSampleData())
 	res.Health.SetReady(true)
 	return nil
+}
+
+// RunStream is Run with the large-payload streaming path enabled (ADR 0001).
+// The SDK calls it instead of Run when a payload store is configured; ingest
+// then streams objects larger than the inline threshold straight from the
+// bucket into the pipeline, so a multi-GB object is never held in memory.
+func (s *cloudConsumer) RunStream(ctx context.Context, publish sdk.PublishFunc, publishStream sdk.PublishStreamFunc) error {
+	s.publishStream = publishStream
+	return s.Run(ctx, publish)
 }
 
 // Run subscribes to the connection command subjects and blocks until ctx is
@@ -349,21 +368,70 @@ func (s *cloudConsumer) runEventLoop(ctx context.Context, connID, tenantID strin
 // ingestObject fetches one object, publishes it into the pipeline, and applies
 // the after-action. Shared by poll and event modes.
 func (s *cloudConsumer) ingestObject(ctx context.Context, connID, tenantID string, store objectstore.ObjectStore, cfg *cloudConfig, key string, logger *slog.Logger) error {
-	data, ct, err := store.Get(ctx, key)
+	size, streamed, err := s.fetchAndPublish(ctx, connID, tenantID, store, cfg, key)
 	if err != nil {
-		return fmt.Errorf("get: %w", err)
+		return err
 	}
-	if ct == "" {
-		ct = detectContentType(path.Base(key), data)
-	}
-	if err := s.publishObject(ctx, connID, tenantID, cfg.Bucket, key, ct, data); err != nil {
-		return fmt.Errorf("publish: %w", err)
-	}
-	logger.Info("cloud-storage object ingested", "key", key, "size", len(data))
+	logger.Info("cloud-storage object ingested", "key", key, "size", size, "streamed", streamed)
 	if err := s.afterAction(ctx, store, cfg, key); err != nil {
 		logger.Warn("after-action failed", "key", key, "action", cfg.AfterAction, "error", err)
 	}
 	return nil
+}
+
+// fetchAndPublish reads one object and publishes it, streaming when this worker
+// supports it and the object is larger than the inline threshold — so a
+// multi-GB object transfers with a bounded buffer instead of being read into
+// memory whole. Returns the payload size and whether the streaming path was used.
+func (s *cloudConsumer) fetchAndPublish(ctx context.Context, connID, tenantID string, store objectstore.ObjectStore, cfg *cloudConfig, key string) (int64, bool, error) {
+	if s.publishStream == nil {
+		data, ct, err := store.Get(ctx, key)
+		if err != nil {
+			return 0, false, fmt.Errorf("get: %w", err)
+		}
+		if ct == "" {
+			ct = detectContentType(path.Base(key), data)
+		}
+		if err := s.publishObject(ctx, connID, tenantID, cfg.Bucket, key, ct, data); err != nil {
+			return 0, false, fmt.Errorf("publish: %w", err)
+		}
+		return int64(len(data)), false, nil
+	}
+
+	rc, ct, err := store.GetStream(ctx, key)
+	if err != nil {
+		return 0, false, fmt.Errorf("get: %w", err)
+	}
+	defer rc.Close()
+
+	// Read up to one byte past the inline threshold. That single read answers
+	// both questions: whether the object is small enough to publish inline, and
+	// what bytes detectContentType should sniff. Nothing larger is ever buffered.
+	head := make([]byte, s.inlineMax+1)
+	n, rerr := io.ReadFull(rc, head)
+	if rerr != nil && !errors.Is(rerr, io.EOF) && !errors.Is(rerr, io.ErrUnexpectedEOF) {
+		return 0, false, fmt.Errorf("read: %w", rerr)
+	}
+	head = head[:n]
+	if ct == "" {
+		ct = detectContentType(path.Base(key), head)
+	}
+
+	if n <= s.inlineMax {
+		// Whole object already in hand — take the normal path so small objects
+		// keep behaving exactly as before (including the UI preview).
+		if err := s.publishObject(ctx, connID, tenantID, cfg.Bucket, key, ct, head); err != nil {
+			return 0, false, fmt.Errorf("publish: %w", err)
+		}
+		return int64(n), false, nil
+	}
+
+	env := s.newObjectEnvelope(connID, tenantID, cfg.Bucket, key, ct)
+	body := io.MultiReader(bytes.NewReader(head), rc)
+	if err := s.publishStream(ctx, env, body); err != nil {
+		return 0, false, fmt.Errorf("publish stream: %w", err)
+	}
+	return env.PayloadSize, true, nil
 }
 
 // finishConn marks the connection's terminal status and removes it from the
@@ -394,16 +462,24 @@ func (s *cloudConsumer) afterAction(ctx context.Context, store objectstore.Objec
 	}
 }
 
-func (s *cloudConsumer) publishObject(ctx context.Context, connID, tenantID, bucket, key, contentType string, data []byte) error {
+// newObjectEnvelope builds the envelope for one ingested object, minus the
+// payload — shared by the inline and streaming paths so both carry identical
+// metadata.
+func (s *cloudConsumer) newObjectEnvelope(connID, tenantID, bucket, key, contentType string) *envelope.Envelope {
 	env := envelope.New()
 	env.TenantID = tenantID
 	env.IntegrationID = connID
 	env.ContentType = contentType
 	env.Source = "cloud-storage:" + key
-	env.Payload = data
-	env.PayloadSize = int64(len(data))
 	env.StepHistory = []string{"cloud-storage-consumer"}
 	env.Metadata = map[string]interface{}{"object_key": key, "bucket": bucket, "filename": path.Base(key)}
+	return env
+}
+
+func (s *cloudConsumer) publishObject(ctx context.Context, connID, tenantID, bucket, key, contentType string, data []byte) error {
+	env := s.newObjectEnvelope(connID, tenantID, bucket, key, contentType)
+	env.Payload = data
+	env.PayloadSize = int64(len(data))
 	return s.publish(ctx, env)
 }
 

--- a/src/cmd/cloud-storage-consumer/streaming_test.go
+++ b/src/cmd/cloud-storage-consumer/streaming_test.go
@@ -147,6 +147,30 @@ func TestFetchAndPublish_NoStreamingFallsBackToBufferedGet(t *testing.T) {
 	}
 }
 
+// PAYLOAD_INLINE_MAX_BYTES <= 0 switches offload off in the SDK (everything
+// inline), so the connector must not stream either — and must not panic sizing a
+// peek buffer from a negative threshold.
+func TestFetchAndPublish_OffloadDisabledStaysInline(t *testing.T) {
+	payload := bytes.Repeat([]byte("B"), 512)
+	for _, inlineMax := range []int{0, -1, -512} {
+		store := &fakeStore{objects: map[string][]byte{"in/big.bin": payload}}
+		probe := &ingestProbe{}
+		s := newTestConsumer(probe, inlineMax, true) // publishStream IS available
+
+		_, streamed, err := s.fetchAndPublish(context.Background(), "conn-1", "tenant-x",
+			store, &cloudConfig{}, "in/big.bin")
+		if err != nil {
+			t.Fatalf("inlineMax=%d: %v", inlineMax, err)
+		}
+		if streamed {
+			t.Errorf("inlineMax=%d: offload is disabled, nothing should stream", inlineMax)
+		}
+		if probe.inline == nil || !bytes.Equal(probe.inline.Payload, payload) {
+			t.Errorf("inlineMax=%d: expected the whole object published inline", inlineMax)
+		}
+	}
+}
+
 // Content type is sniffed from the peeked head, so a streamed object is still
 // typed even though it was never fully read into memory.
 func TestFetchAndPublish_StreamedObjectSniffsContentTypeFromHead(t *testing.T) {

--- a/src/cmd/cloud-storage-consumer/streaming_test.go
+++ b/src/cmd/cloud-storage-consumer/streaming_test.go
@@ -1,0 +1,166 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/ValueRetail/vrsky/pkg/envelope"
+	"github.com/ValueRetail/vrsky/pkg/sdk"
+)
+
+// ingestProbe records which publish path an object took.
+type ingestProbe struct {
+	inline     *envelope.Envelope
+	streamed   *envelope.Envelope
+	streamBody []byte
+}
+
+func (p *ingestProbe) publish(_ context.Context, env *envelope.Envelope) error {
+	p.inline = env
+	return nil
+}
+
+func (p *ingestProbe) publishStream(_ context.Context, env *envelope.Envelope, body io.Reader) error {
+	b, err := io.ReadAll(body)
+	if err != nil {
+		return err
+	}
+	p.streamed = env
+	p.streamBody = b
+	// The SDK stamps the size after streaming; mimic that so callers see it.
+	env.PayloadSize = int64(len(b))
+	return nil
+}
+
+// newTestConsumer builds a consumer wired to the probe. streaming=false models a
+// worker with no payload store configured.
+func newTestConsumer(probe *ingestProbe, inlineMax int, streaming bool) *cloudConsumer {
+	s := &cloudConsumer{
+		logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+		publish:   probe.publish,
+		inlineMax: inlineMax,
+	}
+	if streaming {
+		s.publishStream = sdk.PublishStreamFunc(probe.publishStream)
+	}
+	return s
+}
+
+func TestFetchAndPublish_LargeObjectStreams(t *testing.T) {
+	const inlineMax = 64
+	payload := bytes.Repeat([]byte("L"), inlineMax*4)
+	store := &fakeStore{objects: map[string][]byte{"in/big.bin": payload}}
+	probe := &ingestProbe{}
+	s := newTestConsumer(probe, inlineMax, true)
+
+	size, streamed, err := s.fetchAndPublish(context.Background(), "conn-1", "tenant-x",
+		store, &cloudConfig{}, "in/big.bin")
+	if err != nil {
+		t.Fatalf("fetchAndPublish: %v", err)
+	}
+	if !streamed {
+		t.Error("an object over the inline threshold should stream")
+	}
+	if probe.inline != nil {
+		t.Error("the inline publish path must not be used for a streamed object")
+	}
+	if !bytes.Equal(probe.streamBody, payload) {
+		t.Errorf("streamed %d bytes, want %d", len(probe.streamBody), len(payload))
+	}
+	if size != int64(len(payload)) {
+		t.Errorf("size = %d, want %d", size, len(payload))
+	}
+	// Metadata must survive the streaming path.
+	if probe.streamed.ID == "" {
+		t.Error("streamed envelope needs an ID (it keys the spill object)")
+	}
+	if probe.streamed.Metadata["object_key"] != "in/big.bin" {
+		t.Errorf("metadata lost: %+v", probe.streamed.Metadata)
+	}
+}
+
+func TestFetchAndPublish_SmallObjectStaysInline(t *testing.T) {
+	const inlineMax = 64
+	payload := []byte(`{"small":true}`)
+	store := &fakeStore{objects: map[string][]byte{"in/small.json": payload}}
+	probe := &ingestProbe{}
+	s := newTestConsumer(probe, inlineMax, true)
+
+	size, streamed, err := s.fetchAndPublish(context.Background(), "conn-1", "tenant-x",
+		store, &cloudConfig{}, "in/small.json")
+	if err != nil {
+		t.Fatalf("fetchAndPublish: %v", err)
+	}
+	if streamed || probe.streamed != nil {
+		t.Error("an object under the inline threshold must not stream")
+	}
+	if probe.inline == nil || !bytes.Equal(probe.inline.Payload, payload) {
+		t.Error("expected the object to be published inline, intact")
+	}
+	if size != int64(len(payload)) {
+		t.Errorf("size = %d, want %d", size, len(payload))
+	}
+}
+
+// An object exactly at the threshold is small — the boundary must not stream.
+func TestFetchAndPublish_ExactlyAtThresholdStaysInline(t *testing.T) {
+	const inlineMax = 64
+	payload := bytes.Repeat([]byte("E"), inlineMax)
+	store := &fakeStore{objects: map[string][]byte{"in/edge.bin": payload}}
+	probe := &ingestProbe{}
+	s := newTestConsumer(probe, inlineMax, true)
+
+	_, streamed, err := s.fetchAndPublish(context.Background(), "conn-1", "tenant-x",
+		store, &cloudConfig{}, "in/edge.bin")
+	if err != nil {
+		t.Fatalf("fetchAndPublish: %v", err)
+	}
+	if streamed {
+		t.Error("a payload exactly at the inline threshold should stay inline")
+	}
+	if probe.inline == nil || len(probe.inline.Payload) != inlineMax {
+		t.Error("expected the whole object inline")
+	}
+}
+
+// Without a payload store the SDK never supplies publishStream, so a large
+// object still takes the buffered path — behaviour unchanged from before.
+func TestFetchAndPublish_NoStreamingFallsBackToBufferedGet(t *testing.T) {
+	payload := bytes.Repeat([]byte("B"), 512)
+	store := &fakeStore{objects: map[string][]byte{"in/big.bin": payload}}
+	probe := &ingestProbe{}
+	s := newTestConsumer(probe, 64, false) // no publishStream
+
+	_, streamed, err := s.fetchAndPublish(context.Background(), "conn-1", "tenant-x",
+		store, &cloudConfig{}, "in/big.bin")
+	if err != nil {
+		t.Fatalf("fetchAndPublish: %v", err)
+	}
+	if streamed {
+		t.Error("a worker without a payload store cannot stream")
+	}
+	if probe.inline == nil || !bytes.Equal(probe.inline.Payload, payload) {
+		t.Error("expected the buffered path to publish the whole object")
+	}
+}
+
+// Content type is sniffed from the peeked head, so a streamed object is still
+// typed even though it was never fully read into memory.
+func TestFetchAndPublish_StreamedObjectSniffsContentTypeFromHead(t *testing.T) {
+	const inlineMax = 16
+	payload := append([]byte("{"), bytes.Repeat([]byte("x"), inlineMax*4)...)
+	store := &fakeStore{objects: map[string][]byte{"in/big": payload}}
+	probe := &ingestProbe{}
+	s := newTestConsumer(probe, inlineMax, true)
+
+	if _, streamed, err := s.fetchAndPublish(context.Background(), "conn-1", "tenant-x",
+		store, &cloudConfig{}, "in/big"); err != nil || !streamed {
+		t.Fatalf("expected a streamed ingest, got streamed=%v err=%v", streamed, err)
+	}
+	if probe.streamed.ContentType != "application/json" {
+		t.Errorf("ContentType = %q, want application/json (sniffed from the head)", probe.streamed.ContentType)
+	}
+}

--- a/src/pkg/envelope/envelope.go
+++ b/src/pkg/envelope/envelope.go
@@ -3,6 +3,8 @@ package envelope
 import (
 	"encoding/json"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 // Envelope represents a message as it flows through the VRSky pipeline.
@@ -41,9 +43,17 @@ type Envelope struct {
 	LastError  string `json:"last_error,omitempty"`
 }
 
-// New creates a new envelope with a generated ID and timestamps
+// New creates a new envelope with a generated ID and timestamps.
+//
+// The ID is not decoration. It is the JetStream dedup key (Nats-Msg-Id) and the
+// object key for claim-check payload offload (spill/<tenant>/<connection>/<id>),
+// so an envelope without one loses duplicate suppression AND collides with every
+// other offloaded payload on its connection. Callers may overwrite ID with their
+// own stable identifier (that is how a source's natural key gets dedup); they
+// must not clear it.
 func New() *Envelope {
 	return &Envelope{
+		ID:          uuid.NewString(),
 		CreatedAt:   time.Now(),
 		ExpiresAt:   time.Now().Add(15 * time.Minute), // 15-minute TTL by default
 		RetryCount:  0,

--- a/src/pkg/envelope/envelope_test.go
+++ b/src/pkg/envelope/envelope_test.go
@@ -1,0 +1,46 @@
+package envelope
+
+import "testing"
+
+// The envelope ID is the JetStream dedup key and the claim-check object key, so
+// "every new envelope has a unique ID" is a correctness invariant, not a nicety:
+// an empty ID disables duplicate suppression and makes every offloaded payload
+// on a connection collide at spill/<tenant>/<connection>/.
+func TestNew_GeneratesUniqueID(t *testing.T) {
+	seen := make(map[string]bool, 100)
+	for i := 0; i < 100; i++ {
+		e := New()
+		if e.ID == "" {
+			t.Fatal("New() must generate an ID")
+		}
+		if seen[e.ID] {
+			t.Fatalf("duplicate ID generated: %s", e.ID)
+		}
+		seen[e.ID] = true
+	}
+}
+
+func TestNew_IDSurvivesRoundTrip(t *testing.T) {
+	e := New()
+	e.TenantID = "tenant-x"
+	b, err := Marshal(e)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	got, err := Unmarshal(b)
+	if err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if got.ID != e.ID {
+		t.Errorf("ID = %q after round-trip, want %q", got.ID, e.ID)
+	}
+}
+
+// Callers may substitute a source's natural key so dedup keys off it.
+func TestNew_IDIsOverridable(t *testing.T) {
+	e := New()
+	e.ID = "order-42"
+	if e.ID != "order-42" {
+		t.Errorf("ID = %q", e.ID)
+	}
+}

--- a/src/pkg/sdk/base.go
+++ b/src/pkg/sdk/base.go
@@ -34,8 +34,11 @@ type Resources struct {
 	Health *healthToggle
 
 	// payloadStore + inlineMaxBytes drive the large-payload claim-check (see
-	// payloadstore.go). Unexported so connectors don't couple to them — only the
-	// SDK publish/consume path uses them. payloadStore is nil when unconfigured.
+	// payloadstore.go). Unexported so connectors can't reach the store or rewrite
+	// the thresholds — offload policy stays owned by the SDK publish/consume path.
+	// payloadStore is nil when unconfigured. The threshold alone is readable via
+	// InlineMaxBytes(), which a streaming connector needs to branch at the same
+	// point the SDK does.
 	payloadStore      objectstore.ObjectStore
 	inlineMaxBytes    int
 	rehydrateMaxBytes int64

--- a/src/pkg/sdk/base.go
+++ b/src/pkg/sdk/base.go
@@ -41,6 +41,14 @@ type Resources struct {
 	rehydrateMaxBytes int64
 }
 
+// InlineMaxBytes reports the payload size above which the SDK offloads to the
+// payload store instead of putting the bytes on the message bus. A streaming
+// connector uses it to decide when streaming is worth it: at or below this size
+// the plain publish path is simpler and keeps the UI's data-structure preview
+// working, above it the payload would be offloaded anyway, so streaming avoids
+// ever holding it in memory.
+func (r *Resources) InlineMaxBytes() int { return r.inlineMaxBytes }
+
 // healthToggle is the narrow slice of the health server connectors may touch.
 type healthToggle struct {
 	setReady func(bool)


### PR DESCRIPTION
Completes the **storage → storage multi-GB path**. The producer already streams (#192); with this, a `cloud-storage → cloud-storage` pipeline moves an object of any size without either worker ever holding it in memory.

> **Branch note:** this branch is stacked on `fix/envelope-id`, so its diff currently also contains the `envelope.New()` commit from #193. That was a branching mistake on my part, not a design choice. It is harmless: merge #193 first and this PR's diff reduces to only its own changes. The dependency is real either way — `publishStream` keys the spill object on `env.ID`, and this connector never set one, so a test here asserts a non-empty ID.

## What changed

`cloud-storage-consumer` implements `StreamingConsumer`. `RunStream` just captures `publishStream` and delegates to `Run`, so the polling/event machinery is untouched.

Ingest now **peeks one byte past the inline threshold** and branches on that single read, which answers both questions at once:

- **at or below** the threshold → the whole object is already in hand, so it takes the existing inline path. Small objects behave exactly as before, UI preview included.
- **above** it → the object streams via `MultiReader(head, rest)` and is never fully buffered.

The peeked head also feeds `detectContentType`, so a streamed object is still correctly typed without reading it. Previously objects were fetched with `store.Get` — the entire object into memory — which is precisely the OOM this removes.

When offload is switched off entirely (`PAYLOAD_INLINE_MAX_BYTES <= 0`) the connector stays on the buffered path, so it never contradicts the operator's configuration.

## Small SDK addition

`sdk.Resources` gains `InlineMaxBytes()`, so a streaming connector uses the SDK's *actual* threshold rather than guessing one. Below it the payload travels inline anyway; above it the SDK would offload regardless — so that's exactly the point where buffering stops being worthwhile. Guessing would have created a gap where objects are offloaded (losing the UI preview) purely because the connector picked a different number.

Envelope construction is factored into `newObjectEnvelope`, shared by both paths, so metadata can't drift between them.

## Tests

6 new: large object streams **and never touches the inline path**; small stays inline; **exactly at the threshold** stays inline (boundary); a worker without a payload store still uses the buffered path unchanged; **offload disabled (0, -1, -512) stays inline** without panicking on the peek buffer; content type is sniffed from the head of a streamed object.

`go build ./...`, `go vet`, and the cloud-storage-{consumer,producer} / sdk / envelope suites pass.

## Remaining ADR 0001 adopters

`file-consumer`/`file-producer` and `sftp-consumer` are mechanical. **`http-producer` needs design thought**: it rebuilds the request body per retry attempt, and a stream can't be re-read — the same class of problem as the fan-out case that produced `ErrStreamUnsupported`.

Part of #187.

🤖 Generated with [Claude Code](https://claude.com/claude-code)