### PR TITLE
feat(file-producer): stream large payloads to disk + fix symlinked-root path checks

### DIFF
--- a/src/cmd/file-producer/main.go
+++ b/src/cmd/file-producer/main.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"log/slog"
 	"net/http"
@@ -177,14 +178,7 @@ func (p *fileProducer) Deliver(ctx context.Context, env *envelope.Envelope) erro
 	}
 
 	var transient error
-	for _, config := range configs {
-		if config.PredIsConsumer && lastProcessedBy != "" {
-			continue
-		}
-		if !config.PredIsConsumer && config.PredecessorID != "" && lastProcessedBy != config.PredecessorID {
-			continue
-		}
-
+	for _, config := range p.eligibleConfigs(configs, lastProcessedBy) {
 		outputPath := config.OutputPath
 		if outputPath == "" {
 			outputPath = p.defaultOutputDir
@@ -193,7 +187,7 @@ func (p *fileProducer) Deliver(ctx context.Context, env *envelope.Envelope) erro
 			outputPath = filepath.Join(outputPath, config.FolderName)
 		}
 
-		if werr := p.writeFile(env, outputPath, config.FilePattern); werr != nil {
+		if werr := p.writeFile(env, outputPath, config.FilePattern, nil); werr != nil {
 			if errors.Is(werr, errPathNotAllowed) {
 				// Misconfiguration — don't burn the retry budget on it.
 				p.logger.Error("dropping: output path not allowed", "error", werr, "envelope_id", env.ID, "path", outputPath)
@@ -327,7 +321,79 @@ func (p *fileProducer) cacheConfigs(connectionID string, configs []*ConnectionCo
 }
 
 // writeFile writes the envelope payload to a file under outputPath.
-func (p *fileProducer) writeFile(env *envelope.Envelope, outputPath, filePattern string) error {
+// DeliverStream writes a large, offloaded payload straight from the pipeline's
+// object stream to disk, so a multi-GB file is written with a bounded buffer
+// instead of being held in memory (ADR 0001).
+//
+// A stream reads once, so writing the same payload to several configured output
+// directories is declined (sdk.ErrStreamUnsupported) and the SDK falls back to
+// buffered delivery — behaviour identical to before.
+func (p *fileProducer) DeliverStream(ctx context.Context, env *envelope.Envelope, body io.Reader) error {
+	connectionID := env.IntegrationID
+	if connectionID == "" {
+		return sdk.Permanent(fmt.Errorf("envelope %s has no integration_id; cannot route to a file config", env.ID))
+	}
+	configs, err := p.getConnectionConfigs(ctx, connectionID)
+	if err != nil {
+		return sdk.Retriable(fmt.Errorf("get connection config: %w", err))
+	}
+
+	lastProcessedBy := ""
+	if env.Metadata != nil {
+		if v, ok := env.Metadata["_last_processed_by"].(string); ok {
+			lastProcessedBy = v
+		}
+	}
+
+	eligible := p.eligibleConfigs(configs, lastProcessedBy)
+	if len(eligible) == 0 {
+		return nil
+	}
+	if len(eligible) > 1 {
+		return sdk.ErrStreamUnsupported
+	}
+
+	config := eligible[0]
+	outputPath := config.OutputPath
+	if outputPath == "" {
+		outputPath = p.defaultOutputDir
+	}
+	if config.FolderName != "" {
+		outputPath = filepath.Join(outputPath, config.FolderName)
+	}
+
+	if werr := p.writeFile(env, outputPath, config.FilePattern, body); werr != nil {
+		if errors.Is(werr, errPathNotAllowed) {
+			// Misconfiguration — retrying can't fix it.
+			p.logger.Error("dropping: output path not allowed", "error", werr, "envelope_id", env.ID, "path", outputPath)
+			return nil
+		}
+		return sdk.Retriable(werr)
+	}
+	p.logger.Info("file streamed successfully",
+		"envelope_id", env.ID, "connection_id", connectionID, "path", outputPath, "size", env.PayloadSize)
+	return nil
+}
+
+// eligibleConfigs drops the output configs whose predecessor predicate doesn't
+// match this envelope. Shared by the buffered and streaming paths.
+func (p *fileProducer) eligibleConfigs(configs []*ConnectionConfig, lastProcessedBy string) []*ConnectionConfig {
+	out := make([]*ConnectionConfig, 0, len(configs))
+	for _, config := range configs {
+		if config.PredIsConsumer && lastProcessedBy != "" {
+			continue
+		}
+		if !config.PredIsConsumer && config.PredecessorID != "" && lastProcessedBy != config.PredecessorID {
+			continue
+		}
+		out = append(out, config)
+	}
+	return out
+}
+
+// writeFile writes the envelope to disk. When body is non-nil the contents are
+// streamed from it and env.Payload is ignored.
+func (p *fileProducer) writeFile(env *envelope.Envelope, outputPath, filePattern string, body io.Reader) error {
 	// Refuse to write outside a mounted root (would silently vanish into the
 	// container FS — looks like success in the logs otherwise).
 	if len(p.allowedRoots) > 0 && !isPathAllowed(outputPath, p.allowedRoots) {
@@ -354,14 +420,40 @@ func (p *fileProducer) writeFile(env *envelope.Envelope, outputPath, filePattern
 		return fmt.Errorf("path traversal detected")
 	}
 
-	if err := os.WriteFile(absPath, env.Payload, 0o644); err != nil {
+	size := int64(len(env.Payload))
+	if body != nil {
+		size = env.PayloadSize
+		if err := writeStream(absPath, body); err != nil {
+			return err
+		}
+	} else if err := os.WriteFile(absPath, env.Payload, 0o644); err != nil {
 		return fmt.Errorf("write file: %w", err)
 	}
 
 	chownToHostUser(absPath)
 	chownToHostUser(absOutputPath)
 
-	p.logger.Debug("wrote file", "path", absPath, "size", len(env.Payload))
+	p.logger.Debug("wrote file", "path", absPath, "size", size)
+	return nil
+}
+
+// writeStream copies body to path. A failed copy removes the partial file: a
+// truncated file left on disk looks complete to whatever watches that directory,
+// and the redelivery will write it again anyway.
+func writeStream(path string, body io.Reader) error {
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
+	if err != nil {
+		return fmt.Errorf("create file: %w", err)
+	}
+	if _, err := io.Copy(f, body); err != nil {
+		_ = f.Close()
+		_ = os.Remove(path)
+		return fmt.Errorf("write file: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		_ = os.Remove(path)
+		return fmt.Errorf("close file: %w", err)
+	}
 	return nil
 }
 
@@ -508,20 +600,42 @@ func isPathAllowed(path string, allowedRoots []string) bool {
 	if err != nil {
 		return false
 	}
-	resolved, err := filepath.EvalSymlinks(absPath)
-	if err != nil {
-		resolved = absPath
-	}
+	// Resolve BOTH sides. Comparing a symlink-resolved candidate against an
+	// unresolved root fails whenever the root contains a symlinked component
+	// (/var -> /private/var on macOS, or a mount alias such as /data ->
+	// /mnt/data), which silently rejected every legitimate write. Resolving both
+	// keeps the escape check intact — a real traversal still resolves outside the
+	// root — while making containment correct.
+	resolved := resolveExisting(absPath)
 	for _, root := range allowedRoots {
 		absRoot, err := filepath.Abs(root)
 		if err != nil {
 			continue
 		}
-		if strings.HasPrefix(resolved, absRoot+"/") || resolved == absRoot {
+		resolvedRoot := resolveExisting(absRoot)
+		// The separator matters: without it "/data-evil" would pass as "/data".
+		if resolved == resolvedRoot || strings.HasPrefix(resolved, resolvedRoot+string(filepath.Separator)) {
 			return true
 		}
 	}
 	return false
+}
+
+// resolveExisting resolves symlinks in path, tolerating a path that does not
+// exist yet — the normal case here, since the output directory is checked before
+// it is created. It resolves the deepest existing ancestor and re-attaches the
+// remainder, so a not-yet-created directory under a symlinked root still
+// compares correctly against a resolved root.
+func resolveExisting(path string) string {
+	clean := filepath.Clean(path)
+	if resolved, err := filepath.EvalSymlinks(clean); err == nil {
+		return resolved
+	}
+	parent := filepath.Dir(clean)
+	if parent == clean {
+		return clean // reached the root; nothing further to resolve
+	}
+	return filepath.Join(resolveExisting(parent), filepath.Base(clean))
 }
 
 type fileEntry struct {

--- a/src/cmd/file-producer/streaming_test.go
+++ b/src/cmd/file-producer/streaming_test.go
@@ -1,0 +1,179 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/ValueRetail/vrsky/pkg/envelope"
+	"github.com/ValueRetail/vrsky/pkg/sdk"
+)
+
+// newStreamingFileProducer stubs the config lookup so the streaming decisions
+// can be exercised without a management DB.
+func newStreamingFileProducer(t *testing.T, outDir string, configs []*ConnectionConfig) *fileProducer {
+	t.Helper()
+	return &fileProducer{
+		logger:           slog.New(slog.NewTextHandler(io.Discard, nil)),
+		defaultOutputDir: outDir,
+		allowedRoots:     []string{outDir},
+		configCache:      map[string][]*ConnectionConfig{"conn-1": configs},
+		configCacheTime:  map[string]time.Time{"conn-1": time.Now()},
+		configCacheTTL:   time.Hour,
+	}
+}
+
+func streamedEnv(size int64) *envelope.Envelope {
+	return &envelope.Envelope{
+		ID:            "env-1",
+		TenantID:      "tenant-x",
+		IntegrationID: "conn-1",
+		ContentType:   "text/csv",
+		PayloadSize:   size,
+		Metadata:      map[string]interface{}{"filename": "big.csv"},
+	}
+}
+
+func TestDeliverStream_WritesFileFromStream(t *testing.T) {
+	out := t.TempDir()
+	payload := bytes.Repeat([]byte("S"), 8192)
+	p := newStreamingFileProducer(t, out, []*ConnectionConfig{{OutputPath: out}})
+
+	if err := p.DeliverStream(context.Background(), streamedEnv(int64(len(payload))), bytes.NewReader(payload)); err != nil {
+		t.Fatalf("DeliverStream: %v", err)
+	}
+
+	entries, err := os.ReadDir(out)
+	if err != nil {
+		t.Fatalf("read out dir: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected exactly one written file, got %d", len(entries))
+	}
+	got, err := os.ReadFile(filepath.Join(out, entries[0].Name()))
+	if err != nil {
+		t.Fatalf("read written file: %v", err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Errorf("written %d bytes, want %d", len(got), len(payload))
+	}
+}
+
+// A stream reads once, so writing to several output configs is declined and the
+// SDK falls back to buffered delivery.
+func TestDeliverStream_DeclinesMultipleOutputs(t *testing.T) {
+	out := t.TempDir()
+	p := newStreamingFileProducer(t, out, []*ConnectionConfig{
+		{OutputPath: out}, {OutputPath: out, FolderName: "second"},
+	})
+	err := p.DeliverStream(context.Background(), streamedEnv(1), bytes.NewReader([]byte("x")))
+	if !errors.Is(err, sdk.ErrStreamUnsupported) {
+		t.Fatalf("expected ErrStreamUnsupported, got %v", err)
+	}
+}
+
+// An output path outside the mounted roots is a config error: dropped, not
+// retried, and nothing written.
+func TestDeliverStream_DisallowedPathIsDropped(t *testing.T) {
+	out := t.TempDir()
+	elsewhere := t.TempDir() // not in allowedRoots
+	p := newStreamingFileProducer(t, out, []*ConnectionConfig{{OutputPath: elsewhere}})
+
+	if err := p.DeliverStream(context.Background(), streamedEnv(1), bytes.NewReader([]byte("x"))); err != nil {
+		t.Fatalf("a disallowed path should be dropped, not returned as an error: %v", err)
+	}
+	entries, _ := os.ReadDir(elsewhere)
+	if len(entries) != 0 {
+		t.Errorf("nothing should have been written outside the allowed roots, found %d entries", len(entries))
+	}
+}
+
+// failingReader yields some bytes then fails, standing in for a truncated
+// object-store read partway through a large transfer.
+type failingReader struct {
+	data []byte
+	n    int
+}
+
+func (f *failingReader) Read(p []byte) (int, error) {
+	if f.n >= len(f.data) {
+		return 0, errors.New("simulated mid-stream failure")
+	}
+	n := copy(p, f.data[f.n:])
+	f.n += n
+	return n, nil
+}
+
+// A failed copy must not leave a truncated file behind: whatever watches the
+// output directory would treat it as a complete delivery.
+func TestDeliverStream_PartialWriteLeavesNoFile(t *testing.T) {
+	out := t.TempDir()
+	p := newStreamingFileProducer(t, out, []*ConnectionConfig{{OutputPath: out}})
+
+	err := p.DeliverStream(context.Background(), streamedEnv(9999),
+		&failingReader{data: bytes.Repeat([]byte("P"), 512)})
+	if err == nil {
+		t.Fatal("expected a mid-stream failure to be reported")
+	}
+	if sdk.IsPermanent(err) {
+		t.Error("a mid-stream read failure should stay retriable")
+	}
+	entries, _ := os.ReadDir(out)
+	if len(entries) != 0 {
+		t.Errorf("a truncated file was left behind: %d entries", len(entries))
+	}
+}
+
+func TestDeliverStream_NoEligibleConfigIsNoOp(t *testing.T) {
+	out := t.TempDir()
+	p := newStreamingFileProducer(t, out, []*ConnectionConfig{
+		{OutputPath: out, PredecessorID: "other-node"},
+	})
+	if err := p.DeliverStream(context.Background(), streamedEnv(1), bytes.NewReader([]byte("x"))); err != nil {
+		t.Fatalf("expected a no-op, got %v", err)
+	}
+	if entries, _ := os.ReadDir(out); len(entries) != 0 {
+		t.Errorf("nothing should have been written, found %d entries", len(entries))
+	}
+}
+
+// isPathAllowed resolved symlinks on the candidate path but not on the allowed
+// roots, so any root containing a symlinked component (/var -> /private/var, or
+// a mount alias like /data -> /mnt/data) rejected every legitimate write — the
+// file was logged and dropped, with no retry and no DLQ.
+func TestIsPathAllowed_SymlinkedRoot(t *testing.T) {
+	real := t.TempDir()
+	link := filepath.Join(t.TempDir(), "link")
+	if err := os.Symlink(real, link); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	// The root is configured via the symlink; the write target is under it.
+	target := filepath.Join(link, "out.csv")
+	if !isPathAllowed(target, []string{link}) {
+		t.Error("a path under a symlinked root must be allowed")
+	}
+	// Configured by symlink, resolved differently — the case that was broken.
+	if !isPathAllowed(target, []string{real}) {
+		t.Error("a path under a root that resolves to the same directory must be allowed")
+	}
+
+	// The escape check must still hold.
+	outside := t.TempDir()
+	if isPathAllowed(filepath.Join(outside, "x.csv"), []string{link}) {
+		t.Error("a path outside every root must be rejected")
+	}
+	if isPathAllowed(filepath.Join(link, "..", "..", "etc", "passwd"), []string{link}) {
+		t.Error("a traversal out of the root must be rejected")
+	}
+	// A sibling whose name merely shares the root's prefix must not slip through.
+	if isPathAllowed(real+"-evil/x.csv", []string{real}) {
+		t.Error("a sibling directory with a shared name prefix must be rejected")
+	}
+}

--- a/src/pkg/io/file_output.go
+++ b/src/pkg/io/file_output.go
@@ -239,12 +239,22 @@ func (f *FileProducer) Write(ctx context.Context, env *envelope.Envelope) error 
 	if err != nil {
 		return fmt.Errorf("resolve absolute path: %w", err)
 	}
-	// Resolve symlinks in the target path. The file may not exist yet, so
-	// ignore "not exist" errors and fall back to the absolute path.
+	// Resolve symlinks in the target path. The file usually does NOT exist yet,
+	// and falling back to the unresolved absolute path is not good enough: the
+	// output directory below IS fully resolved, so comparing the two whenever the
+	// directory contains a symlinked component (/var -> /private/var on macOS, a
+	// mount alias such as /data -> /mnt/data) makes filepath.Rel report a bogus
+	// "path traversal" and rejects every legitimate write. Resolve the parent —
+	// which does exist, Start() created it — and re-attach the base name so both
+	// sides of the comparison are resolved.
 	resolvedAbsPath := absPath
 	if resolved, err := filepath.EvalSymlinks(absPath); err == nil {
 		resolvedAbsPath = resolved
-	} else if !os.IsNotExist(err) {
+	} else if os.IsNotExist(err) {
+		if resolvedDir, derr := filepath.EvalSymlinks(filepath.Dir(absPath)); derr == nil {
+			resolvedAbsPath = filepath.Join(resolvedDir, filepath.Base(absPath))
+		}
+	} else {
 		return fmt.Errorf("resolve symlinks for target path: %w", err)
 	}
 

--- a/src/pkg/io/file_output_test.go
+++ b/src/pkg/io/file_output_test.go
@@ -252,16 +252,17 @@ func TestFileProducer_PermissionRespect(t *testing.T) {
 	env.Payload = []byte("test")
 	env.ContentType = "text/plain"
 
-	err = producer.Write(ctx, env)
-	if err != nil {
-		t.Errorf("Write() error = %v", err)
+	// Fatal, not Error: everything below dereferences the result of a successful
+	// write, so continuing after a failure panics and buries the real error.
+	if err = producer.Write(ctx, env); err != nil {
+		t.Fatalf("Write() error = %v", err)
 	}
 
 	// Verify permissions
 	filePath := filepath.Join(tmpDir, "test-perms.txt")
 	info, err := os.Stat(filePath)
 	if err != nil {
-		t.Errorf("Failed to stat file: %v", err)
+		t.Fatalf("Failed to stat file: %v", err)
 	}
 
 	// Check that permissions match (mask with 0777 to ignore platform-specific bits)


### PR DESCRIPTION
The last ADR 0001 phase-1 adopter — plus a real path-validation bug it uncovered, which also turns the repo's test suite fully green.

## 1. `769a77c` — file-producer streams to disk

A multi-GB file is now written straight from the spill object with a bounded buffer (`os.WriteFile(env.Payload)` → `io.Copy` from the stream). Multiple output directories decline with `sdk.ErrStreamUnsupported` (a stream reads once), falling back to buffered delivery.

**A failed copy removes the partial file.** A truncated file left on disk looks like a *complete* delivery to whatever watches that directory, and the redelivery rewrites it anyway.

## 2. The bug this uncovered — silent data loss

My new tests wrote nothing, and returned no error. `isPathAllowed` resolved symlinks on the **candidate path** but not on the **allowed roots**:

```
candidate (resolved): /private/var/folders/.../out
root      (as given): /var/folders/.../out        → no prefix match → REJECTED
```

Any root containing a symlinked component — `/var` → `/private/var` on macOS, or a mount alias like `/data` → `/mnt/data` — **rejects every legitimate write**. The file is logged and dropped: no retry, no DLQ, no failure. That's silent data loss on a plausible production config.

Both sides now resolve through `resolveExisting`, which also handles the normal case that **the path doesn't exist yet** (the output directory is validated *before* it's created, so `EvalSymlinks` fails on it) by resolving the deepest existing ancestor and re-attaching the remainder. My first attempt fixed only the root and the regression test caught it.

**The escape check is unchanged in strength** — a real traversal still resolves outside the root, and the separator guard still stops `/data-evil` matching `/data`. Both are asserted.

## 3. `34760b0` — the same defect in `pkg/io`

`pkg/io/file_output.go` had the identical asymmetry: target unresolved when the file doesn't exist, output dir fully resolved, `filepath.Rel` then reporting a bogus traversal.

**This is why `TestFileProducer_{WriteFile,FileNameGeneration,PermissionRespect}` have been failing on a clean checkout** — the failures I've had to manually triage as "not mine" on every recent PR. Fixed the same way.

`TestFileProducer_PermissionRespect` also *panicked* rather than failing, because it continued to `os.Stat` and dereferenced a nil `FileInfo` after a failed `Write` — which is what buried the actual error. Its assertions are now `Fatal`.

> **`go test ./...` now passes with zero failing packages** — the first fully green sweep in this series. Future PRs no longer need manual triage of `pkg/io`.

## Tests

6 new in file-producer: writes from a stream; declines multiple outputs; disallowed path dropped without writing; mid-stream failure is retriable and leaves no truncated file; no eligible config is a no-op; and a regression test for the symlinked-root fix asserting traversal + prefix-sibling rejection.

## ADR 0001 phase 1 complete

All adopters landed: cloud-storage consumer + producer, file-consumer, sftp-consumer, http-producer, file-producer. Remaining: **phase 2** (record-streaming transforms — the filter/converter question) and **phase 3** (presigned URLs).

Part of #187.

🤖 Generated with [Claude Code](https://claude.com/claude-code)