### PR TITLE
feat(file,sftp): stream large files on ingest (ADR 0001 adopters)

### DIFF
--- a/src/cmd/file-consumer/server.go
+++ b/src/cmd/file-consumer/server.go
@@ -196,9 +196,12 @@ func (s *fileConsumer) ingestFile(ctx context.Context, ac *ActiveConnection, fil
 		return nil, err
 	}
 	// Cache last payload (the SDK publish path marshals the envelope itself;
-	// envelope.Marshal == json.Marshal — identical bytes).
-	if envData, mErr := json.Marshal(env); mErr == nil {
-		_, _ = s.db.Exec("UPDATE connections SET last_payload = $1 WHERE id = $2", envData, ac.ConnectionID)
+	// envelope.Marshal == json.Marshal — identical bytes). Opportunistic: a
+	// missing DB must not fail an ingest that already succeeded.
+	if s.db != nil {
+		if envData, mErr := json.Marshal(env); mErr == nil {
+			_, _ = s.db.Exec("UPDATE connections SET last_payload = $1 WHERE id = $2", envData, ac.ConnectionID)
+		}
 	}
 	return env, nil
 }

--- a/src/cmd/file-consumer/service.go
+++ b/src/cmd/file-consumer/service.go
@@ -1,18 +1,22 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
 	"sync"
 	"time"
 
+	"github.com/ValueRetail/vrsky/pkg/envelope"
 	"github.com/ValueRetail/vrsky/pkg/sdk"
+	"github.com/google/uuid"
 	"github.com/nats-io/nats.go"
 )
 
