### PR TITLE
docs(adr): 1 GiB TEST-env validation of the large-payload path + reusable driver

### DIFF
--- a/docs/adr/0002-transform-large-payloads.md
+++ b/docs/adr/0002-transform-large-payloads.md
@@ -154,6 +154,23 @@ platform deployments, 2 replicas). Per the standing rule: validate in the TEST
 
 ## Test plan
 
+> **Validated in the TEST compose env (2026-08-24)** with `cmd/spill-e2e`, which
+> streams a generated JSON array into the real MinIO spill bucket, publishes the
+> ref envelope on real NATS, and verifies content + DLQ. Result at **1 GiB**
+> (rules keep half, mapping rename, NDJSON out): envelope on the bus **537
+> bytes**; filter 8.5 s → 512 MiB spilled; converter 14 s total → 514 MiB NDJSON,
+> 507,246 lines — exact expected count, mapped field present, DLQ empty.
+> Container memory: filter peaked **246.8 MiB**, converter **290.5 MiB** —
+> identical to a 192 MiB run's peaks, i.e. flat with payload size (steady-state
+> heap + S3 multipart buffers, not proportional buffering).
+>
+> Seed row for the e2e connection (id `11111111-2222-3333-4444-555555555555`,
+> tenant `e2e-tenant`): nodes `consumer c1 → filter f1 (keep=="yes") →
+> converter cv1 (rename i→index, ndjson)`, edges `c1→f1→cv1`, status running.
+> Clean up afterwards: delete the row and
+> `mc rm -r --force local/vrsky-objects/spill/e2e-tenant` (the compose MinIO has
+> no lifecycle TTL, unlike prod).
+
 - Unit: rehydrate-on-entry (offloaded → transformed → republished), over-cap →
   NAK not ack, output offload (large flatten result), store-error → NAK.
 - Phase B: stream a synthetic multi-hundred-MB array through filter and

