### PR TITLE
docs(connectors): SAP S/4HANA connector reference

### DIFF
--- a/docs/connectors/index.md
+++ b/docs/connectors/index.md
@@ -19,6 +19,7 @@ set by `config.type` on the node. Sources are **consumers**, destinations are
 | [Front Systems (POS)](front-systems.md) | ✓ (webhook) | ✓ | `front_systems` |
 | [Dynamics 365 Business Central](business-central.md) | ✓ | ✓ | `business_central` |
 | [Visma.net](visma.md) | ✓ | ✓ | `visma` |
+| [SAP S/4HANA](sap-s4hana.md) | ✓ | ✓ | `sap_s4hana` |
 | [Brightpearl (OMS)](brightpearl.md) | ✓ (poll + webhook) | ✓ | `brightpearl` |
 | [Tenant-to-tenant](tenant.md) | ✓ | — | `tenant` |
 | [Filters & converters](filters-converters.md) | — | — | `filter` / `converter` |

--- a/docs/connectors/sap-s4hana.md
+++ b/docs/connectors/sap-s4hana.md
@@ -1,0 +1,117 @@
+# SAP S/4HANA
+
+The SAP connector (`sap_s4hana`) integrates with [SAP S/4HANA](https://api.sap.com/products/SAPS4HANACloud/apis/ODATA)
+OData APIs — S/4HANA Cloud (public and private edition) and on-premise S/4HANA
+via an exposed OData gateway. It speaks both **OData v2** (the majority of
+`API_*` services, the default) and **OData v4**, and supports Basic
+authentication with a communication user or OAuth 2.0 client credentials.
+
+> **Authentication — two modes, selected with `auth_type`.**
+>
+> **`basic` (default)** — an S/4HANA Cloud *communication user*, created through
+> a Communication Arrangement for the API you intend to use:
+>
+> - `username` — the communication user.
+> - `password_secret_id` — a secrets-vault reference to its password.
+>
+> **`oauth2`** — client credentials against the SAP OAuth token endpoint:
+>
+> - `client_id`
+> - `client_secret_secret_id`
+> - `token_url` — optional; defaults to `https://{host}/sap/bc/sec/oauth2/token`.
+> - `scope` — optional.
+>
+> `sap_client` (the mandt, e.g. `100`) is optional and, when set, is sent as the
+> `sap-client` query parameter — normally needed only for on-premise systems.
+
+## Addressing a service
+
+A node targets one OData **entity set** inside one **service**:
+
+- `host` — e.g. `my347623.s4hana.ondemand.com` (no scheme).
+- `service` — the OData service, e.g. `API_SALES_ORDER_SRV`.
+- `entity_set` — the entity set within it, e.g. `A_SalesOrder`.
+- `odata_version` — `v2` (default) or `v4`.
+
+For on-premise gateways or non-standard routes, set `api_base_url` to the full
+service root instead of `host` + `service`; `entity_set` is appended to it.
+
+## As a source (consumer)
+
+A consumer node polls the entity set on `poll_interval_seconds`, follows the
+version-appropriate pagination cursor (`d.__next` on v2, `@odata.nextLink` on
+v4 — both opaque `$skiptoken` cursors), and emits each page as a JSON-array
+message. The connector requests JSON explicitly, since OData v2 services return
+Atom/XML by default.
+
+- `filter` — optional OData `$filter`, e.g. `LastChangeDate gt datetime'2026-01-01T00:00:00'`.
+- `poll_interval_seconds` — poll cadence.
+
+```json
+{
+  "type": "sap_s4hana",
+  "sap_s4hana": {
+    "host": "my347623.s4hana.ondemand.com",
+    "service": "API_SALES_ORDER_SRV",
+    "entity_set": "A_SalesOrder",
+    "odata_version": "v2",
+    "auth_type": "basic",
+    "username": "COMM_USER",
+    "password_secret_id": "<secret-uuid>",
+    "filter": "SalesOrderType eq 'OR'",
+    "poll_interval_seconds": 300
+  }
+}
+```
+
+**Live schema preview** — the consumer serves `POST /sample-data/` on its
+auxiliary HTTP port (9290 in dev compose), so the pipeline builder can show the
+real record shape *before* the connection is deployed. See
+[schema discovery](index.md#conventions).
+
+## As a destination (producer)
+
+A producer node writes each message to the entity set (create with `POST`,
+update with `PATCH`).
+
+- `method` — `POST` (default) or `PATCH`.
+
+SAP's OData gateway requires **CSRF protection** on writes: the producer fetches
+a token with `X-CSRF-Token: Fetch` and reuses it for subsequent writes. If SAP
+answers `403` with `X-CSRF-Token: Required` — the token or session expired — the
+producer re-fetches once and retries transparently.
+
+```json
+{
+  "type": "sap_s4hana",
+  "sap_s4hana": {
+    "host": "my347623.s4hana.ondemand.com",
+    "service": "API_SALES_ORDER_SRV",
+    "entity_set": "A_SalesOrder",
+    "auth_type": "oauth2",
+    "client_id": "<client-id>",
+    "client_secret_secret_id": "<secret-uuid>",
+    "method": "POST"
+  }
+}
+```
+
+Delivery failures are classified for correct retry behaviour: `2xx` acks; `429`
+and `503`/`5xx`/network errors retry with backoff; `4xx` bad-data and
+`401`/`403` auth failures are poison and go to the DLQ.
+
+## Notes & roadmap
+
+- **Which OData version?** Most `API_*` S/4HANA Cloud services are v2 — keep the
+  default unless the SAP API Business Hub page for your service says v4.
+- **Communication Arrangement** — in S/4HANA Cloud, each API needs an arrangement
+  (with a communication system, user, and the relevant scenario, e.g.
+  `SAP_COM_0109` for sales orders) before it will answer.
+- **Incremental polling** — use `filter` on the entity's change-date field for
+  high-volume entity sets. Cursor persistence across restarts is a follow-up;
+  today each poll cycle restarts from the filter.
+- **Deep inserts** — writing an order with nested items in one call works if the
+  payload matches the service's deep-insert shape; the connector sends the
+  message body through unchanged.
+- **On-premise** — set `api_base_url` to the gateway service root and, usually,
+  `sap_client`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -77,6 +77,7 @@ nav:
       - Front Systems (POS): connectors/front-systems.md
       - Dynamics 365 Business Central: connectors/business-central.md
       - Visma.net: connectors/visma.md
+      - SAP S/4HANA: connectors/sap-s4hana.md
       - Brightpearl (OMS): connectors/brightpearl.md
       - Tenant-to-tenant: connectors/tenant.md
       - Filters & converters: connectors/filters-converters.md


### PR DESCRIPTION
SAP S/4HANA was the **only** connector without a docs page — it existed solely as a mention in ADR 0001, leaving the B2B plan's P4-3 criterion ("all connectors documented") unmet.

Written against the code, not from memory — every claim verified in `cmd/sap-s4hana-{consumer,producer}`:

- **Both auth modes**: `basic` (S/4HANA Cloud communication user) and `oauth2` client credentials, incl. the default `https://{host}/sap/bc/sec/oauth2/token` endpoint.
- **Addressing**: `host` + `service` + `entity_set`, with the `api_base_url` override for on-prem gateways, and the optional `sap_client` mandt sent as the `sap-client` query param.
- **OData v2 (default) vs v4** — including the differing pagination envelopes (`d.__next` vs `@odata.nextLink`) and the explicit JSON request v2 needs (it defaults to Atom/XML).
- **Producer CSRF**: the `X-CSRF-Token: Fetch` flow and the `403` + `X-CSRF-Token: Required` re-fetch-once retry, plus the retry classification (2xx ack / 429+5xx retry / 4xx+401+403 → DLQ).
- **Live schema preview** via `POST /sample-data/` on aux port 9290.

The Notes section carries the practical traps: picking the right OData version, needing a Communication Arrangement before an API answers at all, and that incremental polling has no cursor persistence yet.

Added to the connector index table and the mkdocs nav (YAML validated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)