### PR TITLE
fix(sdk): connection-scoped dispatch — bystander producers must not touch foreign payloads

### DIFF
--- a/infrastructure/azure/deploy-connectors-azure.sh
+++ b/infrastructure/azure/deploy-connectors-azure.sh
@@ -63,6 +63,27 @@ spec:
             secretKeyRef:
               name: postgres-credentials
               key: encryption_key
+        # Claim-check spill store (#187/#201): consumers offload >256KiB
+        # payloads; producers rehydrate/stream them. Prereq: minio-credentials
+        # secret copied into this namespace from vrsky-storage.
+        - name: PAYLOAD_STORE_PROVIDER
+          value: "s3"
+        - name: PAYLOAD_STORE_BUCKET
+          value: "vrsky-objects"
+        - name: PAYLOAD_STORE_ENDPOINT
+          value: "http://minio.vrsky-storage.svc.cluster.local:9000"
+        - name: PAYLOAD_STORE_REGION
+          value: "us-east-1"
+        - name: PAYLOAD_STORE_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: minio-credentials
+              key: accesskey
+        - name: PAYLOAD_STORE_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: minio-credentials
+              key: secretkey
 EOF
   if [ -n "$port" ]; then
     cat <<EOF

--- a/src/cmd/brightpearl-producer/service.go
+++ b/src/cmd/brightpearl-producer/service.go
@@ -187,3 +187,15 @@ func (p *brightpearlProducer) getConfig(ctx context.Context, connectionID, tenan
 	}
 	return nil, errors.New("no brightpearl producer node found")
 }
+
+
+// ServesConnection reports whether this connection has a Brightpearl destination —
+// mirroring Deliver's own "no config -> not ours" semantics — so the SDK can
+// ack foreign connections before rehydrating large payloads (sdk.ConnectionScoped).
+func (p *brightpearlProducer) ServesConnection(ctx context.Context, tenantID, connectionID string) bool {
+	if connectionID == "" {
+		return false
+	}
+	_, err := p.getConfig(ctx, connectionID, tenantID)
+	return err == nil
+}

--- a/src/cmd/business-central-producer/service.go
+++ b/src/cmd/business-central-producer/service.go
@@ -224,3 +224,15 @@ func (p *bcProducer) getConfig(ctx context.Context, connectionID, tenantID strin
 	}
 	return nil, errors.New("no business_central producer node found")
 }
+
+
+// ServesConnection reports whether this connection has a Business Central destination —
+// mirroring Deliver's own "no config -> not ours" semantics — so the SDK can
+// ack foreign connections before rehydrating large payloads (sdk.ConnectionScoped).
+func (p *bcProducer) ServesConnection(ctx context.Context, tenantID, connectionID string) bool {
+	if connectionID == "" {
+		return false
+	}
+	_, err := p.getConfig(ctx, connectionID, tenantID)
+	return err == nil
+}

--- a/src/cmd/cloud-storage-producer/service.go
+++ b/src/cmd/cloud-storage-producer/service.go
@@ -381,3 +381,18 @@ func (p *cloudProducer) getTargets(ctx context.Context, connID, tenantID string)
 	p.cacheMu.Unlock()
 	return targets, nil
 }
+
+
+// ServesConnection reports whether this connection has a matching destination —
+// mirroring Deliver's own "no config -> not ours" semantics — so the SDK can
+// ack foreign connections before rehydrating large payloads (sdk.ConnectionScoped).
+func (p *cloudProducer) ServesConnection(ctx context.Context, tenantID, connectionID string) bool {
+	if connectionID == "" {
+		return false
+	}
+	targets, err := p.getTargets(ctx, connectionID, tenantID)
+	if err != nil {
+		return false // Deliver treats lookup errors as "not ours" too
+	}
+	return len(targets) > 0
+}

