### PR TITLE
feat(transforms): stream over-cap payloads record by record (ADR 0002 phase B)

### DIFF
--- a/docs/adr/0002-transform-large-payloads.md
+++ b/docs/adr/0002-transform-large-payloads.md
@@ -91,6 +91,14 @@ error pointing at the object.
 
 ### Phase B — record streaming (the multi-GB path)
 
+> **Implemented.** Shipped scope: filter (rules + `extract_fields`) and
+> converter (mappings; output `""`/json, `ndjson`, `csv`, `tsv`) stream; results
+> go through a *spool* that keeps small outputs inline (UI preview intact) and
+> spills past the inline threshold. Declining with error → NAK → DLQ: flatten
+> (B2), single JSON objects, and `xml`/`text`/`yaml` output — all replayable
+> after raising the cap or changing the node. Streamed output is byte-identical
+> to the buffered path (shared row encoders + parity tests).
+
 When the input is offloaded **and** over the rehydrate cap, and the payload is a
 **JSON array** (later: NDJSON), the transform streams instead of buffering:
 

--- a/src/cmd/data-converter/claimcheck_test.go
+++ b/src/cmd/data-converter/claimcheck_test.go
@@ -175,3 +175,133 @@ func TestConverter_RehydratesInputAndOffloadsOutput(t *testing.T) {
 		t.Fatal("no republished envelope — the offloaded input was dropped")
 	}
 }
+
+// --- ADR 0002 phase B: record streaming ---
+
+// streamThrough boots a converter on embedded JetStream with a tiny rehydrate
+// cap, pushes an offloaded payload through, and returns the output bytes
+// (inline or read back from the spill store).
+func streamThrough(t *testing.T, cfg *ConverterNodeConfig, payload []byte) []byte {
+	t.Helper()
+	nc, js, cleanup := harness.StartEmbeddedJetStream(t)
+	defer cleanup()
+
+	store := newMemStore()
+	entry := &ConverterEntry{NodeID: "cv1", Config: cfg, PredIsConsumer: true}
+	s := newTestConverterService(store, entry)
+	s.nc = nc
+	s.pub = messaging.NewPublisher(js)
+	s.rehydrateMax = 100 // far below the payloads → streaming path
+	if err := s.Start(context.Background()); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	defer s.Stop()
+
+	out := make(chan *envelope.Envelope, 4)
+	sub, err := nc.Subscribe("vrsky.data.tenant-x.pipeline.conn-1", func(m *nats.Msg) {
+		var env envelope.Envelope
+		if json.Unmarshal(m.Data, &env) == nil && env.Metadata != nil {
+			if v, _ := env.Metadata["_last_processed_by"].(string); v == "cv1" {
+				out <- &env
+			}
+		}
+	})
+	if err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+	defer func() { _ = sub.Unsubscribe() }()
+
+	msg := refEnvelopeMsg(t, store, payload)
+	if _, err := js.Publish(msg.Subject, msg.Data); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+
+	select {
+	case got := <-out:
+		if got.PayloadRef != "" {
+			body, _, _ := store.Get(context.Background(), got.PayloadRef)
+			return body
+		}
+		return got.Payload
+	case <-time.After(5 * time.Second):
+		t.Fatal("no republished envelope from the streaming path")
+		return nil
+	}
+}
+
+// bufferedExpected computes what the BUFFERED path produces for the same input,
+// using the very functions it runs — the parity oracle.
+func bufferedExpected(t *testing.T, cfg *ConverterNodeConfig, payload []byte) []byte {
+	t.Helper()
+	var data interface{}
+	if err := json.Unmarshal(payload, &data); err != nil {
+		t.Fatalf("test payload: %v", err)
+	}
+	arr := data.([]interface{})
+	mapped := make([]interface{}, 0, len(arr))
+	for _, item := range arr {
+		if obj, ok := item.(map[string]interface{}); ok && len(cfg.Mappings) > 0 {
+			m, _ := applyMappings(obj, cfg)
+			mapped = append(mapped, m)
+		} else {
+			mapped = append(mapped, item)
+		}
+	}
+	if cfg.OutputFormat == "" {
+		b, _ := json.Marshal(mapped)
+		return b
+	}
+	rows := toRows(mapped)
+	formatted, _, _ := convertFormat(rows, cfg)
+	return []byte(formatted)
+}
+
+func streamingParityPayload() []byte {
+	// Heterogeneous values + padding to clear the 100-byte cap.
+	return []byte(`[{"name":"a","n":1,"pad":"` + string(bytes.Repeat([]byte("x"), 200)) + `"},` +
+		`{"name":"b,with:delim","n":2,"pad":"y"},{"name":"c\"quoted\"","n":3,"pad":"z"}]`)
+}
+
+func TestConverter_StreamedJSONMatchesBuffered(t *testing.T) {
+	cfg := &ConverterNodeConfig{Mappings: []FieldMapping{{Source: "name", Target: "full_name", Type: "rename"}}}
+	payload := streamingParityPayload()
+	got := streamThrough(t, cfg, payload)
+	want := bufferedExpected(t, cfg, payload)
+	if !bytes.Equal(got, want) {
+		t.Errorf("streamed JSON differs from buffered:\n got: %s\nwant: %s", got, want)
+	}
+}
+
+func TestConverter_StreamedNDJSONMatchesBuffered(t *testing.T) {
+	cfg := &ConverterNodeConfig{OutputFormat: "ndjson", Mappings: []FieldMapping{{Source: "name", Target: "full_name", Type: "rename"}}}
+	payload := streamingParityPayload()
+	got := streamThrough(t, cfg, payload)
+	want := bufferedExpected(t, cfg, payload)
+	if !bytes.Equal(got, want) {
+		t.Errorf("streamed NDJSON differs from buffered:\n got: %s\nwant: %s", got, want)
+	}
+}
+
+func TestConverter_StreamedCSVMatchesBuffered(t *testing.T) {
+	cfg := &ConverterNodeConfig{OutputFormat: "csv"}
+	payload := streamingParityPayload()
+	got := streamThrough(t, cfg, payload)
+	want := bufferedExpected(t, cfg, payload)
+	if !bytes.Equal(got, want) {
+		t.Errorf("streamed CSV differs from buffered:\n got: %s\nwant: %s", got, want)
+	}
+}
+
+// XML needs whole-document context phase B doesn't cover — over-cap NAKs
+// (phase-C error policy) instead of producing wrong output.
+func TestConverter_StreamingDeclinesXML(t *testing.T) {
+	store := newMemStore()
+	entry := &ConverterEntry{NodeID: "cv1", Config: &ConverterNodeConfig{OutputFormat: "xml"}, PredIsConsumer: true}
+	s := newTestConverterService(store, entry)
+	s.rehydrateMax = 100
+
+	msg := refEnvelopeMsg(t, store, streamingParityPayload())
+	if err := s.handleMessage(context.Background(), msg); err == nil {
+		t.Fatal("xml + over-cap must NAK (phase C error policy), not stream")
+	}
+}