--- a/src/cmd/spill-e2e/main.go
+++ b/src/cmd/spill-e2e/main.go
@@ -1,0 +1,222 @@
+// spill-e2e validates the large-payload path (ADR 0001/0002) against the live
+// TEST compose stack: it streams a large JSON array into the real MinIO spill
+// bucket, publishes the ref envelope onto real NATS, and verifies the filter
+// and converter stream it through with correct content and an empty DLQ.
+//
+// Prereqs (see docs/adr/0002-transform-large-payloads.md, Test plan):
+//   docker compose up -d nats postgres-management minio-test data-filter data-converter
+//   docker compose up minio-init
+//   seed the e2e connection row (SQL in the ADR), then:
+//   go run ./cmd/spill-e2e -mb 1024
+//
+// Watch transform memory while it runs:
+//   docker stats vrsky-data-filter vrsky-data-converter
+package main
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/nats-io/nats.go"
+
+	"github.com/ValueRetail/vrsky/pkg/envelope"
+	"github.com/ValueRetail/vrsky/pkg/messaging"
+	"github.com/ValueRetail/vrsky/pkg/objectstore"
+)
+
+const (
+	tenant = "e2e-tenant"
+	connID = "11111111-2222-3333-4444-555555555555"
+)
+
+// recordGen emits a JSON array of records as a stream: the driver itself never
+// holds the payload in memory either.
+type recordGen struct {
+	target  int64 // stop emitting new records past this many bytes
+	written int64
+	i       int
+	buf     []byte
+	done    bool
+	pad     string
+}
+
+func (g *recordGen) Read(p []byte) (int, error) {
+	if len(g.buf) == 0 {
+		if g.done {
+			return 0, io.EOF
+		}
+		switch {
+		case g.i == 0:
+			g.buf = []byte("[")
+		case g.written >= g.target:
+			g.buf = []byte("]")
+			g.done = true
+		default:
+			keep := "no"
+			if g.i%2 == 1 {
+				keep = "yes"
+			}
+			sep := ","
+			if g.i == 1 {
+				sep = ""
+			}
+			g.buf = []byte(fmt.Sprintf(`%s{"keep":%q,"i":%d,"pad":%q}`, sep, keep, g.i, g.pad))
+		}
+		g.i++
+	}
+	n := copy(p, g.buf)
+	g.buf = g.buf[n:]
+	g.written += int64(n)
+	return n, nil
+}
+
+func main() {
+	sizeMB := flag.Int64("mb", 1024, "approximate payload size in MiB")
+	flag.Parse()
+	ctx := context.Background()
+
+	store, err := objectstore.New(ctx, &objectstore.Config{
+		Provider: "s3", Bucket: "vrsky-objects", Region: "us-east-1",
+		Endpoint: "http://127.0.0.1:9000", AccessKeyID: "minioadmin", SecretAccessKey: "minioadmin",
+	})
+	if err != nil {
+		log.Fatalf("minio: %v", err)
+	}
+
+	env := envelope.New()
+	env.TenantID = tenant
+	env.IntegrationID = connID
+	env.ContentType = "application/json"
+	key := fmt.Sprintf("spill/%s/%s/%s", tenant, connID, env.ID)
+
+	// Stream-generate the payload into MinIO, hashing and counting as we go.
+	gen := &recordGen{target: *sizeMB << 20, pad: strings.Repeat("x", 1024)}
+	h := sha256.New()
+	counted := io.TeeReader(gen, h)
+	start := time.Now()
+	if err := store.PutStream(ctx, key, counted, "application/json"); err != nil {
+		log.Fatalf("upload: %v", err)
+	}
+	env.PayloadRef = key
+	env.PayloadSize = gen.written
+	env.Checksum = "sha256:" + hex.EncodeToString(h.Sum(nil))
+	totalRecords := gen.i - 2 // minus '[' and ']' emissions
+	fmt.Printf("UPLOADED  %.1f MiB, %d records, in %s\n", float64(gen.written)/(1<<20), totalRecords, time.Since(start).Round(time.Millisecond))
+
+	// Watch for the transform outputs before publishing.
+	nc, err := nats.Connect("nats://127.0.0.1:4222")
+	if err != nil {
+		log.Fatalf("nats: %v", err)
+	}
+	defer nc.Close()
+	js, _ := nc.JetStream()
+
+	outFilter := make(chan *envelope.Envelope, 2)
+	outConv := make(chan *envelope.Envelope, 2)
+	sub, err := nc.Subscribe(messaging.DataSubject(tenant, connID), func(m *nats.Msg) {
+		var e envelope.Envelope
+		if json.Unmarshal(m.Data, &e) != nil || e.Metadata == nil {
+			return
+		}
+		switch e.Metadata["_last_processed_by"] {
+		case "f1":
+			outFilter <- &e
+		case "cv1":
+			outConv <- &e
+		}
+	})
+	if err != nil {
+		log.Fatalf("subscribe: %v", err)
+	}
+	defer sub.Unsubscribe()
+
+	pub := messaging.NewPublisher(js)
+	body, _ := json.Marshal(env)
+	fmt.Printf("PUBLISHED ref envelope (%d bytes on the bus) at %s\n", len(body), time.Now().Format("15:04:05"))
+	if err := pub.Publish(ctx, tenant, connID, env.ID, body); err != nil {
+		log.Fatalf("publish: %v", err)
+	}
+	t0 := time.Now()
+
+	wait := func(name string, ch chan *envelope.Envelope) *envelope.Envelope {
+		select {
+		case e := <-ch:
+			fmt.Printf("%-9s ref=%v inline=%dB size=%.1f MiB checksum=%v after %s\n",
+				strings.ToUpper(name), e.PayloadRef != "", len(e.Payload), float64(e.PayloadSize)/(1<<20), e.Checksum != "", time.Since(t0).Round(time.Millisecond))
+			return e
+		case <-time.After(5 * time.Minute):
+			log.Fatalf("TIMEOUT waiting for %s output", name)
+			return nil
+		}
+	}
+	fe := wait("filter", outFilter)
+	ce := wait("converter", outConv)
+
+	// Validate the converter's NDJSON output by streaming it back.
+	if ce.PayloadRef == "" {
+		log.Fatalf("FAIL: converter output expected to be spilled, was inline (%d bytes)", len(ce.Payload))
+	}
+	rc, _, err := store.GetStream(ctx, ce.PayloadRef)
+	if err != nil {
+		log.Fatalf("read converter output: %v", err)
+	}
+	defer rc.Close()
+	var lines, badLines int
+	var firstLine string
+	dec := json.NewDecoder(rc)
+	for {
+		var rec map[string]interface{}
+		if derr := dec.Decode(&rec); derr == io.EOF {
+			break
+		} else if derr != nil {
+			log.Fatalf("converter output line %d: %v", lines+1, derr)
+		}
+		lines++
+		if firstLine == "" {
+			b, _ := json.Marshal(rec)
+			firstLine = string(b)
+		}
+		if _, hasIdx := rec["index"]; !hasIdx {
+			badLines++
+		}
+		if rec["keep"] != "yes" {
+			badLines++
+		}
+	}
+
+	wantKept := (totalRecords + 1) / 2 // odd indices 1..N
+	fmt.Printf("VALIDATE  converter NDJSON: %d lines (want %d), first: %s\n", lines, wantKept, firstLine)
+	ok := true
+	if lines != wantKept {
+		fmt.Printf("FAIL: line count %d != kept records %d\n", lines, wantKept)
+		ok = false
+	}
+	if badLines > 0 {
+		fmt.Printf("FAIL: %d lines missing the mapped field or with keep!=yes\n", badLines)
+		ok = false
+	}
+	if fe.PayloadRef == "" {
+		fmt.Println("FAIL: filter output expected spilled")
+		ok = false
+	}
+
+	// DLQ must be empty.
+	if entries, derr := messaging.ListDLQ(js, tenant, connID, 10, 0); derr == nil && len(entries) > 0 {
+		fmt.Printf("FAIL: DLQ has %d entries\n", len(entries))
+		ok = false
+	}
+
+	if !ok {
+		os.Exit(1)
+	}
+	fmt.Println("PASS")
+}