--- a/src/cmd/db-producer/main.go
+++ b/src/cmd/db-producer/main.go
@@ -652,3 +652,18 @@ func testConnectionHandler() http.HandlerFunc {
 // --- Helpers ---
 
 func now() string { return time.Now().UTC().Format(time.RFC3339) }
+
+
+// ServesConnection reports whether this connection has a matching destination —
+// mirroring Deliver's own "no config -> not ours" semantics — so the SDK can
+// ack foreign connections before rehydrating large payloads (sdk.ConnectionScoped).
+func (p *dbProducer) ServesConnection(ctx context.Context, tenantID, connectionID string) bool {
+	if connectionID == "" {
+		return false
+	}
+	targets, err := p.getTargetConnections(ctx, connectionID, tenantID)
+	if err != nil {
+		return false // Deliver treats lookup errors as "not ours" too
+	}
+	return len(targets) > 0
+}

--- a/src/cmd/file-producer/main.go
+++ b/src/cmd/file-producer/main.go
@@ -804,3 +804,19 @@ func getHostOwner() (int, int) {
 	}
 	return -1, -1
 }
+
+// ServesConnection reports whether this connection has a file destination so
+// the SDK can ack foreign connections before rehydrating large payloads
+// (sdk.ConnectionScoped). Unlike the other producers, Deliver treats a config
+// lookup failure as RETRIABLE — so a failed lookup answers true here, letting
+// Deliver run and keep that retry semantic.
+func (p *fileProducer) ServesConnection(ctx context.Context, tenantID, connectionID string) bool {
+	if connectionID == "" {
+		return false
+	}
+	configs, err := p.getConnectionConfigs(ctx, connectionID)
+	if err != nil {
+		return true
+	}
+	return len(configs) > 0
+}

--- a/src/cmd/front-systems-producer/service.go
+++ b/src/cmd/front-systems-producer/service.go
@@ -211,3 +211,15 @@ func (p *frontSystemsProducer) getConfig(ctx context.Context, connectionID, tena
 	}
 	return nil, errors.New("no front_systems producer node found")
 }
+
+
+// ServesConnection reports whether this connection has a Front Systems destination —
+// mirroring Deliver's own "no config -> not ours" semantics — so the SDK can
+// ack foreign connections before rehydrating large payloads (sdk.ConnectionScoped).
+func (p *frontSystemsProducer) ServesConnection(ctx context.Context, tenantID, connectionID string) bool {
+	if connectionID == "" {
+		return false
+	}
+	_, err := p.getConfig(ctx, connectionID, tenantID)
+	return err == nil
+}

--- a/src/cmd/http-producer/main.go
+++ b/src/cmd/http-producer/main.go
@@ -534,3 +534,18 @@ func (p *httpProducer) eventsHandler() http.HandlerFunc {
 // --- Helpers ---
 
 func now() string { return time.Now().UTC().Format(time.RFC3339) }
+
+
+// ServesConnection reports whether this connection has a matching HTTP destination —
+// mirroring Deliver's own "no config -> not ours" semantics — so the SDK can
+// ack foreign connections before rehydrating large payloads (sdk.ConnectionScoped).
+func (p *httpProducer) ServesConnection(ctx context.Context, tenantID, connectionID string) bool {
+	if connectionID == "" {
+		return false
+	}
+	configs, err := p.getHTTPConfigs(ctx, connectionID, tenantID)
+	if err != nil {
+		return false // Deliver treats lookup errors as "not ours" too
+	}
+	return len(configs) > 0
+}

--- a/src/cmd/kafka-producer/service.go
+++ b/src/cmd/kafka-producer/service.go
@@ -218,3 +218,18 @@ func (p *kafkaProducer) getTargets(ctx context.Context, connID, tenantID string)
 	p.cacheMu.Unlock()
 	return targets, nil
 }
+
+
+// ServesConnection reports whether this connection has a matching destination —
+// mirroring Deliver's own "no config -> not ours" semantics — so the SDK can
+// ack foreign connections before rehydrating large payloads (sdk.ConnectionScoped).
+func (p *kafkaProducer) ServesConnection(ctx context.Context, tenantID, connectionID string) bool {
+	if connectionID == "" {
+		return false
+	}
+	targets, err := p.getTargets(ctx, connectionID, tenantID)
+	if err != nil {
+		return false // Deliver treats lookup errors as "not ours" too
+	}
+	return len(targets) > 0
+}

--- a/src/cmd/rabbitmq-producer/service.go
+++ b/src/cmd/rabbitmq-producer/service.go
@@ -208,3 +208,18 @@ func (p *rabbitProducer) getTargets(ctx context.Context, connID, tenantID string
 	p.cacheMu.Unlock()
 	return targets, nil
 }