--- a/src/cmd/data-converter/main.go
+++ b/src/cmd/data-converter/main.go
@@ -247,13 +247,18 @@ func (s *ConverterService) handleMessage(ctx context.Context, msg *nats.Msg) err
 		return nil // will never parse — ack, don't burn retries
 	}
 
-	// Rehydrate an offloaded payload (claim-check) before converting. An error
-	// here is infrastructure, not converter logic: NAK so the message is retried
-	// (transient store blip) or lands in the DLQ (over-cap) instead of being
-	// silently dropped as invalid JSON.
-	if err := claimcheck.Rehydrate(ctx, s.spill, &env, s.rehydrateMax); err != nil {
-		s.emitEvent(env.IntegrationID, ConvertEvent{Type: "error", Message: "Payload rehydrate failed: " + err.Error(), Time: now()})
-		return fmt.Errorf("rehydrate: %w", err)
+	// Rehydrate an offloaded payload (claim-check) before converting — EXCEPT
+	// when it is over the rehydrate cap and a store is available: then the ref
+	// stays set and each entry takes the record-streaming path instead of
+	// buffering (ADR 0002 phase B). Other rehydrate errors are infrastructure,
+	// not converter logic: NAK so the message is retried (transient store blip)
+	// or lands in the DLQ instead of being silently dropped as invalid JSON.
+	overCap := env.PayloadRef != "" && s.rehydrateMax > 0 && env.PayloadSize > s.rehydrateMax && s.spill != nil
+	if !overCap {
+		if err := claimcheck.Rehydrate(ctx, s.spill, &env, s.rehydrateMax); err != nil {
+			s.emitEvent(env.IntegrationID, ConvertEvent{Type: "error", Message: "Payload rehydrate failed: " + err.Error(), Time: now()})
+			return fmt.Errorf("rehydrate: %w", err)
+		}
 	}
 
 	connectionID := env.IntegrationID
@@ -309,6 +314,12 @@ func (s *ConverterService) processEntry(ctx context.Context, connectionID, subje
 	hasFormat := converterCfg.OutputFormat != ""
 	if !hasMapping && !hasFormat {
 		return nil
+	}
+
+	// An envelope still carrying a ref here is over the rehydrate cap — take the
+	// record-streaming path (ADR 0002 phase B) instead of buffering it.
+	if origEnv.PayloadRef != "" {
+		return s.streamEntry(ctx, connectionID, origEnv, entry)
 	}
 
 	// Work on a copy of the original payload to avoid mutating shared state
@@ -604,14 +615,7 @@ func convertCSV(rows []map[string]interface{}, cfg *ConverterNodeConfig) string 
 	if len(rows) == 0 {
 		return ""
 	}
-	delim := cfg.CsvDelimiter
-	if delim == "" {
-		delim = ","
-	}
-	if cfg.OutputFormat == "tsv" {
-		delim = "\t"
-	}
-
+	delim := csvDelim(cfg)
 	keys := stableKeys(rows)
 	var sb strings.Builder
 
@@ -623,23 +627,40 @@ func convertCSV(rows []map[string]interface{}, cfg *ConverterNodeConfig) string 
 	}
 
 	for _, row := range rows {
-		vals := make([]string, len(keys))
-		for i, k := range keys {
-			v := row[k]
-			s := fmt.Sprintf("%v", v)
-			if v == nil {
-				s = ""
-			}
-			// Quote if contains delimiter or newline
-			if strings.ContainsAny(s, delim+"\n\"") {
-				s = "\"" + strings.ReplaceAll(s, "\"", "\"\"") + "\""
-			}
-			vals[i] = s
-		}
-		sb.WriteString(strings.Join(vals, delim))
-		sb.WriteString("\n")
+		sb.WriteString(csvLine(keys, row, delim))
 	}
 	return sb.String()
+}
+
+// csvDelim resolves the effective delimiter for a csv/tsv node.
+func csvDelim(cfg *ConverterNodeConfig) string {
+	delim := cfg.CsvDelimiter
+	if delim == "" {
+		delim = ","
+	}
+	if cfg.OutputFormat == "tsv" {
+		delim = "\t"
+	}
+	return delim
+}
+
+// csvLine renders one row against a pinned key order — shared by the buffered
+// and streaming paths so their output cannot drift.
+func csvLine(keys []string, row map[string]interface{}, delim string) string {
+	vals := make([]string, len(keys))
+	for i, k := range keys {
+		v := row[k]
+		s := fmt.Sprintf("%v", v)
+		if v == nil {
+			s = ""
+		}
+		// Quote if contains delimiter or newline
+		if strings.ContainsAny(s, delim+"\n\"") {
+			s = "\"" + strings.ReplaceAll(s, "\"", "\"\"") + "\""
+		}
+		vals[i] = s
+	}
+	return strings.Join(vals, delim) + "\n"
 }
 
 func convertXML(rows []map[string]interface{}, cfg *ConverterNodeConfig) string {

--- a/src/cmd/data-converter/streaming.go
+++ b/src/cmd/data-converter/streaming.go
@@ -1,0 +1,200 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/google/uuid"
+
+	"github.com/ValueRetail/vrsky/pkg/claimcheck"
+	"github.com/ValueRetail/vrsky/pkg/envelope"
+)
+
+// streamEntry is the record-streaming path (ADR 0002 phase B): the input
+// payload is offloaded AND over the rehydrate cap, so it is never buffered.
+// Records are decoded one at a time off the spill object, mapped, encoded, and
+// written through a Spool — inline if the result ends up small, re-offloaded if
+// not. Memory is bounded by the largest single record.
+//
+// Streamable output formats: "" (mappings only, compact JSON array — matching
+// json.Marshal of the buffered path), ndjson, csv, tsv. XML/text/YAML need
+// whole-document or template context that phase B does not cover, and a single
+// JSON object over the cap has no records to iterate — those decline with an
+// error → NAK → DLQ, replayable after raising the cap (phase-C "error" policy).
+func (s *ConverterService) streamEntry(ctx context.Context, connectionID string, origEnv *envelope.Envelope, entry *ConverterEntry) error {
+	cfg := entry.Config
+	hasMapping := len(cfg.Mappings) > 0
+
+	var contentType, label string
+	switch cfg.OutputFormat {
+	case "":
+		contentType, label = "application/json", "JSON"
+	case "ndjson":
+		contentType, label = "application/x-ndjson", "NDJSON"
+	case "csv", "tsv":
+		contentType, label = "text/csv", "CSV"
+		if cfg.OutputFormat == "tsv" {
+			label = "TSV"
+		}
+	default:
+		return fmt.Errorf("converter node %s: output format %q does not support streamed payloads (%d bytes, over the %d-byte rehydrate cap); raise %s or use json/ndjson/csv/tsv",
+			entry.NodeID, cfg.OutputFormat, origEnv.PayloadSize, s.rehydrateMax, claimcheck.EnvRehydrateMax)
+	}
+
+	rc, _, err := s.spill.GetStream(ctx, origEnv.PayloadRef)
+	if err != nil {
+		return fmt.Errorf("open streamed payload %q: %w", origEnv.PayloadRef, err)
+	}
+	defer rc.Close()
+
+	dec := json.NewDecoder(rc)
+	tok, err := dec.Token()
+	if err != nil {
+		s.emitEvent(connectionID, ConvertEvent{Type: "error", Message: "Streamed payload is not valid JSON: " + err.Error(), Time: now()})
+		return nil // will never parse — ack, like the buffered invalid-JSON path
+	}
+	if d, ok := tok.(json.Delim); !ok || d != '[' {
+		return fmt.Errorf("converter node %s: only JSON array payloads can be streamed; this payload (%d bytes) starts with %v — raise %s to buffer it",
+			entry.NodeID, origEnv.PayloadSize, tok, claimcheck.EnvRehydrateMax)
+	}
+
+	env := *origEnv
+	env.ID = uuid.New().String()
+	env.Payload, env.PayloadRef, env.Checksum, env.PayloadSize = nil, "", "", 0
+	env.ContentType = contentType
+	env.Metadata = make(map[string]interface{})
+	for k, v := range origEnv.Metadata {
+		env.Metadata[k] = v
+	}
+	env.Metadata["_last_processed_by"] = entry.NodeID
+	env.Metadata["_converted"] = true
+	env.Metadata["_source_envelope_id"] = origEnv.ID
+	if cfg.OutputFormat != "" {
+		env.Metadata["_output_format"] = cfg.OutputFormat
+	}
+
+	spool := claimcheck.NewSpool(ctx, s.spill, claimcheck.Key(&env), contentType, s.inlineMax)
+	fail := func(werr error) error {
+		spool.Abort(s.logger)
+		return fmt.Errorf("write streamed result: %w", werr)
+	}
+
+	var (
+		fieldCount int
+		rows       int
+		wrote      bool
+		csvKeys    []string // pinned from the first map row, exactly like stableKeys
+		delim      = csvDelim(cfg)
+	)
+
+	for dec.More() {
+		var rec interface{}
+		if derr := dec.Decode(&rec); derr != nil {
+			spool.Abort(s.logger)
+			s.emitEvent(connectionID, ConvertEvent{Type: "error", Message: "Streamed payload record is not valid JSON: " + derr.Error(), Time: now()})
+			return nil // deterministic — ack, matching the buffered invalid-JSON path
+		}
+
+		obj, isMap := rec.(map[string]interface{})
+		if hasMapping && isMap {
+			// Buffered parity: map records are mapped, non-maps pass through.
+			obj, fieldCount = applyMappings(obj, cfg)
+			rec = obj
+		}
+
+		switch cfg.OutputFormat {
+		case "":
+			// Compact JSON array — byte-identical to json.Marshal of the slice.
+			b, merr := json.Marshal(rec)
+			if merr != nil {
+				return fail(merr)
+			}
+			sep := ","
+			if !wrote {
+				sep = "["
+				wrote = true
+			}
+			if _, werr := spool.Write(append([]byte(sep), b...)); werr != nil {
+				return fail(werr)
+			}
+		case "ndjson":
+			// Buffered parity: toRows drops non-map records.
+			if !isMap {
+				continue
+			}
+			b, merr := json.Marshal(obj)
+			if merr != nil {
+				return fail(merr)
+			}
+			if _, werr := spool.Write(append(b, '\n')); werr != nil {
+				return fail(werr)
+			}
+			wrote = true
+		case "csv", "tsv":
+			if !isMap {
+				continue
+			}
+			if csvKeys == nil {
+				csvKeys = stableKeys([]map[string]interface{}{obj})
+				if cfg.CsvHeaders == nil || *cfg.CsvHeaders {
+					if _, werr := spool.Write([]byte(joinDelim(csvKeys, delim) + "\n")); werr != nil {
+						return fail(werr)
+					}
+				}
+			}
+			if _, werr := spool.Write([]byte(csvLine(csvKeys, obj, delim))); werr != nil {
+				return fail(werr)
+			}
+			wrote = true
+		}
+		rows++
+	}
+
+	if cfg.OutputFormat == "" {
+		closing := "]"
+		if !wrote {
+			closing = "[]"
+		}
+		if _, werr := spool.Write([]byte(closing)); werr != nil {
+			return fail(werr)
+		}
+	}
+	if cerr := spool.Close(); cerr != nil {
+		return fmt.Errorf("finalize streamed result: %w", cerr)
+	}
+	res := spool.Result()
+	if res.Inline != nil {
+		env.Payload = res.Inline
+		env.PayloadSize = int64(len(res.Inline))
+	} else {
+		env.PayloadRef, env.PayloadSize, env.Checksum = res.Ref, res.Size, res.Checksum
+	}
+
+	envData, _ := json.Marshal(env)
+	if perr := s.pub.Publish(ctx, env.TenantID, connectionID, env.ID, envData); perr != nil {
+		s.emitEvent(connectionID, ConvertEvent{Type: "error", Message: "Failed to re-publish: " + perr.Error(), Time: now()})
+		return fmt.Errorf("publish: %w", perr)
+	}
+
+	msg := fmt.Sprintf("Streamed %d bytes: converted %d rows to %s", origEnv.PayloadSize, rows, label)
+	if fieldCount > 0 {
+		msg = fmt.Sprintf("Streamed %d bytes: mapped %d fields, converted %d rows to %s", origEnv.PayloadSize, fieldCount, rows, label)
+	}
+	s.logger.Info("Data converted (streamed)", "connection_id", connectionID, "format", label, "rows", rows, "fields", fieldCount)
+	s.emitEvent(connectionID, ConvertEvent{Type: "converted", Message: msg, Time: now(), Fields: fieldCount})
+	return nil
+}
+
+// joinDelim joins already-safe header names with the delimiter (headers come
+// from JSON object keys; parity with convertCSV, which does not quote them).
+func joinDelim(parts []string, delim string) string {
+	out := ""
+	for i, p := range parts {
+		if i > 0 {
+			out += delim
+		}
+		out += p
+	}
+	return out
+}