--- a/src/cmd/spill-e2e/main.go
+++ b/src/cmd/spill-e2e/main.go
@@ -137,7 +137,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("subscribe: %v", err)
 	}
-	defer sub.Unsubscribe()
+	defer func() { _ = sub.Unsubscribe() }()
 
 	pub := messaging.NewPublisher(js)
 	body, _ := json.Marshal(env)


### PR DESCRIPTION
The TEST-before-prod validation for the #187 work (#198/#199), run against the live compose stack — **real MinIO, real NATS JetStream, freshly built transform images** — rather than the in-memory fakes the unit tests use.

## Result at 1 GiB

Pipeline: offloaded JSON array → filter (`keep == "yes"`, drops half) → converter (rename mapping, NDJSON out).

| Measurement | Value |
|---|---|
| Envelope on the NATS bus | **537 bytes** |
| Filter: 1 GiB in → 512 MiB spilled | 8.5 s |
| Converter: → 514 MiB NDJSON | 14 s total |
| Output lines | 507,246 — **exactly** the expected count |
| Mapped field present / keep=="yes" on every line | ✅ |
| DLQ | empty |

**The boundedness proof:** filter peaked at **246.8 MiB**, converter at **290.5 MiB** — *byte-identical to a 192 MiB run's peaks*. Memory did not move with a 5.3× larger payload: steady-state heap + S3 multipart buffers, not proportional buffering. This is the empirical confirmation of the claim the whole ADR rests on.

## What's in the PR

- `cmd/spill-e2e` — the validation driver, kept for reruns (B2, prod-image verification). It stream-generates the payload straight into the spill bucket (the driver never holds it either), publishes the ref envelope, waits for both transform outputs, stream-verifies the NDJSON, and checks the DLQ.
- ADR 0002 test plan updated with the results, the seed-row recipe, and the cleanup steps (compose MinIO has no lifecycle TTL, unlike prod).

## Prod rollout reminder

The prod filter/converter deployments still run pre-#198 images. When you next roll prod: rebuild/push the transform images, apply the updated filter/converter manifests (`PAYLOAD_STORE_*`), and ensure the `minio-credentials` secret exists in their namespace — same prereq as #189.

🤖 Generated with [Claude Code](https://claude.com/claude-code)