+
+
+// ServesConnection reports whether this connection has a matching destination —
+// mirroring Deliver's own "no config -> not ours" semantics — so the SDK can
+// ack foreign connections before rehydrating large payloads (sdk.ConnectionScoped).
+func (p *rabbitProducer) ServesConnection(ctx context.Context, tenantID, connectionID string) bool {
+	if connectionID == "" {
+		return false
+	}
+	targets, err := p.getTargets(ctx, connectionID, tenantID)
+	if err != nil {
+		return false // Deliver treats lookup errors as "not ours" too
+	}
+	return len(targets) > 0
+}

--- a/src/cmd/sap-s4hana-producer/service.go
+++ b/src/cmd/sap-s4hana-producer/service.go
@@ -335,3 +335,15 @@ func (p *sapProducer) getConfig(ctx context.Context, connectionID, tenantID stri
 	}
 	return nil, errors.New("no sap_s4hana producer node found")
 }
+
+
+// ServesConnection reports whether this connection has a SAP destination —
+// mirroring Deliver's own "no config -> not ours" semantics — so the SDK can
+// ack foreign connections before rehydrating large payloads (sdk.ConnectionScoped).
+func (p *sapProducer) ServesConnection(ctx context.Context, tenantID, connectionID string) bool {
+	if connectionID == "" {
+		return false
+	}
+	_, err := p.getConfig(ctx, connectionID, tenantID)
+	return err == nil
+}

--- a/src/cmd/sftp-producer/service.go
+++ b/src/cmd/sftp-producer/service.go
@@ -313,3 +313,18 @@ func (p *sftpProducer) getTargets(ctx context.Context, connID, tenantID string) 
 	p.cacheMu.Unlock()
 	return targets, nil
 }
+
+
+// ServesConnection reports whether this connection has a matching destination —
+// mirroring Deliver's own "no config -> not ours" semantics — so the SDK can
+// ack foreign connections before rehydrating large payloads (sdk.ConnectionScoped).
+func (p *sftpProducer) ServesConnection(ctx context.Context, tenantID, connectionID string) bool {
+	if connectionID == "" {
+		return false
+	}
+	targets, err := p.getTargets(ctx, connectionID, tenantID)
+	if err != nil {
+		return false // Deliver treats lookup errors as "not ours" too
+	}
+	return len(targets) > 0
+}

--- a/src/cmd/sitoo-producer/service.go
+++ b/src/cmd/sitoo-producer/service.go
@@ -234,3 +234,15 @@ func (p *sitooProducer) getSitooConfig(ctx context.Context, connectionID, tenant
 	}
 	return nil, errors.New("no sitoo producer node found")
 }
+
+
+// ServesConnection reports whether this connection has a Sitoo destination —
+// mirroring Deliver's own "no config -> not ours" semantics — so the SDK can
+// ack foreign connections before rehydrating large payloads (sdk.ConnectionScoped).
+func (p *sitooProducer) ServesConnection(ctx context.Context, tenantID, connectionID string) bool {
+	if connectionID == "" {
+		return false
+	}
+	_, err := p.getSitooConfig(ctx, connectionID, tenantID)
+	return err == nil
+}

--- a/src/cmd/spill-e2e/main.go
+++ b/src/cmd/spill-e2e/main.go
@@ -4,13 +4,15 @@
 // and converter stream it through with correct content and an empty DLQ.
 //
 // Prereqs (see docs/adr/0002-transform-large-payloads.md, Test plan):
-//   docker compose up -d nats postgres-management minio-test data-filter data-converter
-//   docker compose up minio-init
-//   seed the e2e connection row (SQL in the ADR), then:
-//   go run ./cmd/spill-e2e -mb 1024
+//
+//	docker compose up -d nats postgres-management minio-test data-filter data-converter
+//	docker compose up minio-init
+//	seed the e2e connection row (SQL in the ADR), then:
+//	go run ./cmd/spill-e2e -mb 1024
 //
 // Watch transform memory while it runs:
-//   docker stats vrsky-data-filter vrsky-data-converter
+//
+//	docker stats vrsky-data-filter vrsky-data-converter
 package main
 
 import (
@@ -79,14 +81,25 @@ func (g *recordGen) Read(p []byte) (int, error) {
 	return n, nil
 }
 
+func envOr(k, def string) string {
+	if v := os.Getenv(k); v != "" {
+		return v
+	}
+	return def
+}
+
 func main() {
 	sizeMB := flag.Int64("mb", 1024, "approximate payload size in MiB")
 	flag.Parse()
 	ctx := context.Background()
 
+	// Defaults match the TEST compose stack; override via env to target another
+	// stack (e.g. prod through port-forwards).
 	store, err := objectstore.New(ctx, &objectstore.Config{
 		Provider: "s3", Bucket: "vrsky-objects", Region: "us-east-1",
-		Endpoint: "http://127.0.0.1:9000", AccessKeyID: "minioadmin", SecretAccessKey: "minioadmin",
+		Endpoint:        envOr("SPILL_E2E_MINIO_ENDPOINT", "http://127.0.0.1:9000"),
+		AccessKeyID:     envOr("SPILL_E2E_MINIO_ACCESS_KEY", "minioadmin"),
+		SecretAccessKey: envOr("SPILL_E2E_MINIO_SECRET_KEY", "minioadmin"),
 	})
 	if err != nil {
 		log.Fatalf("minio: %v", err)
@@ -113,7 +126,7 @@ func main() {
 	fmt.Printf("UPLOADED  %.1f MiB, %d records, in %s\n", float64(gen.written)/(1<<20), totalRecords, time.Since(start).Round(time.Millisecond))
 
 	// Watch for the transform outputs before publishing.
-	nc, err := nats.Connect("nats://127.0.0.1:4222")
+	nc, err := nats.Connect(envOr("SPILL_E2E_NATS_URL", "nats://127.0.0.1:4222"))
 	if err != nil {
 		log.Fatalf("nats: %v", err)
 	}

--- a/src/cmd/visma-producer/service.go
+++ b/src/cmd/visma-producer/service.go
@@ -195,3 +195,15 @@ func (p *vismaProducer) getConfig(ctx context.Context, connectionID, tenantID st
 	}
 	return nil, errors.New("no visma producer node found")
 }
+
+
+// ServesConnection reports whether this connection has a Visma destination —
+// mirroring Deliver's own "no config -> not ours" semantics — so the SDK can
+// ack foreign connections before rehydrating large payloads (sdk.ConnectionScoped).
+func (p *vismaProducer) ServesConnection(ctx context.Context, tenantID, connectionID string) bool {
+	if connectionID == "" {
+		return false
+	}
+	_, err := p.getConfig(ctx, connectionID, tenantID)
+	return err == nil
+}

--- a/src/pkg/sdk/harness/harness.go
+++ b/src/pkg/sdk/harness/harness.go
@@ -127,6 +127,17 @@ func (h *ProducerHarness) ExpectDLQ(t *testing.T, timeout time.Duration) *envelo
 	}
 }
 
+// ExpectNoDLQ asserts nothing is dead-lettered within the window — the
+// counterpart to ExpectDLQ for paths that must ack quietly.
+func (h *ProducerHarness) ExpectNoDLQ(t *testing.T, window time.Duration) {
+	t.Helper()
+	select {
+	case env := <-h.dlqCh:
+		t.Fatalf("harness: expected no DLQ message, got envelope %s", env.ID)
+	case <-time.After(window):
+	}
+}
+
 // Stop cancels the connector and tears down the embedded server.
 func (h *ProducerHarness) Stop() {
 	if h.cancel != nil {

--- a/src/pkg/sdk/lifecycle.go
+++ b/src/pkg/sdk/lifecycle.go
@@ -90,9 +90,15 @@ func RunProducer(ctx context.Context, name string, p Producer, opts ...RunOption
 				streamDeliver = sp.DeliverStream
 				res.Logger.Info("streaming delivery enabled")
 			}
+			// A ConnectionScoped producer lets the dispatch ack foreign
+			// connections before the payload is rehydrated or delivered.
+			var serves servesFunc
+			if cs, ok := p.(ConnectionScoped); ok {
+				serves = cs.ServesConnection
+			}
 			return subscribeDispatch(js, name, res, func(c context.Context, env *envelope.Envelope) error {
 				return p.Deliver(c, env)
-			}, streamDeliver)
+			}, streamDeliver, serves)
 		}, opts...)
 }
 
@@ -192,9 +198,9 @@ func RunFilter(ctx context.Context, name string, f Filter, opts ...RunOption) er
 					return nil // dropped — ack
 				}
 				return republish(c, pub, res, out)