--- a/src/cmd/data-filter/claimcheck_test.go
+++ b/src/cmd/data-filter/claimcheck_test.go
@@ -119,14 +119,25 @@ func TestFilter_OffloadedEnvelopeWithoutStoreNAKs(t *testing.T) {
 	}
 }
 
-func TestFilter_OverCapEnvelopeNAKs(t *testing.T) {
+// Since phase B an over-cap payload STREAMS rather than NAKing outright — but an
+// infrastructure failure on that path (the spill object is gone or the store is
+// unreachable) must still NAK so the message retries or DLQs, never acks empty.
+func TestFilter_OverCapMissingObjectNAKs(t *testing.T) {
 	store := newMemStore()
-	msg := refEnvelopeMsg(t, store, bytes.Repeat([]byte("A"), 4096))
+	entry := &FilterEntry{NodeID: "f1", Config: &FilterNodeConfig{Rules: []FilterRule{{Field: "a", Operator: "equals", Value: "b"}}}, PredIsConsumer: true}
+	s := newTestFilterService(store, entry)
+	s.rehydrateMax = 100
 
-	s := newTestFilterService(store)
-	s.rehydrateMax = 100 // cap far below the payload
+	env := envelope.New()
+	env.TenantID = "tenant-x"
+	env.IntegrationID = "conn-1"
+	env.PayloadRef = "spill/tenant-x/conn-1/vanished"
+	env.PayloadSize = 4096 // over the cap → streaming path
+	data, _ := json.Marshal(env)
+	msg := &nats.Msg{Subject: "vrsky.data.tenant-x.pipeline.conn-1", Data: data}
+
 	if err := s.handleMessage(context.Background(), msg); err == nil {
-		t.Fatal("an over-cap payload must NAK (explicit DLQ path), not ack")
+		t.Fatal("a missing spill object on the streaming path must NAK, not ack")
 	}
 }
 
@@ -247,5 +258,154 @@ func TestFilter_OffloadsLargeOutput(t *testing.T) {
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("no republished envelope")
+	}
+}
+
+// --- ADR 0002 phase B: record streaming ---
+
+// startStreamingFilter boots a filter on embedded JetStream with a tiny
+// rehydrate cap, so any offloaded input takes the streaming path.
+func startStreamingFilter(t *testing.T, store objectstore.ObjectStore, entry *FilterEntry) (*FilterService, *nats.Conn, nats.JetStreamContext, chan *envelope.Envelope, func()) {
+	t.Helper()
+	nc, js, cleanup := harness.StartEmbeddedJetStream(t)
+	s := newTestFilterService(store, entry)
+	s.nc = nc
+	s.pub = messaging.NewPublisher(js)
+	s.rehydrateMax = 100 // far below the test payloads → streaming path
+	if err := s.Start(context.Background()); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	out := make(chan *envelope.Envelope, 4)
+	sub, err := nc.Subscribe("vrsky.data.tenant-x.pipeline.conn-1", func(m *nats.Msg) {
+		var env envelope.Envelope
+		if json.Unmarshal(m.Data, &env) == nil && env.Metadata != nil {
+			if v, _ := env.Metadata["_last_processed_by"].(string); v == entry.NodeID {
+				out <- &env
+			}
+		}
+	})
+	if err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+	return s, nc, js, out, func() { _ = sub.Unsubscribe(); s.Stop(); cleanup() }
+}
+
+// An over-cap array is filtered record by record and republished — never
+// buffered, and byte-identical to what the buffered path would produce.
+func TestFilter_StreamsOverCapArray(t *testing.T) {
+	store := newMemStore()
+	entry := &FilterEntry{
+		NodeID:         "f1",
+		Config:         &FilterNodeConfig{Rules: []FilterRule{{Field: "keep", Operator: "equals", Value: "yes"}}},
+		PredIsConsumer: true,
+	}
+	_, _, js, out, done := startStreamingFilter(t, store, entry)
+	defer done()
+
+	// ~4 KB payload, cap is 100 bytes → must stream.
+	payload := []byte(`[{"keep":"yes","v":1},{"keep":"no","v":2},{"keep":"yes","pad":"` +
+		string(bytes.Repeat([]byte("x"), 4000)) + `"}]`)
+	msg := refEnvelopeMsg(t, store, payload)
+	if _, err := js.Publish(msg.Subject, msg.Data); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+
+	select {
+	case got := <-out:
+		var body []byte
+		if got.PayloadRef != "" {
+			body, _, _ = store.Get(context.Background(), got.PayloadRef)
+		} else {
+			body = got.Payload
+		}
+		var rows []map[string]interface{}
+		if err := json.Unmarshal(body, &rows); err != nil {
+			t.Fatalf("streamed output not JSON: %v", err)
+		}
+		if len(rows) != 2 || rows[0]["keep"] != "yes" || rows[1]["keep"] != "yes" {
+			t.Errorf("streamed filter semantics wrong: %d rows", len(rows))
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("no republished envelope from the streaming path")
+	}
+}
+
+// A large streamed result is re-offloaded via the spool (output over inlineMax).
+func TestFilter_StreamedLargeOutputSpills(t *testing.T) {
+	store := newMemStore()
+	entry := &FilterEntry{NodeID: "f1", Config: &FilterNodeConfig{}, PredIsConsumer: true} // pass-through
+	s, _, js, out, done := startStreamingFilter(t, store, entry)
+	defer done()
+	s.inlineMax = 64 // output must spill
+
+	payload := []byte(`[{"pad":"` + string(bytes.Repeat([]byte("y"), 3000)) + `"}]`)
+	msg := refEnvelopeMsg(t, store, payload)
+	if _, err := js.Publish(msg.Subject, msg.Data); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+
+	select {
+	case got := <-out:
+		if got.PayloadRef == "" {
+			t.Fatalf("output of %d bytes should have spilled (inlineMax=64)", got.PayloadSize)
+		}
+		if got.Checksum == "" {
+			t.Error("spilled output should carry a checksum")
+		}
+		body, _, _ := store.Get(context.Background(), got.PayloadRef)
+		if !bytes.Equal(body, payload) {
+			t.Errorf("pass-through streamed output differs from input: %d vs %d bytes", len(body), len(payload))
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("no republished envelope")
+	}
+}
+
+// Flatten needs document context (phase B2) — an over-cap payload at a flatten
+// node NAKs instead of streaming wrong results or buffering into an OOM.
+func TestFilter_StreamingDeclinesFlatten(t *testing.T) {
+	store := newMemStore()
+	entry := &FilterEntry{NodeID: "f1", Config: &FilterNodeConfig{FlattenPath: "items"}, PredIsConsumer: true}
+	s := newTestFilterService(store, entry)
+	s.rehydrateMax = 100
+
+	msg := refEnvelopeMsg(t, store, []byte(`[{"items":[1,2],"pad":"`+string(bytes.Repeat([]byte("p"), 500))+`"}]`))
+	if err := s.handleMessage(context.Background(), msg); err == nil {
+		t.Fatal("flatten + over-cap must NAK (phase C error policy), not stream")
+	}
+}
+
+// A single JSON object has no records to stream — over the cap it NAKs.
+func TestFilter_StreamingDeclinesSingleObject(t *testing.T) {
+	store := newMemStore()
+	entry := &FilterEntry{NodeID: "f1", Config: &FilterNodeConfig{Rules: []FilterRule{{Field: "a", Operator: "equals", Value: "b"}}}, PredIsConsumer: true}
+	s := newTestFilterService(store, entry)
+	s.rehydrateMax = 100
+
+	msg := refEnvelopeMsg(t, store, []byte(`{"a":"b","pad":"`+string(bytes.Repeat([]byte("z"), 500))+`"}`))
+	if err := s.handleMessage(context.Background(), msg); err == nil {
+		t.Fatal("a single object over the cap cannot record-stream and must NAK")
+	}
+}
+
+// Rules that drop every record publish nothing — and leave no partial spill
+// object behind.
+func TestFilter_StreamedAllDroppedPublishesNothing(t *testing.T) {
+	store := newMemStore()
+	entry := &FilterEntry{
+		NodeID:         "f1",
+		Config:         &FilterNodeConfig{Rules: []FilterRule{{Field: "keep", Operator: "equals", Value: "never"}}},
+		PredIsConsumer: true,
+	}
+	s := newTestFilterService(store, entry)
+	s.rehydrateMax = 100
+
+	msg := refEnvelopeMsg(t, store, []byte(`[{"keep":"no","pad":"`+string(bytes.Repeat([]byte("q"), 500))+`"},{"keep":"also-no"}]`))
+	objectsBefore := len(store.objects)
+	if err := s.handleMessage(context.Background(), msg); err != nil {
+		t.Fatalf("all-dropped is a normal outcome, not an error: %v", err)
+	}
+	if len(store.objects) != objectsBefore {
+		t.Errorf("no output object should exist after an all-dropped stream")
 	}
 }

--- a/src/cmd/data-filter/main.go
+++ b/src/cmd/data-filter/main.go
@@ -250,13 +250,18 @@ func (s *FilterService) handleMessage(ctx context.Context, msg *nats.Msg) error 
 		return nil // malformed envelope will never parse — ack, don't burn retries
 	}
 
-	// Rehydrate an offloaded payload (claim-check) before filtering. An error
-	// here is infrastructure, not filter logic: NAK so the message is retried
-	// (transient store blip) or lands in the DLQ (over-cap) instead of being
-	// silently dropped as "Invalid JSON payload".
-	if err := claimcheck.Rehydrate(ctx, s.spill, &env, s.rehydrateMax); err != nil {
-		s.emitEvent(env.IntegrationID, FilterEvent{Type: "error", Message: "Payload rehydrate failed: " + err.Error(), Time: now()})
-		return fmt.Errorf("rehydrate: %w", err)
+	// Rehydrate an offloaded payload (claim-check) before filtering — EXCEPT
+	// when it is over the rehydrate cap and a store is available: then the ref
+	// stays set and each entry takes the record-streaming path instead of
+	// buffering (ADR 0002 phase B). Other rehydrate errors are infrastructure,
+	// not filter logic: NAK so the message is retried (transient store blip) or
+	// lands in the DLQ instead of being silently dropped as invalid JSON.
+	overCap := env.PayloadRef != "" && s.rehydrateMax > 0 && env.PayloadSize > s.rehydrateMax && s.spill != nil
+	if !overCap {
+		if err := claimcheck.Rehydrate(ctx, s.spill, &env, s.rehydrateMax); err != nil {
+			s.emitEvent(env.IntegrationID, FilterEvent{Type: "error", Message: "Payload rehydrate failed: " + err.Error(), Time: now()})
+			return fmt.Errorf("rehydrate: %w", err)
+		}
 	}
 
 	connectionID := env.IntegrationID
@@ -307,6 +312,12 @@ func (s *FilterService) handleMessage(ctx context.Context, msg *nats.Msg) error 
 // caller NAKs those; transform-logic failures emit a UI event and ack, exactly
 // as before.
 func (s *FilterService) processFilterEntry(ctx context.Context, connectionID, subject string, origEnv *envelope.Envelope, entry *FilterEntry) error {
+	// An envelope still carrying a ref here is over the rehydrate cap — take the
+	// record-streaming path (ADR 0002 phase B) instead of buffering it.
+	if origEnv.PayloadRef != "" {
+		return s.streamFilterEntry(ctx, connectionID, origEnv, entry)
+	}
+
 	var data interface{}
 	if err := json.Unmarshal(origEnv.Payload, &data); err != nil {
 		s.emitEvent(connectionID, FilterEvent{Type: "error", Message: "Invalid JSON payload", Time: now()})

--- a/src/cmd/data-filter/streaming.go
+++ b/src/cmd/data-filter/streaming.go
@@ -1,0 +1,167 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/google/uuid"
+
+	"github.com/ValueRetail/vrsky/pkg/claimcheck"
+	"github.com/ValueRetail/vrsky/pkg/envelope"
+)
+
+// streamFilterEntry is the record-streaming path (ADR 0002 phase B): the input
+// payload is offloaded AND over the rehydrate cap, so it is never buffered.
+// Records are decoded one at a time off the spill object, filtered, and the
+// kept ones written through a Spool — inline if the result ends up small,
+// re-offloaded if not. Memory is bounded by the largest single record.
+//
+// Only JSON array payloads stream: a single object over the cap has no records
+// to iterate, and flatten needs document context outside the array (phase B2).
+// Both decline with an error → NAK → DLQ, where the payload can be replayed
+// after raising the cap or changing the node (the phase-C "error" policy).
+func (s *FilterService) streamFilterEntry(ctx context.Context, connectionID string, origEnv *envelope.Envelope, entry *FilterEntry) error {
+	cfg := entry.Config
+	if cfg.FlattenPath != "" {
+		return fmt.Errorf("filter node %s: flatten does not support streamed payloads (%d bytes, over the %d-byte rehydrate cap); raise %s or remove flatten",
+			entry.NodeID, origEnv.PayloadSize, s.rehydrateMax, claimcheck.EnvRehydrateMax)
+	}
+
+	rc, _, err := s.spill.GetStream(ctx, origEnv.PayloadRef)
+	if err != nil {
+		return fmt.Errorf("open streamed payload %q: %w", origEnv.PayloadRef, err)
+	}
+	defer rc.Close()
+
+	dec := json.NewDecoder(rc)
+	tok, err := dec.Token()
+	if err != nil {
+		s.emitEvent(connectionID, FilterEvent{Type: "error", Message: "Streamed payload is not valid JSON: " + err.Error(), Time: now()})
+		return nil // will never parse — ack, like the buffered invalid-JSON path
+	}
+	if d, ok := tok.(json.Delim); !ok || d != '[' {
+		return fmt.Errorf("filter node %s: only JSON array payloads can be streamed; this payload (%d bytes) starts with %v — raise %s to buffer it",
+			entry.NodeID, origEnv.PayloadSize, tok, claimcheck.EnvRehydrateMax)
+	}
+
+	hasRules := len(cfg.Rules) > 0
+	hasExtract := len(cfg.ExtractFields) > 0
+	logic := cfg.Logic
+	if logic == "" {
+		logic = "and"
+	}
+
+	// Output envelope: fresh ID (JetStream dedup + the spill key for the result).
+	env := *origEnv
+	env.ID = uuid.New().String()
+	env.Payload, env.PayloadRef, env.Checksum, env.PayloadSize = nil, "", "", 0
+	env.Metadata = make(map[string]interface{})
+	for k, v := range origEnv.Metadata {
+		env.Metadata[k] = v
+	}
+	env.Metadata["_last_processed_by"] = entry.NodeID
+	env.Metadata["_source_envelope_id"] = origEnv.ID
+
+	spool := claimcheck.NewSpool(ctx, s.spill, claimcheck.Key(&env), "application/json", s.inlineMax)
+	wrote := false
+	var passed, dropped int
+
+	writeRec := func(rec interface{}) error {
+		b, merr := json.Marshal(rec)
+		if merr != nil {
+			return merr
+		}
+		sep := ","
+		if !wrote {
+			sep = "["
+			wrote = true
+		}
+		if _, werr := spool.Write(append([]byte(sep), b...)); werr != nil {
+			return werr
+		}
+		return nil
+	}
+
+	for dec.More() {
+		var rec interface{}
+		if derr := dec.Decode(&rec); derr != nil {
+			spool.Abort(s.logger)
+			s.emitEvent(connectionID, FilterEvent{Type: "error", Message: "Streamed payload record is not valid JSON: " + derr.Error(), Time: now()})
+			return nil // deterministic — ack, matching the buffered invalid-JSON path
+		}
+
+		obj, isMap := rec.(map[string]interface{})
+		if hasRules {
+			// Buffered parity: rules keep only map records that match.
+			if !isMap || !evaluateRules(obj, cfg.Rules, logic) {
+				dropped++
+				continue
+			}
+			passed++
+		}
+		if hasExtract {
+			// Buffered parity: extract over an array drops non-map records.
+			if !isMap {
+				continue
+			}
+			rec = extractFields(obj, cfg.ExtractFields)
+		}
+		if werr := writeRec(rec); werr != nil {
+			spool.Abort(s.logger)
+			return fmt.Errorf("write streamed result: %w", werr)
+		}
+	}
+
+	// Buffered parity: rules that drop every record publish nothing.
+	if hasRules && passed == 0 {
+		spool.Abort(s.logger)
+		filterDroppedTotal.WithLabelValues(connectionID).Add(float64(dropped))
+		s.logger.Info("Filter dropped all rows (streamed)", "connection_id", connectionID, "dropped", dropped, "rules", len(cfg.Rules))
+		s.emitEvent(connectionID, FilterEvent{
+			Type: "dropped", Message: fmt.Sprintf("All %d rows filtered out", dropped),
+			Time: now(), Rules: len(cfg.Rules),
+		})
+		return nil
+	}
+
+	closing := "]"
+	if !wrote {
+		closing = "[]"
+	}
+	if _, werr := spool.Write([]byte(closing)); werr != nil {
+		spool.Abort(s.logger)
+		return fmt.Errorf("write streamed result: %w", werr)
+	}
+	if cerr := spool.Close(); cerr != nil {
+		return fmt.Errorf("finalize streamed result: %w", cerr)
+	}
+	res := spool.Result()
+	if res.Inline != nil {
+		env.Payload = res.Inline
+		env.PayloadSize = int64(len(res.Inline))
+	} else {
+		env.PayloadRef, env.PayloadSize, env.Checksum = res.Ref, res.Size, res.Checksum
+	}
+
+	envData, _ := json.Marshal(env)
+	if perr := s.pub.Publish(ctx, env.TenantID, connectionID, env.ID, envData); perr != nil {
+		s.emitEvent(connectionID, FilterEvent{Type: "error", Message: "Failed to re-publish: " + perr.Error(), Time: now()})
+		return fmt.Errorf("publish: %w", perr)
+	}
+
+	if passed > 0 {
+		filterPassedTotal.WithLabelValues(connectionID).Add(float64(passed))
+	}
+	if dropped > 0 {
+		filterDroppedTotal.WithLabelValues(connectionID).Add(float64(dropped))
+	}
+	s.logger.Info("Filter applied (streamed)", "connection_id", connectionID, "passed", passed, "dropped", dropped, "size", origEnv.PayloadSize)
+	s.emitEvent(connectionID, FilterEvent{
+		Type:    "passed",
+		Message: fmt.Sprintf("Streamed %d bytes: passed %d, dropped %d rows", origEnv.PayloadSize, passed, dropped),
+		Time:    now(),
+		Rules:   len(cfg.Rules),
+	})
+	return nil
+}

--- a/src/pkg/claimcheck/spool.go
+++ b/src/pkg/claimcheck/spool.go
@@ -1,0 +1,156 @@
+package claimcheck
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"hash"
+	"io"
+	"log/slog"
+
+	"github.com/ValueRetail/vrsky/pkg/objectstore"
+)
+
+// Spool is an io.Writer for transform output whose size is unknown until it has
+// been produced (ADR 0002 phase B). It keeps the bytes in memory while they fit
+// under the inline threshold — so a large input whose filtered result is small
+// still travels inline, UI preview included — and switches to streaming into the
+// spill store the moment the threshold is crossed. Memory is bounded by the
+// threshold regardless of output size.
+type Spool struct {
+	ctx         context.Context
+	store       objectstore.ObjectStore
+	key         string
+	contentType string
+	threshold   int
+
+	buf  bytes.Buffer
+	h    hash.Hash
+	size int64
+
+	// set once the threshold is crossed
+	spilled bool
+	pw      *io.PipeWriter
+	putErr  chan error
+
+	closed bool
+}
+
+// SpoolResult is what a completed Spool produced: either the inline bytes, or a
+// reference into the spill store.
+type SpoolResult struct {
+	Inline []byte // non-nil when the output stayed at or below the threshold
+
+	Ref      string // set when spilled
+	Size     int64
+	Checksum string
+}
+
+// NewSpool starts spooling output destined for key. A threshold <= 0 spills
+// from the first byte (offload effectively disabled for inline travel — the
+// output cannot be kept in memory either way on this path).
+func NewSpool(ctx context.Context, store objectstore.ObjectStore, key, contentType string, threshold int) *Spool {
+	return &Spool{
+		ctx:         ctx,
+		store:       store,
+		key:         key,
+		contentType: contentType,
+		threshold:   threshold,
+		h:           sha256.New(),
+	}
+}
+
+func (s *Spool) Write(p []byte) (int, error) {
+	if s.closed {
+		return 0, fmt.Errorf("spool: write after close")
+	}
+	s.h.Write(p)
+	s.size += int64(len(p))
+
+	if !s.spilled && (s.threshold <= 0 || s.size > int64(s.threshold)) {
+		if err := s.startSpill(); err != nil {
+			return 0, err
+		}
+	}
+	if s.spilled {
+		return s.pw.Write(p)
+	}
+	return s.buf.Write(p)
+}
+
+// startSpill opens the pipe into the store and replays the buffered prefix.
+func (s *Spool) startSpill() error {
+	if s.store == nil {
+		return fmt.Errorf("spool: output exceeds the %d-byte inline threshold but no offload store is configured", s.threshold)
+	}
+	pr, pw := io.Pipe()
+	s.putErr = make(chan error, 1)
+	go func() {
+		err := s.store.PutStream(s.ctx, s.key, pr, s.contentType)
+		if err != nil {
+			// Unblock the writer; Write/Close surface the error.
+			_ = pr.CloseWithError(err)
+		}
+		s.putErr <- err
+	}()
+	if s.buf.Len() > 0 {
+		if _, err := pw.Write(s.buf.Bytes()); err != nil {
+			return fmt.Errorf("spool: replay buffered prefix: %w", err)
+		}
+		s.buf.Reset()
+	}
+	s.pw = pw
+	s.spilled = true
+	return nil
+}
+
+// Close finalizes the spool. It must be called exactly once before Result.
+func (s *Spool) Close() error {
+	if s.closed {
+		return nil
+	}
+	s.closed = true
+	if !s.spilled {
+		return nil
+	}
+	if err := s.pw.Close(); err != nil {
+		return err
+	}
+	if err := <-s.putErr; err != nil {
+		return fmt.Errorf("spool: store write: %w", err)
+	}
+	return nil
+}
+
+// Abort discards the spool: nothing produced should survive (e.g. a filter that
+// dropped every record publishes nothing). Best-effort — a spilled partial
+// object that cannot be deleted is reaped by the bucket lifecycle TTL.
+func (s *Spool) Abort(logger *slog.Logger) {
+	if s.closed {
+		return
+	}
+	s.closed = true
+	if !s.spilled {
+		return
+	}
+	_ = s.pw.CloseWithError(fmt.Errorf("spool aborted"))
+	<-s.putErr // wait the goroutine out; its error is expected and irrelevant
+	if err := s.store.Delete(s.ctx, s.key); err != nil {
+		logger.Warn("spool abort: could not delete partial object; lifecycle TTL will reap it", "key", s.key, "error", err)
+	}
+}
+
+// Result reports what the spool produced. Only valid after a successful Close.
+func (s *Spool) Result() SpoolResult {
+	if !s.spilled {
+		// Copy: the caller owns the result; the spool may be reused/GC'd.
+		return SpoolResult{Inline: append([]byte(nil), s.buf.Bytes()...)}
+	}
+	return SpoolResult{
+		Ref:      s.key,
+		Size:     s.size,
+		Checksum: "sha256:" + hex.EncodeToString(s.h.Sum(nil)),
+	}
+}

--- a/src/pkg/claimcheck/spool_test.go
+++ b/src/pkg/claimcheck/spool_test.go
@@ -1,0 +1,143 @@
+package claimcheck
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"sync"
+	"testing"
+
+	"github.com/ValueRetail/vrsky/pkg/objectstore"
+)
+
+// spoolStore is a minimal in-memory ObjectStore for spool tests.
+type spoolStore struct {
+	mu      sync.Mutex
+	objects map[string][]byte
+	deleted []string
+}
+
+func newSpoolStore() *spoolStore { return &spoolStore{objects: map[string][]byte{}} }
+
+func (m *spoolStore) List(context.Context, string) ([]objectstore.Object, error) { return nil, nil }
+func (m *spoolStore) Get(_ context.Context, key string) ([]byte, string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.objects[key], "", nil
+}
+func (m *spoolStore) Put(_ context.Context, key string, body []byte, _ string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.objects[key] = append([]byte(nil), body...)
+	return nil
+}
+func (m *spoolStore) GetStream(_ context.Context, key string) (io.ReadCloser, string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return io.NopCloser(bytes.NewReader(m.objects[key])), "", nil
+}
+func (m *spoolStore) PutStream(_ context.Context, key string, body io.Reader, _ string) error {
+	b, err := io.ReadAll(body)
+	if err != nil {
+		return err
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.objects[key] = b
+	return nil
+}
+func (m *spoolStore) Delete(_ context.Context, key string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.objects, key)
+	m.deleted = append(m.deleted, key)
+	return nil
+}
+func (m *spoolStore) Copy(context.Context, string, string) error { return nil }
+func (m *spoolStore) Close() error                               { return nil }
+
+func TestSpool_SmallOutputStaysInline(t *testing.T) {
+	store := newSpoolStore()
+	sp := NewSpool(context.Background(), store, "spill/t/c/x", "application/json", 1024)
+	if _, err := sp.Write([]byte(`{"small":true}`)); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := sp.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	res := sp.Result()
+	if res.Inline == nil || string(res.Inline) != `{"small":true}` {
+		t.Errorf("expected inline result, got %+v", res)
+	}
+	if len(store.objects) != 0 {
+		t.Error("nothing should have been written to the store")
+	}
+}
+
+func TestSpool_LargeOutputSpillsWithPrefixIntact(t *testing.T) {
+	store := newSpoolStore()
+	sp := NewSpool(context.Background(), store, "spill/t/c/x", "application/json", 64)
+
+	// Cross the threshold over many small writes: the buffered prefix must be
+	// replayed before the later chunks.
+	var want bytes.Buffer
+	for i := 0; i < 20; i++ {
+		chunk := bytes.Repeat([]byte{byte('a' + i)}, 10)
+		want.Write(chunk)
+		if _, err := sp.Write(chunk); err != nil {
+			t.Fatalf("write %d: %v", i, err)
+		}
+	}
+	if err := sp.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	res := sp.Result()
+	if res.Inline != nil {
+		t.Fatal("200 bytes over a 64-byte threshold must spill")
+	}
+	if res.Ref != "spill/t/c/x" || res.Size != 200 {
+		t.Errorf("result = %+v", res)
+	}
+	if got := store.objects["spill/t/c/x"]; !bytes.Equal(got, want.Bytes()) {
+		t.Errorf("stored %d bytes, want %d; prefix corrupted?", len(got), want.Len())
+	}
+	if res.Checksum != Checksum(want.Bytes()) {
+		t.Errorf("checksum mismatch: %s", res.Checksum)
+	}
+}
+
+func TestSpool_ThresholdZeroSpillsImmediately(t *testing.T) {
+	store := newSpoolStore()
+	sp := NewSpool(context.Background(), store, "spill/t/c/x", "", 0)
+	if _, err := sp.Write([]byte("x")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := sp.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	if res := sp.Result(); res.Inline != nil {
+		t.Error("threshold 0 must spill from the first byte")
+	}
+}
+
+func TestSpool_OverflowWithoutStoreErrors(t *testing.T) {
+	sp := NewSpool(context.Background(), nil, "spill/t/c/x", "", 4)
+	if _, err := sp.Write([]byte("over the threshold")); err == nil {
+		t.Fatal("expected an error when overflow has no store to spill to")
+	}
+}
+
+func TestSpool_AbortDeletesSpilledObject(t *testing.T) {
+	store := newSpoolStore()
+	sp := NewSpool(context.Background(), store, "spill/t/c/x", "", 4)
+	if _, err := sp.Write([]byte("spills immediately over threshold")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	sp.Abort(captureLogs(&bytes.Buffer{}))
+	if len(store.objects) != 0 {
+		t.Error("abort should have deleted the partial object")
+	}
+	if len(store.deleted) != 1 {
+		t.Errorf("expected one delete, got %v", store.deleted)
+	}
+}


### PR DESCRIPTION
Completes the multi-GB path through the whole pipeline: a JSON-array payload over the rehydrate cap now flows `source → filter → converter → destination` **without any worker ever buffering it**. Phase A (merged in #198) made large payloads *correct* at the transforms; this makes them *unbounded*.

## How it works

`handleMessage` leaves an over-cap envelope's `PayloadRef` set instead of rehydrating. The entry then decodes records **one at a time** off the spill object (`json.Decoder` token loop), applies the transform per record, and writes results through a new **`claimcheck.Spool`**. Memory is bounded by the largest single record.

**The spool** solves the unknown-output-size problem: it buffers up to the inline threshold — so a big input whose *filtered result is small* still travels inline, UI preview intact — and switches to `PutStream` mid-write the moment the threshold is crossed, replaying the buffered prefix. Size + sha256 accumulate from the first byte either way. `Abort()` discards partial objects (a filter that drops every record publishes nothing); the lifecycle TTL backstops anything a failed abort leaves.

## Parity is enforced, not promised

The risk in reimplementing transforms as streams is semantic drift. Two defenses:

1. **Shared encoders**: `csvLine`/`csvDelim` are factored *out of* `convertCSV`, so buffered and streamed CSV render through one function, with keys pinned from the first row exactly like `stableKeys`. Compact JSON and NDJSON match `json.Marshal` by construction.
2. **Parity tests**: streamed output is asserted **byte-identical** to the buffered functions run on the same input — including CSV quoting/delimiter edge cases (`"a,with:delim"`, embedded quotes).

Per-record edge semantics mirror the buffered array loops precisely: rules keep matching map records (non-maps dropped), `extract_fields` drops non-maps, converter mappings pass non-maps through, rules-drop-all publishes nothing.

## What declines (error → NAK → DLQ)

The ADR's phase-C `"error"` default — loud, inspectable, replayable after raising `PAYLOAD_REHYDRATE_MAX_BYTES` or changing the node:

- **flatten** — needs document context outside the array (phase B2)
- **a single JSON object** — no records to iterate
- **`xml`/`text`/`yaml` output** — whole-document/template context; fringe for multi-GB data
- **infrastructure failures** on the streaming path (missing spill object, store errors) — never an empty ack

## One phase-A test rewritten — deliberately

`TestFilter_OverCapEnvelopeNAKs` asserted over-cap → NAK. Phase B *changes that contract*: over-cap now streams. The still-must-NAK case it was really guarding — an infra failure leaving nothing to deliver — is now tested as a **missing spill object on the streaming path**.

## Tests

5 spool unit tests (inline / spill with prefix-replay across the threshold mid-write / threshold-0 / no-store overflow / abort-deletes). Filter: streams an over-cap array, spills large output with checksum, declines flatten + single-object, all-dropped leaves no object behind. Converter: 3 byte-parity tests + xml decline. All on embedded JetStream + in-memory store — no Docker. **Full-repo `go test ./...` passes.**

## Rollout

Same as #198 (these are the same two platform services): TEST compose env first, then prod images. No new env or secrets beyond what #198 added.

Remaining on #187: phase B2 (flatten streaming), phase C (`large_payloads: passthrough` opt-out), presigned URLs (ADR 0001 phase 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)