@@ -28,6 +32,14 @@ type fileConsumer struct {
 	nc      *nats.Conn
 	publish sdk.PublishFunc // injected by the runner; the one data-emit path
 	logger  *slog.Logger
+
+	// publishStream is non-nil only when the SDK selected the streaming path
+	// (ADR 0001) — i.e. this worker has a payload store. When it is available a
+	// watched file is streamed from disk rather than read into memory, which is
+	// what lifts the maxWatchFileBytes ceiling. inlineMax is the size above which
+	// the SDK offloads anyway, so it marks where buffering stops paying off.
+	publishStream sdk.PublishStreamFunc
+	inlineMax     int
 
 	baseDir  string // FILE_CONSUMER_BASE_DIR; default watch root when a node has no path
 	hostHome string // HOST_HOME; used to expand a leading ~ in node paths
@@ -45,7 +57,70 @@ type fileConsumer struct {
 
 // maxWatchFileBytes caps the size of a watched file the poller will read into
 // memory before publishing (mirrors the 32 MiB cap on the HTTP upload path).
+// It applies only to the buffered path: when the worker can stream (ADR 0001)
+// a file over the inline threshold is sent straight from disk and this ceiling
+// does not apply at all.
 const maxWatchFileBytes = 32 << 20
+
+// ingestWatchedFile publishes one newly-detected file, streaming it from disk
+// when the worker supports that and the file is over the inline threshold —
+// which is what allows files larger than maxWatchFileBytes to be ingested at
+// all. Returns the envelope, the file size, and whether it was streamed.
+func (s *fileConsumer) ingestWatchedFile(ctx context.Context, ac *ActiveConnection, name, path string) (*envelope.Envelope, int64, bool, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, 0, false, fmt.Errorf("stat: %w", err)
+	}
+	size := info.Size()
+
+	// Small enough to buffer, or no streaming available: existing behaviour,
+	// including the size ceiling that protects worker memory.
+	if s.publishStream == nil || s.inlineMax <= 0 || size <= int64(s.inlineMax) {
+		if size > maxWatchFileBytes {
+			return nil, size, false, fmt.Errorf("file exceeds the %d-byte limit and this worker cannot stream (no payload store configured)", int64(maxWatchFileBytes))
+		}
+		data, rerr := os.ReadFile(path)
+		if rerr != nil {
+			return nil, size, false, rerr
+		}
+		env, perr := s.ingestFile(ctx, ac, name, data, "watch:"+name)
+		return env, size, false, perr
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, size, false, fmt.Errorf("open: %w", err)
+	}
+	defer f.Close()
+
+	// Sniff the content type from a small head, then hand the whole file over as
+	// head + remainder so nothing is read twice and nothing is buffered.
+	head := make([]byte, contentSniffBytes)
+	n, rerr := io.ReadFull(f, head)
+	if rerr != nil && !errors.Is(rerr, io.EOF) && !errors.Is(rerr, io.ErrUnexpectedEOF) {
+		return nil, size, false, fmt.Errorf("read: %w", rerr)
+	}
+	head = head[:n]
+
+	env := &envelope.Envelope{
+		ID:            uuid.New().String(),
+		TenantID:      ac.TenantID,
+		IntegrationID: ac.ConnectionID,
+		ContentType:   detectContentType(name, head),
+		Source:        "watch:" + name,
+		StepHistory:   []string{"file-consumer"},
+		CreatedAt:     time.Now().UTC(),
+		Metadata:      map[string]interface{}{"filename": name},
+	}
+	if err := s.publishStream(ctx, env, io.MultiReader(bytes.NewReader(head), f)); err != nil {
+		return nil, size, true, err
+	}
+	return env, size, true, nil
+}
+
+// contentSniffBytes is how much of a streamed file is read up front to detect
+// its content type — enough for detectContentType, small enough to be free.
+const contentSniffBytes = 512
 
 // FileEvent represents an activity event for the UI
 type FileEvent struct {
@@ -74,6 +149,7 @@ func (s *fileConsumer) Configure(ctx context.Context, res *sdk.Resources) error 
 	s.db = res.DB
 	s.nc = res.NATS
 	s.logger = res.Logger
+	s.inlineMax = res.InlineMaxBytes()
 	s.activeConnections = make(map[string]*ActiveConnection)
 	s.eventSubs = make(map[string][]chan FileEvent)
 	s.baseDir = getEnv("FILE_CONSUMER_BASE_DIR", "/data/input")
@@ -89,6 +165,15 @@ func (s *fileConsumer) Configure(ctx context.Context, res *sdk.Resources) error 
 
 // Run subscribes to the connection command subjects and blocks until the runner
 // cancels ctx. Per-connection directory watching is driven from the handlers.
+// RunStream is Run with large-file streaming enabled (ADR 0001). The SDK calls
+// it instead of Run when a payload store is configured; watched files above the
+// inline threshold are then streamed from disk into the pipeline, so size is
+// bounded by the copy buffer rather than by worker memory.
+func (s *fileConsumer) RunStream(ctx context.Context, publish sdk.PublishFunc, publishStream sdk.PublishStreamFunc) error {
+	s.publishStream = publishStream
+	return s.Run(ctx, publish)
+}
+
 func (s *fileConsumer) Run(ctx context.Context, publish sdk.PublishFunc) error {
 	s.publish = publish
 	s.logger.Info("Starting File Consumer Service")
@@ -278,35 +363,18 @@ func (s *fileConsumer) watchDirectory(ctx context.Context, ac *ActiveConnection)
 				}
 				logger.Info("File added", "file", name)
 				path := filepath.Join(ac.WatchDir, name)
-				if info, statErr := os.Stat(path); statErr == nil && info.Size() > maxWatchFileBytes {
-					logger.Error("Skipping oversized file", "file", name, "size", info.Size(), "limit", maxWatchFileBytes)
+				env, size, streamed, ingErr := s.ingestWatchedFile(ctx, ac, name, path)
+				if ingErr != nil {
+					logger.Error("Failed to ingest detected file", "file", name, "error", ingErr)
 					s.emitEvent(ac.ConnectionID, FileEvent{
-						Type: "error", Filename: name, Size: info.Size(),
-						Message: "file exceeds size limit", Time: time.Now().UTC().Format(time.RFC3339),
-					})
-					continue
-				}
-				data, readErr := os.ReadFile(path)
-				if readErr != nil {
-					logger.Error("Failed to read detected file", "file", name, "error", readErr)
-					s.emitEvent(ac.ConnectionID, FileEvent{
-						Type: "error", Filename: name, Message: readErr.Error(),
+						Type: "error", Filename: name, Size: size, Message: ingErr.Error(),
 						Time: time.Now().UTC().Format(time.RFC3339),
 					})
 					continue
 				}
-				env, pubErr := s.ingestFile(ctx, ac, name, data, "watch:"+name)
-				if pubErr != nil {
-					logger.Error("Failed to publish detected file", "file", name, "error", pubErr)
-					s.emitEvent(ac.ConnectionID, FileEvent{
-						Type: "error", Filename: name, Message: pubErr.Error(),
-						Time: time.Now().UTC().Format(time.RFC3339),
-					})
-					continue
-				}
-				logger.Info("File ingested from watch dir", "file", name, "size", len(data), "envelope_id", env.ID)
+				logger.Info("File ingested from watch dir", "file", name, "size", size, "streamed", streamed, "envelope_id", env.ID)
 				s.emitEvent(ac.ConnectionID, FileEvent{
-					Type: "added", Filename: name, Size: int64(len(data)),
+					Type: "added", Filename: name, Size: size,
 					Time: time.Now().UTC().Format(time.RFC3339),
 				})
 			}

--- a/src/cmd/file-consumer/streaming_test.go
+++ b/src/cmd/file-consumer/streaming_test.go
@@ -1,0 +1,147 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ValueRetail/vrsky/pkg/envelope"
+	"github.com/ValueRetail/vrsky/pkg/sdk"
+)
+
+type fileProbe struct {
+	inline     *envelope.Envelope
+	streamed   *envelope.Envelope
+	streamBody []byte
+}
+
+func (p *fileProbe) publish(_ context.Context, env *envelope.Envelope) error {
+	p.inline = env
+	return nil
+}
+
+func (p *fileProbe) publishStream(_ context.Context, env *envelope.Envelope, body io.Reader) error {
+	b, err := io.ReadAll(body)
+	if err != nil {
+		return err
+	}
+	p.streamed, p.streamBody = env, b
+	return nil
+}
+
+// newStreamingFileConsumer wires a consumer against the probe. db is left nil:
+// the buffered path's last_payload write is opportunistic and skipped without a
+// DB, and the streaming path never touches the DB at all.
+func newStreamingFileConsumer(probe *fileProbe, inlineMax int, streaming bool) *fileConsumer {
+	c := &fileConsumer{
+		logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+		publish:   probe.publish,
+		inlineMax: inlineMax,
+	}
+	if streaming {
+		c.publishStream = sdk.PublishStreamFunc(probe.publishStream)
+	}
+	return c
+}
+
+func writeTempFile(t *testing.T, name string, content []byte) (dir, path string) {
+	t.Helper()
+	dir = t.TempDir()
+	path = filepath.Join(dir, name)
+	if err := os.WriteFile(path, content, 0o600); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+	return dir, path
+}
+
+// The headline win: a file larger than maxWatchFileBytes used to be rejected
+// outright ("file exceeds size limit"). With streaming it is ingested.
+func TestIngestWatchedFile_OversizedFileStreamsInsteadOfBeingRejected(t *testing.T) {
+	const inlineMax = 64
+	content := bytes.Repeat([]byte("X"), maxWatchFileBytes+1024)
+	_, path := writeTempFile(t, "huge.csv", content)
+	probe := &fileProbe{}
+	c := newStreamingFileConsumer(probe, inlineMax, true)
+	ac := &ActiveConnection{ConnectionID: "conn-1", TenantID: "tenant-x"}
+
+	env, size, streamed, err := c.ingestWatchedFile(context.Background(), ac, "huge.csv", path)
+	if err != nil {
+		t.Fatalf("a file over maxWatchFileBytes should now stream, got: %v", err)
+	}
+	if !streamed {
+		t.Error("expected the streaming path")
+	}
+	if size != int64(len(content)) {
+		t.Errorf("size = %d, want %d", size, len(content))
+	}
+	if !bytes.Equal(probe.streamBody, content) {
+		t.Errorf("streamed %d bytes, want %d", len(probe.streamBody), len(content))
+	}
+	if env.ContentType != "text/csv" {
+		t.Errorf("ContentType = %q, want text/csv", env.ContentType)
+	}
+	if env.ID == "" {
+		t.Error("streamed envelope needs an ID (it keys the spill object)")
+	}
+}
+
+// Without streaming, an oversized file is still refused rather than read into
+// memory — the ceiling is only lifted when there is somewhere to stream to.
+func TestIngestWatchedFile_OversizedStillRefusedWithoutStreaming(t *testing.T) {
+	content := bytes.Repeat([]byte("X"), maxWatchFileBytes+1024)
+	_, path := writeTempFile(t, "huge.bin", content)
+	probe := &fileProbe{}
+	c := newStreamingFileConsumer(probe, 64, false) // no payload store
+	ac := &ActiveConnection{ConnectionID: "conn-1", TenantID: "tenant-x"}
+
+	_, size, streamed, err := c.ingestWatchedFile(context.Background(), ac, "huge.bin", path)
+	if err == nil {
+		t.Fatal("expected an oversized file to be refused without streaming")
+	}
+	if streamed {
+		t.Error("nothing should have been streamed")
+	}
+	if size != int64(len(content)) {
+		t.Errorf("size should still be reported for the error event, got %d", size)
+	}
+	if probe.inline != nil {
+		t.Error("the file must not have been read into memory")
+	}
+}
+
+func TestIngestWatchedFile_SmallFileStaysInline(t *testing.T) {
+	content := []byte(`{"id":1}`)
+	_, path := writeTempFile(t, "small.json", content)
+	probe := &fileProbe{}
+	c := newStreamingFileConsumer(probe, 1024, true)
+	ac := &ActiveConnection{ConnectionID: "conn-1", TenantID: "tenant-x"}
+
+	env, size, streamed, err := c.ingestWatchedFile(context.Background(), ac, "small.json", path)
+	if err != nil {
+		t.Fatalf("ingestWatchedFile: %v", err)
+	}
+	if streamed || probe.streamed != nil {
+		t.Error("a file under the inline threshold must not stream")
+	}
+	if probe.inline == nil || !bytes.Equal(probe.inline.Payload, content) {
+		t.Error("expected the file published inline, intact")
+	}
+	if size != int64(len(content)) || env == nil {
+		t.Errorf("size = %d, env = %v", size, env)
+	}
+}
+
+func TestIngestWatchedFile_MissingFileErrors(t *testing.T) {
+	probe := &fileProbe{}
+	c := newStreamingFileConsumer(probe, 1024, true)
+	ac := &ActiveConnection{ConnectionID: "conn-1", TenantID: "tenant-x"}
+
+	if _, _, _, err := c.ingestWatchedFile(context.Background(), ac,
+		"gone.json", filepath.Join(t.TempDir(), "gone.json")); err == nil {
+		t.Fatal("expected a stat error for a missing file")
+	}
+}

--- a/src/cmd/sftp-consumer/consumer_test.go
+++ b/src/cmd/sftp-consumer/consumer_test.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
+	"io"
 	"sync"
 	"testing"
 	"time"
@@ -33,6 +35,12 @@ func (f *fakeSFTP) Read(filePath string) ([]byte, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	return f.files[path_base(filePath)], nil
+}
+
+func (f *fakeSFTP) Open(filePath string) (io.ReadCloser, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return io.NopCloser(bytes.NewReader(f.files[path_base(filePath)])), nil
 }
 
 func (f *fakeSFTP) Remove(filePath string) error {

--- a/src/cmd/sftp-consumer/service.go
+++ b/src/cmd/sftp-consumer/service.go
@@ -1,11 +1,13 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"path"
 	"sync"
@@ -34,6 +36,13 @@ type sftpConsumer struct {
 	nc      *nats.Conn
 	publish sdk.PublishFunc
 	logger  *slog.Logger
+
+	// publishStream is non-nil only when the SDK selected the streaming path
+	// (ADR 0001) — i.e. this worker has a payload store. inlineMax is the size
+	// above which the SDK offloads anyway, so it marks where buffering a remote
+	// file into memory stops paying off.
+	publishStream sdk.PublishStreamFunc
+	inlineMax     int
 
 	// dial opens an SFTP connection. Defaulted to realDial in Configure; tests
 	// inject a fake so the poller runs without a live server.
@@ -86,6 +95,7 @@ func (s *sftpConsumer) Configure(ctx context.Context, res *sdk.Resources) error 
 	s.db = res.DB
 	s.nc = res.NATS
 	s.logger = res.Logger
+	s.inlineMax = res.InlineMaxBytes()
 	s.active = make(map[string]context.CancelFunc)
 	if s.dial == nil {
 		s.dial = realDial
@@ -94,6 +104,15 @@ func (s *sftpConsumer) Configure(ctx context.Context, res *sdk.Resources) error 
 	s.RegisterHTTPHandler("/sample-data/", s.handleSampleData())
 	res.Health.SetReady(true)
 	return nil
+}
+
+// RunStream is Run with large-file streaming enabled (ADR 0001). The SDK calls
+// it instead of Run when a payload store is configured; remote files over the
+// inline threshold are then streamed off the SFTP session straight into the
+// pipeline instead of being read into memory whole.
+func (s *sftpConsumer) RunStream(ctx context.Context, publish sdk.PublishFunc, publishStream sdk.PublishStreamFunc) error {
+	s.publishStream = publishStream
+	return s.Run(ctx, publish)
 }
 
 // Run subscribes to the connection command subjects and blocks until ctx is
@@ -266,18 +285,13 @@ func (s *sftpConsumer) pollOnce(ctx context.Context, connID, tenantID string, cf
 		}
 
 		remotePath := joinRemote(cfg.RemoteDir, f.Name)
-		data, err := conn.Read(remotePath)
+		streamed, err := s.fetchAndPublish(ctx, conn, connID, tenantID, f, remotePath)
 		if err != nil {
-			logger.Error("SFTP read failed", "file", f.Name, "error", err)
-			continue
-		}
-
-		if err := s.publishFile(ctx, connID, tenantID, f.Name, data); err != nil {
-			logger.Error("publish failed", "file", f.Name, "error", err)
+			logger.Error("SFTP ingest failed", "file", f.Name, "error", err)
 			continue // leave the file in place; retried next cycle
 		}
 		processed[f.Name] = true
-		logger.Info("SFTP file ingested", "file", f.Name, "size", len(data))
+		logger.Info("SFTP file ingested", "file", f.Name, "size", f.Size, "streamed", streamed)
 
 		if err := s.afterAction(conn, cfg, f.Name, remotePath); err != nil {
 			logger.Warn("after-action failed", "file", f.Name, "action", cfg.AfterAction, "error", err)
@@ -330,6 +344,55 @@ func (s *sftpConsumer) afterAction(conn sftpConn, cfg *SFTPConfig, name, remoteP
 		return nil
 	}
 }
+
+// fetchAndPublish reads one remote file and publishes it, streaming it off the
+// SFTP session when the worker supports that and the file is over the inline
+// threshold — so a multi-GB file is never held in memory. The size comes from
+// the directory listing, so no probing read is needed. Reports whether the
+// streaming path was used.
+func (s *sftpConsumer) fetchAndPublish(ctx context.Context, conn sftpConn, connID, tenantID string, f remoteFile, remotePath string) (bool, error) {
+	if s.publishStream == nil || s.inlineMax <= 0 || f.Size <= int64(s.inlineMax) {
+		data, err := conn.Read(remotePath)
+		if err != nil {
+			return false, fmt.Errorf("read: %w", err)
+		}
+		if err := s.publishFile(ctx, connID, tenantID, f.Name, data); err != nil {
+			return false, fmt.Errorf("publish: %w", err)
+		}
+		return false, nil
+	}
+
+	rc, err := conn.Open(remotePath)
+	if err != nil {
+		return false, fmt.Errorf("open: %w", err)
+	}
+	defer rc.Close()
+
+	// Sniff the content type from a small head, then stream head + remainder so
+	// nothing is read twice and nothing is buffered.
+	head := make([]byte, contentSniffBytes)
+	n, rerr := io.ReadFull(rc, head)
+	if rerr != nil && !errors.Is(rerr, io.EOF) && !errors.Is(rerr, io.ErrUnexpectedEOF) {
+		return false, fmt.Errorf("read: %w", rerr)
+	}
+	head = head[:n]
+
+	env := envelope.New()
+	env.TenantID = tenantID
+	env.IntegrationID = connID
+	env.ContentType = detectContentType(f.Name, head)
+	env.Source = "sftp:" + f.Name
+	env.StepHistory = []string{"sftp-consumer"}
+	env.Metadata = map[string]interface{}{"filename": f.Name}
+	if err := s.publishStream(ctx, env, io.MultiReader(bytes.NewReader(head), rc)); err != nil {
+		return true, fmt.Errorf("publish stream: %w", err)
+	}
+	return true, nil
+}
+
+// contentSniffBytes is how much of a streamed file is read up front to detect
+// its content type — enough for detectContentType, small enough to be free.
+const contentSniffBytes = 512
 
 func (s *sftpConsumer) publishFile(ctx context.Context, connID, tenantID, filename string, data []byte) error {
 	env := envelope.New()

--- a/src/cmd/sftp-consumer/sftp.go
+++ b/src/cmd/sftp-consumer/sftp.go
@@ -24,6 +24,10 @@ type remoteFile struct {
 type sftpConn interface {
 	List(dir string) ([]remoteFile, error)
 	Read(filePath string) ([]byte, error)
+	// Open returns the file as a stream for large transfers (ADR 0001); the
+	// caller must Close it. Read is the buffered equivalent, kept for small
+	// files and for workers with no payload store configured.
+	Open(filePath string) (io.ReadCloser, error)
 	Remove(filePath string) error
 	Rename(oldPath, newPath string) error
 	MkdirAll(dir string) error
@@ -62,6 +66,12 @@ func (r *realSFTP) Read(filePath string) ([]byte, error) {
 	}
 	defer f.Close()
 	return io.ReadAll(f)
+}
+
+// Open hands back the remote file as a stream, so a large transfer never has to
+// be materialised in worker memory the way Read does.
+func (r *realSFTP) Open(filePath string) (io.ReadCloser, error) {
+	return r.sftp.Open(filePath)
 }
 
 func (r *realSFTP) Remove(filePath string) error { return r.sftp.Remove(filePath) }

--- a/src/cmd/sftp-consumer/streaming_test.go
+++ b/src/cmd/sftp-consumer/streaming_test.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/ValueRetail/vrsky/pkg/envelope"
+	"github.com/ValueRetail/vrsky/pkg/sdk"
+)
+
+type sftpProbe struct {
+	inline     *envelope.Envelope
+	streamed   *envelope.Envelope
+	streamBody []byte
+}
+
+func (p *sftpProbe) publish(_ context.Context, env *envelope.Envelope) error {
+	p.inline = env
+	return nil
+}
+
+func (p *sftpProbe) publishStream(_ context.Context, env *envelope.Envelope, body io.Reader) error {
+	b, err := io.ReadAll(body)
+	if err != nil {
+		return err
+	}
+	p.streamed, p.streamBody = env, b
+	return nil
+}
+
+func newStreamingSFTPConsumer(probe *sftpProbe, inlineMax int, streaming bool) *sftpConsumer {
+	c := &sftpConsumer{
+		logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+		publish:   probe.publish,
+		inlineMax: inlineMax,
+	}
+	if streaming {
+		c.publishStream = sdk.PublishStreamFunc(probe.publishStream)
+	}
+	return c
+}
+
+func TestSFTPFetchAndPublish_LargeFileStreams(t *testing.T) {
+	const inlineMax = 32
+	payload := bytes.Repeat([]byte("L"), inlineMax*10)
+	fake := &fakeSFTP{files: map[string][]byte{"big.csv": payload}}
+	probe := &sftpProbe{}
+	c := newStreamingSFTPConsumer(probe, inlineMax, true)
+
+	streamed, err := c.fetchAndPublish(context.Background(), fake, "conn-1", "tenant-x",
+		remoteFile{Name: "big.csv", Size: int64(len(payload))}, "/in/big.csv")
+	if err != nil {
+		t.Fatalf("fetchAndPublish: %v", err)
+	}
+	if !streamed {
+		t.Error("a file over the inline threshold should stream")
+	}
+	if probe.inline != nil {
+		t.Error("the buffered publish path must not be used for a streamed file")
+	}
+	if !bytes.Equal(probe.streamBody, payload) {
+		t.Errorf("streamed %d bytes, want %d", len(probe.streamBody), len(payload))
+	}
+	if probe.streamed.ContentType != "text/csv" {
+		t.Errorf("ContentType = %q, want text/csv", probe.streamed.ContentType)
+	}
+	if probe.streamed.ID == "" {
+		t.Error("streamed envelope needs an ID (it keys the spill object)")
+	}
+	if probe.streamed.Metadata["filename"] != "big.csv" {
+		t.Errorf("metadata lost: %+v", probe.streamed.Metadata)
+	}
+}
+
+func TestSFTPFetchAndPublish_SmallFileStaysInline(t *testing.T) {
+	payload := []byte(`{"id":1}`)
+	fake := &fakeSFTP{files: map[string][]byte{"small.json": payload}}
+	probe := &sftpProbe{}
+	c := newStreamingSFTPConsumer(probe, 1024, true)
+
+	streamed, err := c.fetchAndPublish(context.Background(), fake, "conn-1", "tenant-x",
+		remoteFile{Name: "small.json", Size: int64(len(payload))}, "/in/small.json")
+	if err != nil {
+		t.Fatalf("fetchAndPublish: %v", err)
+	}
+	if streamed || probe.streamed != nil {
+		t.Error("a file under the inline threshold must not stream")
+	}
+	if probe.inline == nil || !bytes.Equal(probe.inline.Payload, payload) {
+		t.Error("expected the file published inline, intact")
+	}
+}
+
+// No payload store (or offload disabled) means the buffered path, unchanged.
+func TestSFTPFetchAndPublish_FallsBackWithoutStreaming(t *testing.T) {
+	payload := bytes.Repeat([]byte("B"), 4096)
+	for _, tc := range []struct {
+		name      string
+		inlineMax int
+		streaming bool
+	}{
+		{"no payload store", 32, false},
+		{"offload disabled", 0, true},
+		{"negative threshold", -8, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fake := &fakeSFTP{files: map[string][]byte{"big.bin": payload}}
+			probe := &sftpProbe{}
+			c := newStreamingSFTPConsumer(probe, tc.inlineMax, tc.streaming)
+
+			streamed, err := c.fetchAndPublish(context.Background(), fake, "conn-1", "tenant-x",
+				remoteFile{Name: "big.bin", Size: int64(len(payload))}, "/in/big.bin")
+			if err != nil {
+				t.Fatalf("fetchAndPublish: %v", err)
+			}
+			if streamed {
+				t.Error("must not stream")
+			}
+			if probe.inline == nil || !bytes.Equal(probe.inline.Payload, payload) {
+				t.Error("expected the buffered path to publish the whole file")
+			}
+		})
+	}
+}


### PR DESCRIPTION
Two more ADR 0001 adopters. Both connectors already held a reader and simply buffered it, so this mostly **deletes** buffering rather than adding machinery.

## file-consumer — a limitation becomes a capability

Previously a watched file over `maxWatchFileBytes` (32 MiB) was **rejected outright**: logged as `"file exceeds size limit"` and skipped. Not slow, not risky — *impossible*.

With a payload store configured, files over the inline threshold now stream from disk and that ceiling doesn't apply at all. Without a store the ceiling still stands, because there's nowhere to stream to and reading the file would be exactly the OOM the cap exists to prevent.

Ingest is factored into `ingestWatchedFile`, so the watch loop no longer inlines the stat/read/publish/error-event dance.

## sftp-consumer

`sftpConn` gains `Open()` alongside `Read()`; `realSFTP` just hands back the `sftp.File` it was already opening and discarding inside `io.ReadAll`. The file size comes from the directory listing, so routing needs no probing read.

## Shared approach

Both sniff the content type from a **512-byte head** and then publish `MultiReader(head, rest)` — nothing is read twice, nothing is buffered. Both stay on the buffered path when there's no payload store or when offload is disabled (`inlineMax <= 0`), so those configurations behave exactly as before.

## Incidental fix

Found while testing: file-consumer's `last_payload` cache is *documented* as best-effort but called `s.db.Exec` unconditionally, panicking on a nil DB. `Configure` requires a DB so production never hit this, but the write is opportunistic by intent — now it actually is.

## Tests

9 new. The ones that matter most:
- **oversized file streams instead of being rejected** — the headline case
- oversized **still refused without streaming**, and provably never read into memory
- small files stay inline; missing file errors
- sftp: large streams / small inline / falls back for no-store, zero, and negative thresholds

`go build ./...`, `go vet`, and the file-consumer / sftp-consumer / sdk suites pass.

## Remaining on #187

`file-producer` and **`http-producer`** — the latter needs a decision: it rebuilds the request body per retry attempt, and a stream can't be re-read. Likely answer is that JetStream redelivery *is* the retry (each redelivery re-opens the stream from object storage), but that changes backoff semantics, so it deserves a deliberate call rather than a quiet one. Then phase 2 (record-streaming transforms) and phase 3 (presigned URLs).

Part of #187.

🤖 Generated with [Claude Code](https://claude.com/claude-code)