-				// nil: record-streaming transforms are ADR 0001 phase 2; until
-				// then an over-cap payload at a filter is a clear DLQ error.
-			}, nil)
+				// nils: no streaming transform path here (ADR 0001 phase 2),
+				// and filters aren't connection-scoped.
+			}, nil, nil)
 		}, opts...)
 }
 
@@ -213,8 +219,8 @@ func RunConverter(ctx context.Context, name string, cv Converter, opts ...RunOpt
 					return nil
 				}
 				return republish(c, pub, res, out)
-				// nil: see RunFilter — phase 2 covers streaming transforms.
-			}, nil)
+				// nils: see RunFilter.
+			}, nil, nil)
 		}, opts...)
 }
 
@@ -433,7 +439,11 @@ func ackWaitFromEnv(logger *slog.Logger) time.Duration {
 // payload was offloaded — the object is handed over as a stream and never
 // buffered (so the rehydrate cap does not apply). nil for connectors and node
 // kinds that don't stream.
-func subscribeDispatch(js nats.JetStreamContext, durable string, res *Resources, deliver func(context.Context, *envelope.Envelope) error, streamDeliver streamDeliverFunc) (func(), error) {
+// servesFunc reports whether this worker serves a (tenant, connection); nil
+// means "serves everything" (transforms, single-purpose workers).
+type servesFunc func(ctx context.Context, tenantID, connectionID string) bool
+
+func subscribeDispatch(js nats.JetStreamContext, durable string, res *Resources, deliver func(context.Context, *envelope.Envelope) error, streamDeliver streamDeliverFunc, serves servesFunc) (func(), error) {
 	logger := res.Logger
 	sub, err := messaging.Subscribe(js, messaging.SubscriberOpts{
 		DurableName: durable,
@@ -470,6 +480,14 @@ func subscribeDispatch(js nats.JetStreamContext, durable string, res *Resources,
 			),
 		)
 		defer span.End()
+
+		// Foreign connection: ack before touching the payload. Without this,
+		// every producer's shared durable rehydrated (and, past the cap,
+		// NAK'd) large payloads destined for other connectors entirely.
+		if serves != nil && !serves(ctx, env.TenantID, env.IntegrationID) {
+			span.SetAttributes(attribute.Bool("vrsky.foreign_connection", true))
+			return nil
+		}
 
 		streamed, derr := dispatchEnvelope(ctx, res, env, deliver, streamDeliver)
 		if streamed {

--- a/src/pkg/sdk/producer.go
+++ b/src/pkg/sdk/producer.go
@@ -19,6 +19,24 @@ type Producer interface {
 	Deliver(ctx context.Context, env *envelope.Envelope) error
 }
 
+// ConnectionScoped lets a producer on the shared data durable tell the dispatch
+// loop whether a connection is its business BEFORE the payload is touched.
+//
+// Every producer's durable receives every message on vrsky.data.>, and most
+// already begin Deliver with "look up my config for this connection; none →
+// ack". That worked until the claim-check: the SDK rehydrates BEFORE Deliver,
+// so a large offloaded payload was downloaded (and, past the rehydrate cap,
+// NAK'd to the DLQ) by every bystander producer even though its true
+// destination handled it fine. With this implemented, the dispatch loop acks
+// foreign connections without rehydrating or delivering.
+//
+// Implementations MUST mirror their Deliver's own "not mine" semantics — in
+// particular, if Deliver treats a config-lookup failure as retriable, return
+// true on lookup failure so the retry still happens.
+type ConnectionScoped interface {
+	ServesConnection(ctx context.Context, tenantID, connectionID string) bool
+}
+
 // BaseProducer is embedded by producer connectors. It supplies Name/Version/
 // Start/Stop/Health + the RegisterHTTPHandler hook, so an author writes only
 // Configure + Deliver.

--- a/src/pkg/sdk/scoped_test.go
+++ b/src/pkg/sdk/scoped_test.go
@@ -1,0 +1,71 @@
+package sdk_test
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/ValueRetail/vrsky/pkg/envelope"
+	"github.com/ValueRetail/vrsky/pkg/sdk"
+	"github.com/ValueRetail/vrsky/pkg/sdk/harness"
+)
+
+// scopedProbe is a Producer that only serves connection "mine". It records
+// Deliver calls so the test can prove foreign envelopes never reach it.
+type scopedProbe struct {
+	sdk.BaseProducer
+	delivered atomic.Int32
+}
+
+func (p *scopedProbe) Configure(ctx context.Context, res *sdk.Resources) error { return nil }
+
+func (p *scopedProbe) Deliver(ctx context.Context, env *envelope.Envelope) error {
+	p.delivered.Add(1)
+	return nil
+}
+
+func (p *scopedProbe) ServesConnection(_ context.Context, _, connectionID string) bool {
+	return connectionID == "mine"
+}
+
+// The bystander bug this guards (#201 activation finding): every producer's
+// shared durable used to rehydrate — and, past the cap, NAK to the DLQ — large
+// offloaded payloads destined for OTHER connections. A ConnectionScoped
+// producer must ack a foreign ref envelope without touching the payload: no
+// store is configured here, so if the dispatch tried to rehydrate, the message
+// would NAK and land in the DLQ.
+func TestConnectionScoped_ForeignRefEnvelopeAckedWithoutRehydrate(t *testing.T) {
+	p := &scopedProbe{}
+	h := harness.NewProducerHarness(t, p, harness.Options{Name: "scoped-probe"})
+
+	env := envelope.New()
+	env.TenantID = "tenant-x"
+	env.IntegrationID = "not-mine"
+	env.PayloadRef = "spill/tenant-x/not-mine/" + env.ID // offloaded, no store configured
+	env.PayloadSize = 5 << 30                            // 5 GiB — far over any cap
+	h.Publish(t, env)
+
+	// The message must be acked quietly: no Deliver call, nothing in the DLQ.
+	time.Sleep(2 * time.Second)
+	if n := p.delivered.Load(); n != 0 {
+		t.Errorf("Deliver called %d times for a foreign connection", n)
+	}
+	h.ExpectNoDLQ(t, time.Second)
+}
+
+// A connection the producer serves still gets delivered.
+func TestConnectionScoped_OwnConnectionDelivers(t *testing.T) {
+	p := &scopedProbe{}
+	h := harness.NewProducerHarness(t, p, harness.Options{Name: "scoped-probe-own"})
+
+	env := envelope.New()
+	env.TenantID = "tenant-x"
+	env.IntegrationID = "mine"
+	env.Payload = []byte(`{"ok":true}`)
+	h.Publish(t, env)
+
+	harness.Eventually(t, 5*time.Second, "Deliver called for own connection", func() bool {
+		return p.delivered.Load() == 1
+	})
+}


### PR DESCRIPTION
Found during prod activation, with hard evidence: every producer's shared durable receives every message on `vrsky.data.>`, and the SDK rehydrates **before** `Deliver`. Each 1 GiB ref envelope destined for the transforms was rehydrate-capped by every *bystander* producer — `visma-producer` alone logged 15 `over the 134217728-byte rehydrate cap` NAKs and moved 3 messages to the DLQ — while the true destination processed them perfectly. Bystanders poison the DLQ for payloads that are none of their business, and (under the cap) download them pointlessly.

## Fix

**`sdk.ConnectionScoped`** (optional interface): a producer reports whether it serves a `(tenant, connection)`; the dispatch loop acks foreign connections **before** rehydrate/deliver — with a `vrsky.foreign_connection` span attribute for observability.

All 13 producers implement it by reusing the exact config lookup their `Deliver` already starts with, mirroring each one's own "not mine" semantics. The one deliberate asymmetry: **file-producer returns `true` on lookup failure**, because its `Deliver` treats lookup errors as *retriable* — scoping must not eat that retry. The other 12 treat lookup errors as "not ours" already.

Also: `deploy-connectors-azure.sh` now bakes `PAYLOAD_STORE_*` into the generated connector manifests — the permanent form of the live patch applied during activation.

## Tests

Harness (embedded JetStream): a foreign **5 GiB ref envelope with no store configured** is acked quietly — zero `Deliver` calls, nothing in the DLQ (without the skip it would NAK on rehydrate). An owned connection still delivers. Harness gains `ExpectNoDLQ`.

Full-repo `go test ./...` and golangci-lint pass.

## Post-merge

Rebuild connectors + rollout-restart, then re-run the 1 GiB prod validation — expected result: PASS with a clean DLQ. (Note: #196 — http-producer streaming — turned out to be still open, not merged; unrelated but worth landing.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)