### PR TITLE
ADR 0003 + implementation: transforms accept CSV / XML / NDJSON / YAML input

### DIFF
--- a/docs/adr/0003-transform-input-formats.md
+++ b/docs/adr/0003-transform-input-formats.md
@@ -1,6 +1,6 @@
 # ADR 0003 — Transform input formats (CSV / XML / NDJSON / YAML in)
 
-- **Status:** Proposed
+- **Status:** Accepted (2026-08-26)
 - **Date:** 2026-08-26
 - **Relates to:** [ADR 0002](0002-transform-large-payloads.md) (record streaming),
   #187, PRs #198/#199
@@ -131,6 +131,21 @@ Converter and filter nodes gain: `input_format` ("" = auto, `json`, `csv`,
 mirroring the existing output-format one, with the XML record-path field shown
 conditionally. Schema preview ("show data structure") for non-JSON inputs is a
 follow-up — it currently assumes JSON samples.
+
+## Accepted decisions (2026-08-26)
+
+All three open questions were confirmed, with one amplification:
+
+1. **XML's required `input_xml_record_path` — accepted**, *and generalised*: every
+   format carries whatever configuration it genuinely needs to work correctly,
+   rather than a minimal subset. Where a format has a knob that changes whether
+   parsing is right or wrong (CSV delimiter/header presence, XML record path and
+   attribute conventions, NDJSON leniency, YAML multi-document), that knob is
+   exposed rather than assumed. All five input formats ship as first-class.
+2. **CSV values stay strings — accepted.**
+3. **Output behaviour unchanged — accepted.** The converter's output side and
+   the filter's JSON output stay exactly as they are today; this work adds an
+   input stage in front of them and changes nothing downstream.
 
 ## Implementation slices
 

--- a/docs/adr/0003-transform-input-formats.md
+++ b/docs/adr/0003-transform-input-formats.md
@@ -1,0 +1,168 @@
+# ADR 0003 — Transform input formats (CSV / XML / NDJSON / YAML in)
+
+- **Status:** Proposed
+- **Date:** 2026-08-26
+- **Relates to:** [ADR 0002](0002-transform-large-payloads.md) (record streaming),
+  #187, PRs #198/#199
+
+## Context
+
+The converter's *output* side is rich — JSON, CSV, TSV, XML, YAML, text,
+NDJSON — but its *input* side is JSON only: `processEntry` does
+`json.Unmarshal(payload)` and anything else is rejected as "Payload is not
+valid JSON". The filter has the same restriction. So the natural expectations
+**CSV → JSON** and **XML → CSV** fail at the first step, even though every
+piece downstream of parsing already exists.
+
+Two traps documented so they aren't rediscovered:
+
+- `pkg/filter/parser.go` *appears* to support XML input, but it is wired only
+  into the retired legacy `cmd/filter` worker — and its approach doesn't work:
+  `xml.Unmarshal` into a `map[string]interface{}` returns `unknown type`
+  (verified). There is no working non-JSON input anywhere.
+- `pkg/converter` is the legacy `cmd/converter` worker's library, not the live
+  transform's. New code must not build on either legacy package.
+
+What already helps: consumers stamp `env.ContentType` from extension + content
+sniffing (`application/json`, `text/csv`, `application/xml`, `text/plain`,
+`application/octet-stream`), so format auto-detection is mostly free; `yaml.v3`
+is already a dependency; and ADR 0002's record-streaming machinery (spool,
+per-record loop) is exactly the shape a CSV/XML reader needs to plug into.
+
+## Decision drivers
+
+1. CSV→JSON and XML→CSV must work — the full input×output matrix, not pairs.
+2. Non-JSON inputs must not regress ADR 0002: a 2 GB CSV through a converter
+   must stream with bounded memory, not buffer.
+3. Ambiguity must be explicit, not guessed: XML has no inherent record shape.
+4. Both transforms (filter *and* converter) share the record model, so parsing
+   must be shared, not duplicated.
+5. Wrong-format payloads must fail loudly (event/DLQ), never silently
+   mis-parse.
+
+## Decision
+
+### One abstraction: `pkg/records.Reader`
+
+A new package `pkg/records` owns input parsing for both transforms:
+
+```go
+// Reader yields one record at a time; io.EOF ends the stream. Constructors
+// take an io.Reader, so the same Reader serves the buffered path
+// (bytes.NewReader(payload)) and the streaming path (GetStream from the spill
+// store) with no format-specific branching at the call sites.
+type Reader interface {
+    Next() (map[string]interface{}, error)
+}
+
+func New(format string, r io.Reader, opts Options) (Reader, error)
+```
+
+`Options` carries the per-format knobs (CSV delimiter, XML record path/attr
+prefix). Readers for `csv`/`tsv`, `ndjson`, and `xml` are **truly streaming**
+(bounded by record size); `yaml` buffers its document (a yaml.v3 limitation) —
+so over-cap YAML declines exactly like ADR 0002's un-streamable cases.
+
+### Format resolution (per node)
+
+1. `input_format` node config, when set — explicit always wins.
+2. Else `env.ContentType` (`text/csv` → csv, `application/xml` → xml,
+   `application/x-ndjson` → ndjson, `application/json`/empty → json …).
+3. Else a small head-sniff (`{`/`[` → json, `<` → xml, header-like line with
+   delimiters → csv).
+
+JSON remains the default and its existing code paths are **untouched** — the
+legacy buffered semantics (single objects, non-map array elements passing
+through) carry zero regression risk. Non-JSON formats always take the
+reader → per-record transform → spool path regardless of size; the spool keeps
+small outputs inline, so behavior stays consistent with JSON for small
+payloads.
+
+`text/plain` and `application/octet-stream` are **not convertible** — clear
+error naming the content type (today's failure, but honest). Line-oriented
+text-as-records is deliberately out of scope until a real use case names it.
+
+### Format semantics (the decisions that prevent silent wrongness)
+
+**CSV / TSV** — first row is the header; each subsequent row becomes
+`{header: value}` with **string values** (no numeric coercion — predictable
+beats clever; coercion can become a mapping feature later). Headers are
+normalised the way the schema-preview already does (blank → `column_N`,
+duplicates suffixed). Delimiter: `input_csv_delimiter` config, defaulting to a
+sniff of the header line (`,` / `;` / tab). Ragged rows tolerate
+(`FieldsPerRecord = -1`); missing cells are empty strings.
+
+**NDJSON** — one JSON value per line; each object is a record. The streaming
+JSON path gets this nearly free: `json.Decoder` yields concatenated values
+natively.
+
+**XML** — the genuinely ambiguous one, resolved by configuration + convention:
+
+- `input_xml_record_path` (**required** for XML input): the path to the
+  repeating record element, e.g. `Orders.Order`. No inherent row concept in
+  XML means guessing here silently produces wrong shapes — so we don't guess;
+  missing path with XML input is a config error.
+- Element → map: child elements become keys; repeated same-name children
+  become arrays; leaf text is the string value; attributes become `@attr`
+  keys; mixed text alongside children lands in `#text`. (The mxj/badgerfish
+  convention — familiar, round-trippable.)
+- Namespaces: prefixes are kept as written (`ns:Order` stays a literal key);
+  namespace *resolution* is out of scope.
+- Implementation: a token-walking `encoding/xml.Decoder` — streams natively,
+  buffers only the current record subtree, no new dependency.
+
+**YAML** — parsed with yaml.v3; a mapping document is one record, a sequence
+document is N records, multi-document streams (`---`) yield records per
+document. Non-string map keys are stringified. Buffered-only (see above).
+
+### The filter's output shape
+
+The filter gains the same input formats (rules and `extract_fields` operate on
+records regardless of where they came from), but its output stays **JSON** —
+it has no output-format config, and inventing implicit format preservation
+would surprise more than it helps. Pipeline wanting CSV-in → CSV-out filtering
+adds a converter after the filter. Documented, not hidden.
+
+### Config + UI surface
+
+Converter and filter nodes gain: `input_format` ("" = auto, `json`, `csv`,
+`tsv`, `ndjson`, `xml`, `yaml`), `input_csv_delimiter`, and (XML)
+`input_xml_record_path`. The PropertyEditor gets an "Input format" selector
+mirroring the existing output-format one, with the XML record-path field shown
+conditionally. Schema preview ("show data structure") for non-JSON inputs is a
+follow-up — it currently assumes JSON samples.
+
+## Implementation slices
+
+1. **`pkg/records` + CSV/TSV + NDJSON** wired into both transforms (buffered +
+   streaming paths), format resolution, config fields, UI selector, tests.
+   Covers CSV → anything — the headline ask — and streams at any size.
+2. **XML** — the token-walking reader + `input_xml_record_path` + attribute
+   conventions. Covers XML → anything.
+3. **YAML** (small, buffered-only) — take it opportunistically with slice 1 or
+   2.
+
+## Consequences
+
+**Positive.** The full input×output matrix (5 inputs × 7 outputs) with one
+shared parsing package; CSV and XML inputs stream at any size through the
+ADR 0002 machinery; explicit configuration where formats are ambiguous.
+
+**Negative / accepted.** XML requires the user to name the record path — a
+deliberate refusal to guess. YAML stays buffered (cap applies). String-typed
+CSV values may need a later coercion story for numeric filter rules
+(`gt`/`lt` on `"42"`); the filter's `compareNumeric` already coerces strings,
+so the common cases work — documented rather than solved here. The transforms
+gain another axis of config surface.
+
+## Test plan
+
+- Per-reader unit tests incl. the nasty cases: quoted/ragged CSV, duplicate
+  headers, XML attributes/repeats/mixed content, YAML multi-doc.
+- Round-trip parity: CSV → records → CSV re-encode is stable; XML fixture →
+  records matches a golden file.
+- Streaming parity: streamed CSV output byte-identical to buffered on the same
+  input (same harness pattern as ADR 0002's parity tests).
+- TEST-env validation with a multi-hundred-MB CSV through
+  converter (`csv` in → `ndjson` out) via `cmd/spill-e2e` (extended to
+  generate CSV), per the standing TEST-before-prod rule.

--- a/docs/adr/0003-transform-input-formats.md
+++ b/docs/adr/0003-transform-input-formats.md
@@ -172,6 +172,34 @@ gain another axis of config surface.
 
 ## Test plan
 
+> **Validated in the TEST compose env (2026-08-27)** — real NATS + MinIO, rebuilt
+> transform images, pipeline `CSV -> filter (csv in, rules) -> converter
+> (rename, ndjson out)` driven by `cmd/spill-e2e -format csv`:
+>
+> | Run | Result |
+> |---|---|
+> | 8 MiB CSV (buffered path) | PASS — 4,059 NDJSON lines, exact expected count |
+> | 300 MiB CSV (streaming path) | PASS — 151,948 lines, exact count |
+>
+> Memory during the 300 MiB run peaked at **44.2 MiB (filter)** and **42.2 MiB
+> (converter)** — the record-streaming bound holds for CSV exactly as it does
+> for JSON. Output carried `"index":"1"` as a *string*, confirming the
+> values-stay-strings decision end to end.
+>
+> **The run earned its keep — it caught two bugs unit tests did not:**
+>
+> 1. **ContentType propagation.** The filter parses CSV but emits JSON, and it
+>    was inheriting the input's `text/csv`. The next node auto-detects from
+>    ContentType, so the converter parsed the filter's JSON *as CSV*, read the
+>    whole single-line array as a header row, and produced **zero records** —
+>    silently. Both transforms now stamp the content type they actually emit,
+>    and neither inherits the input's `PayloadSize`/`Checksum` (which described
+>    a different payload). Guarded by a regression test over both paths.
+> 2. **Empty streamed output.** `Spool.Result()` returned a nil `Inline` for an
+>    empty result, which callers read as "spilled" — publishing an envelope with
+>    neither payload nor reference. Now a non-nil empty slice.
+
+
 - Per-reader unit tests incl. the nasty cases: quoted/ragged CSV, duplicate
   headers, XML attributes/repeats/mixed content, YAML multi-doc.
 - Round-trip parity: CSV → records → CSV re-encode is stable; XML fixture →

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,4 +37,5 @@ Architecture and internals — [NATS architecture](NATS_ARCHITECTURE.md),
 [connector SDK](sdk/README.md), [scalability](scalability.md).
 
 Design decisions — [ADR 0001: streaming payload contract](adr/0001-streaming-payload-contract.md),
-[ADR 0002: large payloads through transforms](adr/0002-transform-large-payloads.md).
+[ADR 0002: large payloads through transforms](adr/0002-transform-large-payloads.md),
+[ADR 0003: transform input formats](adr/0003-transform-input-formats.md).

--- a/src/cmd/brightpearl-producer/service.go
+++ b/src/cmd/brightpearl-producer/service.go
@@ -188,7 +188,6 @@ func (p *brightpearlProducer) getConfig(ctx context.Context, connectionID, tenan
 	return nil, errors.New("no brightpearl producer node found")
 }
 
-
 // ServesConnection reports whether this connection has a Brightpearl destination —
 // mirroring Deliver's own "no config -> not ours" semantics — so the SDK can
 // ack foreign connections before rehydrating large payloads (sdk.ConnectionScoped).

--- a/src/cmd/business-central-producer/service.go
+++ b/src/cmd/business-central-producer/service.go
@@ -225,7 +225,6 @@ func (p *bcProducer) getConfig(ctx context.Context, connectionID, tenantID strin
 	return nil, errors.New("no business_central producer node found")
 }
 
-
 // ServesConnection reports whether this connection has a Business Central destination —
 // mirroring Deliver's own "no config -> not ours" semantics — so the SDK can
 // ack foreign connections before rehydrating large payloads (sdk.ConnectionScoped).

--- a/src/cmd/cloud-storage-producer/service.go
+++ b/src/cmd/cloud-storage-producer/service.go
@@ -382,7 +382,6 @@ func (p *cloudProducer) getTargets(ctx context.Context, connID, tenantID string)
 	return targets, nil
 }
 
-
 // ServesConnection reports whether this connection has a matching destination —
 // mirroring Deliver's own "no config -> not ours" semantics — so the SDK can
 // ack foreign connections before rehydrating large payloads (sdk.ConnectionScoped).

--- a/src/cmd/data-converter/claimcheck_test.go
+++ b/src/cmd/data-converter/claimcheck_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"io"
 	"log/slog"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -303,5 +304,150 @@ func TestConverter_StreamingDeclinesXML(t *testing.T) {
 	msg := refEnvelopeMsg(t, store, streamingParityPayload())
 	if err := s.handleMessage(context.Background(), msg); err == nil {
 		t.Fatal("xml + over-cap must NAK (phase C error policy), not stream")
+	}
+}
+
+// --- ADR 0003: non-JSON input formats ---
+
+// bufferedThrough runs an INLINE (non-offloaded) payload through the converter
+// and returns the republished output — the ordinary small-payload path.
+func bufferedThrough(t *testing.T, cfg *ConverterNodeConfig, contentType string, payload []byte) *envelope.Envelope {
+	t.Helper()
+	nc, js, cleanup := harness.StartEmbeddedJetStream(t)
+	defer cleanup()
+
+	store := newMemStore()
+	entry := &ConverterEntry{NodeID: "cv1", Config: cfg, PredIsConsumer: true}
+	s := newTestConverterService(store, entry)
+	s.nc = nc
+	s.pub = messaging.NewPublisher(js)
+	if err := s.Start(context.Background()); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	defer s.Stop()
+
+	out := make(chan *envelope.Envelope, 4)
+	sub, err := nc.Subscribe("vrsky.data.tenant-x.pipeline.conn-1", func(m *nats.Msg) {
+		var env envelope.Envelope
+		if json.Unmarshal(m.Data, &env) == nil && env.Metadata != nil {
+			if v, _ := env.Metadata["_last_processed_by"].(string); v == "cv1" {
+				out <- &env
+			}
+		}
+	})
+	if err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+	defer func() { _ = sub.Unsubscribe() }()
+
+	env := envelope.New()
+	env.TenantID = "tenant-x"
+	env.IntegrationID = "conn-1"
+	env.ContentType = contentType
+	env.Payload = payload
+	data, _ := json.Marshal(env)
+	if _, err := js.Publish("vrsky.data.tenant-x.pipeline.conn-1", data); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+
+	select {
+	case got := <-out:
+		return got
+	case <-time.After(5 * time.Second):
+		t.Fatal("no republished envelope")
+		return nil
+	}
+}
+
+// The headline ask: deliver CSV, want JSON.
+func TestConverter_CSVInJSONOut(t *testing.T) {
+	cfg := &ConverterNodeConfig{} // no output_format = JSON out
+	got := bufferedThrough(t, cfg, "text/csv", []byte("name,qty\nwidget,3\ngadget,7\n"))
+
+	var rows []map[string]interface{}
+	if err := json.Unmarshal(got.Payload, &rows); err != nil {
+		t.Fatalf("output is not JSON: %v (%s)", err, got.Payload)
+	}
+	if len(rows) != 2 || rows[0]["name"] != "widget" || rows[1]["qty"] != "7" {
+		t.Errorf("CSV was not parsed into records: %v", rows)
+	}
+}
+
+// The other headline ask: deliver XML, want CSV.
+func TestConverter_XMLInCSVOut(t *testing.T) {
+	cfg := &ConverterNodeConfig{
+		OutputFormat:       "csv",
+		InputFormat:        "xml",
+		InputXmlRecordPath: "Orders.Order",
+	}
+	doc := []byte(`<Orders><Order><id>1</id><city>Oslo</city></Order><Order><id>2</id><city>Bergen</city></Order></Orders>`)
+	got := bufferedThrough(t, cfg, "application/xml", doc)
+
+	csvOut := string(got.Payload)
+	if !strings.Contains(csvOut, "Oslo") || !strings.Contains(csvOut, "Bergen") {
+		t.Errorf("XML rows missing from CSV output: %q", csvOut)
+	}
+	if got.ContentType != "text/csv" {
+		t.Errorf("ContentType = %q, want text/csv", got.ContentType)
+	}
+	if lines := strings.Count(strings.TrimSpace(csvOut), "\n"); lines != 2 { // header + 2 rows
+		t.Errorf("expected a header and 2 rows, got:\n%s", csvOut)
+	}
+}
+
+// Auto-detection: no input_format set, format comes from the ContentType the
+// consumer stamped.
+func TestConverter_AutoDetectsCSVFromContentType(t *testing.T) {
+	got := bufferedThrough(t, &ConverterNodeConfig{OutputFormat: "ndjson"}, "text/csv", []byte("a,b\n1,2\n"))
+	if !strings.Contains(string(got.Payload), `"a":"1"`) {
+		t.Errorf("CSV not auto-detected from ContentType: %q", got.Payload)
+	}
+}
+
+// A mapping applies to CSV records the same way it does to JSON ones.
+func TestConverter_CSVWithFieldMapping(t *testing.T) {
+	cfg := &ConverterNodeConfig{
+		InputFormat: "csv",
+		Mappings:    []FieldMapping{{Source: "qty", Target: "quantity", Type: "rename"}},
+	}
+	got := bufferedThrough(t, cfg, "text/csv", []byte("name,qty\nwidget,3\n"))
+	var rows []map[string]interface{}
+	if err := json.Unmarshal(got.Payload, &rows); err != nil {
+		t.Fatalf("output not JSON: %v", err)
+	}
+	if rows[0]["quantity"] != "3" {
+		t.Errorf("mapping did not apply to a CSV record: %v", rows[0])
+	}
+	if _, still := rows[0]["qty"]; still {
+		t.Errorf("rename should have removed the source field: %v", rows[0])
+	}
+}
+
+// XML without a record path is a config error the operator must fix — the
+// message has to name the field, not fail obscurely.
+func TestConverter_XMLWithoutRecordPathIsAClearError(t *testing.T) {
+	cfg := &ConverterNodeConfig{InputFormat: "xml"}
+	env := envelope.New()
+	env.ContentType = "application/xml"
+	env.Payload = []byte("<a><b/></a>")
+	_, err := parsePayload(cfg, env)
+	if err == nil {
+		t.Fatal("xml without a record path must error")
+	}
+	if !strings.Contains(err.Error(), "input_xml_record_path") {
+		t.Errorf("error should name the config field, got: %v", err)
+	}
+}
+
+// JSON keeps its original code path — the accepted zero-regression condition.
+func TestConverter_JSONInputUnchanged(t *testing.T) {
+	cfg := &ConverterNodeConfig{Mappings: []FieldMapping{{Source: "name", Target: "full_name", Type: "rename"}}}
+	got := bufferedThrough(t, cfg, "application/json", []byte(`{"name":"acme"}`))
+	var obj map[string]interface{}
+	if err := json.Unmarshal(got.Payload, &obj); err != nil {
+		t.Fatalf("a single JSON object should still convert to a single object: %v (%s)", err, got.Payload)
+	}
+	if obj["full_name"] != "acme" {
+		t.Errorf("JSON behaviour changed: %v", obj)
 	}
 }

--- a/src/cmd/data-converter/input.go
+++ b/src/cmd/data-converter/input.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"github.com/ValueRetail/vrsky/pkg/envelope"
+	"github.com/ValueRetail/vrsky/pkg/records"
+)
+
+// inputOptions maps the node's input_* config onto reader options (ADR 0003).
+func (cfg *ConverterNodeConfig) inputOptions() records.Options {
+	opts := records.Options{
+		NoHeader:   cfg.InputCsvNoHeader,
+		TrimSpace:  cfg.InputCsvTrimSpace,
+		RecordPath: cfg.InputXmlRecordPath,
+		AttrPrefix: cfg.InputXmlAttrPrefix,
+		TextKey:    cfg.InputXmlTextKey,
+	}
+	if d := []rune(cfg.InputCsvDelimiter); len(d) > 0 {
+		opts.Delimiter = d[0]
+	}
+	return opts
+}
+
+// inputFormat resolves the format for this envelope: explicit node config
+// first, then the ContentType the consumer stamped, then a sniff of the payload
+// head, then json.
+func (cfg *ConverterNodeConfig) inputFormat(env *envelope.Envelope) string {
+	head := env.Payload
+	if len(head) > records.SniffLen {
+		head = head[:records.SniffLen]
+	}
+	return records.Detect(cfg.InputFormat, env.ContentType, head)
+}
+
+// parsePayload produces the value the transform works on, from a payload in
+// whatever format the node accepts (ADR 0003).
+//
+// JSON deliberately keeps its ORIGINAL code path — a plain json.Unmarshal —
+// rather than routing through pkg/records. The two agree on ordinary payloads,
+// but the old path has long-standing edge behaviour (scalar documents, arrays
+// of non-objects passing through the mapping stage untouched) that existing
+// pipelines may depend on. Zero regression for JSON was an accepted ADR
+// condition, so JSON gets bit-for-bit the same handling as before and the new
+// readers serve only the formats that previously did not work at all.
+func parsePayload(cfg *ConverterNodeConfig, env *envelope.Envelope) (interface{}, error) {
+	format := cfg.inputFormat(env)
+	if format == records.FormatJSON {
+		var data interface{}
+		if err := json.Unmarshal(env.Payload, &data); err != nil {
+			return nil, fmt.Errorf("payload is not valid JSON: %w", err)
+		}
+		return data, nil
+	}
+
+	r, err := records.New(format, bytes.NewReader(env.Payload), cfg.inputOptions())
+	if err != nil {
+		return nil, err
+	}
+	recs, err := records.ReadAll(r)
+	if err != nil {
+		return nil, fmt.Errorf("parse %s payload: %w", format, err)
+	}
+	// Record-oriented formats always present as a list, which is what the
+	// mapping and format stages already expect from a JSON array.
+	out := make([]interface{}, len(recs))
+	for i, rec := range recs {
+		out[i] = map[string]interface{}(rec)
+	}
+	return out, nil
+}
+
+// transcodes reports whether this node changes the payload's format on its own,
+// i.e. the input is something other than JSON. It matters because the converter
+// treats "no mappings and no output format" as a no-op — which was right when
+// every input was JSON, but a CSV input with no output format means "parse this
+// CSV and give me JSON", which is real work.
+func (cfg *ConverterNodeConfig) transcodes(env *envelope.Envelope) bool {
+	return cfg.inputFormat(env) != records.FormatJSON
+}

--- a/src/cmd/data-converter/main.go
+++ b/src/cmd/data-converter/main.go
@@ -47,6 +47,16 @@ type ConverterNodeConfig struct {
 	Mappings     []FieldMapping `json:"mappings"`
 	DropUnmapped bool           `json:"drop_unmapped"`
 
+	// Input parsing (ADR 0003). Empty InputFormat = auto-detect from the
+	// envelope's ContentType, then a content sniff, then json.
+	InputFormat        string `json:"input_format"`          // "", "json", "ndjson", "csv", "tsv", "xml", "yaml"
+	InputCsvDelimiter  string `json:"input_csv_delimiter"`   // "" = sniff
+	InputCsvNoHeader   bool   `json:"input_csv_no_header"`   // treat the first row as data
+	InputCsvTrimSpace  bool   `json:"input_csv_trim_space"`  // trim whitespace in values
+	InputXmlRecordPath string `json:"input_xml_record_path"` // REQUIRED for xml, e.g. "Orders.Order"
+	InputXmlAttrPrefix string `json:"input_xml_attr_prefix"` // default "@"
+	InputXmlTextKey    string `json:"input_xml_text_key"`    // default "#text"
+
 	// Format conversion
 	OutputFormat string `json:"output_format"` // "", "csv", "tsv", "xml", "text", "yaml", "ndjson"
 	CsvDelimiter string `json:"csv_delimiter"`
@@ -312,7 +322,9 @@ func (s *ConverterService) processEntry(ctx context.Context, connectionID, subje
 	converterCfg := entry.Config
 	hasMapping := len(converterCfg.Mappings) > 0
 	hasFormat := converterCfg.OutputFormat != ""
-	if !hasMapping && !hasFormat {
+	// A non-JSON input is a conversion in itself (ADR 0003): "CSV in, nothing
+	// else configured" means "give me JSON", so it is not a no-op.
+	if !hasMapping && !hasFormat && !converterCfg.transcodes(origEnv) {
 		return nil
 	}
 
@@ -326,9 +338,11 @@ func (s *ConverterService) processEntry(ctx context.Context, connectionID, subje
 	payload := make([]byte, len(origEnv.Payload))
 	copy(payload, origEnv.Payload)
 
-	var data interface{}
-	if err := json.Unmarshal(payload, &data); err != nil {
-		s.emitEvent(connectionID, ConvertEvent{Type: "error", Message: "Payload is not valid JSON: " + err.Error(), Time: now()})
+	// Parse the payload in whatever format this node accepts (ADR 0003): json
+	// (default, unchanged code path), ndjson, csv/tsv, xml or yaml.
+	data, perr := parsePayload(converterCfg, origEnv)
+	if perr != nil {
+		s.emitEvent(connectionID, ConvertEvent{Type: "error", Message: "Payload parse failed: " + perr.Error(), Time: now()})
 		return nil
 	}
 

--- a/src/cmd/data-converter/main.go
+++ b/src/cmd/data-converter/main.go
@@ -407,6 +407,9 @@ func (s *ConverterService) processEntry(ctx context.Context, connectionID, subje
 	if newContentType != "" {
 		env.ContentType = newContentType
 	}
+	// Never inherit the INPUT's size/checksum/ref — they describe a different
+	// payload. OffloadIfLarge re-stamps them when it spills.
+	env.PayloadRef, env.PayloadSize, env.Checksum = "", int64(len(newPayload)), ""
 	env.Metadata = make(map[string]interface{})
 	for k, v := range origEnv.Metadata {
 		env.Metadata[k] = v

--- a/src/cmd/data-converter/streaming.go
+++ b/src/cmd/data-converter/streaming.go
@@ -1,14 +1,18 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 
 	"github.com/google/uuid"
 
 	"github.com/ValueRetail/vrsky/pkg/claimcheck"
 	"github.com/ValueRetail/vrsky/pkg/envelope"
+	"github.com/ValueRetail/vrsky/pkg/records"
 )
 
 // streamEntry is the record-streaming path (ADR 0002 phase B): the input
@@ -48,15 +52,27 @@ func (s *ConverterService) streamEntry(ctx context.Context, connectionID string,
 	}
 	defer rc.Close()
 
-	dec := json.NewDecoder(rc)
-	tok, err := dec.Token()
-	if err != nil {
-		s.emitEvent(connectionID, ConvertEvent{Type: "error", Message: "Streamed payload is not valid JSON: " + err.Error(), Time: now()})
-		return nil // will never parse — ack, like the buffered invalid-JSON path
+	// Resolve the input format from the node config / ContentType and build a
+	// streaming reader for it (ADR 0003). csv/tsv, json, ndjson and xml all
+	// parse incrementally, so a multi-GB payload in any of them streams; yaml
+	// buffers each document and is declined above.
+	head := make([]byte, records.SniffLen)
+	n, _ := io.ReadFull(rc, head)
+	head = head[:n]
+	body := io.MultiReader(bytes.NewReader(head), rc)
+
+	format := records.Detect(cfg.InputFormat, origEnv.ContentType, head)
+	if !records.Streams(format) {
+		return fmt.Errorf("converter node %s: %s input cannot be streamed (payload is %d bytes, over the %d-byte rehydrate cap); raise %s to buffer it",
+			entry.NodeID, format, origEnv.PayloadSize, s.rehydrateMax, claimcheck.EnvRehydrateMax)
 	}
-	if d, ok := tok.(json.Delim); !ok || d != '[' {
-		return fmt.Errorf("converter node %s: only JSON array payloads can be streamed; this payload (%d bytes) starts with %v — raise %s to buffer it",
-			entry.NodeID, origEnv.PayloadSize, tok, claimcheck.EnvRehydrateMax)
+	opts := cfg.inputOptions()
+	opts.RequireSequence = true // a lone top-level value would buffer the whole payload
+	reader, rerr := records.New(format, body, opts)
+	if rerr != nil {
+		// Config errors (e.g. xml without a record path) will never succeed on
+		// redelivery, but they are the operator's to fix — surface loudly.
+		return fmt.Errorf("converter node %s: %w", entry.NodeID, rerr)
 	}
 
 	env := *origEnv
@@ -88,13 +104,23 @@ func (s *ConverterService) streamEntry(ctx context.Context, connectionID string,
 		delim      = csvDelim(cfg)
 	)
 
-	for dec.More() {
-		var rec interface{}
-		if derr := dec.Decode(&rec); derr != nil {
-			spool.Abort(s.logger)
-			s.emitEvent(connectionID, ConvertEvent{Type: "error", Message: "Streamed payload record is not valid JSON: " + derr.Error(), Time: now()})
-			return nil // deterministic — ack, matching the buffered invalid-JSON path
+	for {
+		parsedRec, derr := reader.Next()
+		if derr == io.EOF {
+			break
 		}
+		if derr != nil {
+			spool.Abort(s.logger)
+			if errors.Is(derr, records.ErrNotASequence) {
+				// Well-formed but unstreamable (a lone top-level value): decline
+				// so it reaches the DLQ, rather than acking it away.
+				return fmt.Errorf("converter node %s: %w (payload is %d bytes, over the %d-byte rehydrate cap); raise %s to buffer it",
+					entry.NodeID, derr, origEnv.PayloadSize, s.rehydrateMax, claimcheck.EnvRehydrateMax)
+			}
+			s.emitEvent(connectionID, ConvertEvent{Type: "error", Message: "Streamed payload record is malformed: " + derr.Error(), Time: now()})
+			return nil // deterministic — ack, matching the buffered parse-failure path
+		}
+		var rec interface{} = map[string]interface{}(parsedRec)
 
 		obj, isMap := rec.(map[string]interface{})
 		if hasMapping && isMap {

--- a/src/cmd/data-filter/claimcheck_test.go
+++ b/src/cmd/data-filter/claimcheck_test.go
@@ -536,3 +536,83 @@ func patchContentType(t *testing.T, msg *nats.Msg, ct string) {
 	}
 	msg.Data = data
 }
+
+// The filter emits JSON whatever it consumed, so it MUST stamp
+// application/json — the next node auto-detects from ContentType, and
+// inheriting "text/csv" made the converter parse the filter's JSON as CSV and
+// silently produce zero records. Found by the TEST-env run; guarded here on
+// both the buffered and the streaming path.
+func TestFilter_OutputContentTypeIsJSONForNonJSONInput(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		streaming bool
+	}{{"buffered", false}, {"streamed", true}} {
+		t.Run(tc.name, func(t *testing.T) {
+			nc, js, cleanup := harness.StartEmbeddedJetStream(t)
+			defer cleanup()
+
+			store := newMemStore()
+			entry := &FilterEntry{
+				NodeID:         "f1",
+				Config:         &FilterNodeConfig{InputFormat: "csv", Rules: []FilterRule{{Field: "keep", Operator: "equals", Value: "yes"}}},
+				PredIsConsumer: true,
+			}
+			s := newTestFilterService(store, entry)
+			s.nc = nc
+			s.pub = messaging.NewPublisher(js)
+			if tc.streaming {
+				s.rehydrateMax = 100 // force the streaming path
+			}
+			if err := s.Start(context.Background()); err != nil {
+				t.Fatalf("start: %v", err)
+			}
+			defer s.Stop()
+
+			out := make(chan *envelope.Envelope, 4)
+			sub, err := nc.Subscribe("vrsky.data.tenant-x.pipeline.conn-1", func(m *nats.Msg) {
+				var env envelope.Envelope
+				if json.Unmarshal(m.Data, &env) == nil && env.Metadata != nil {
+					if v, _ := env.Metadata["_last_processed_by"].(string); v == "f1" {
+						out <- &env
+					}
+				}
+			})
+			if err != nil {
+				t.Fatalf("subscribe: %v", err)
+			}
+			defer func() { _ = sub.Unsubscribe() }()
+
+			payload := []byte("keep,v\nyes,1\nno,2\nyes,3\n")
+			if tc.streaming {
+				msg := refEnvelopeMsg(t, store, payload)
+				patchContentType(t, msg, "text/csv")
+				if _, err := js.Publish(msg.Subject, msg.Data); err != nil {
+					t.Fatalf("publish: %v", err)
+				}
+			} else {
+				env := envelope.New()
+				env.TenantID = "tenant-x"
+				env.IntegrationID = "conn-1"
+				env.ContentType = "text/csv"
+				env.Payload = payload
+				data, _ := json.Marshal(env)
+				if _, err := js.Publish("vrsky.data.tenant-x.pipeline.conn-1", data); err != nil {
+					t.Fatalf("publish: %v", err)
+				}
+			}
+
+			select {
+			case got := <-out:
+				if got.ContentType != "application/json" {
+					t.Errorf("ContentType = %q, want application/json — a downstream node would mis-parse this", got.ContentType)
+				}
+				// And the size/checksum must describe THIS payload, not the input's.
+				if got.PayloadRef == "" && got.PayloadSize != int64(len(got.Payload)) {
+					t.Errorf("PayloadSize %d does not match the inline payload (%d bytes)", got.PayloadSize, len(got.Payload))
+				}
+			case <-time.After(5 * time.Second):
+				t.Fatal("no republished envelope")
+			}
+		})
+	}
+}

--- a/src/cmd/data-filter/claimcheck_test.go
+++ b/src/cmd/data-filter/claimcheck_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"io"
 	"log/slog"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -408,4 +409,130 @@ func TestFilter_StreamedAllDroppedPublishesNothing(t *testing.T) {
 	if len(store.objects) != objectsBefore {
 		t.Errorf("no output object should exist after an all-dropped stream")
 	}
+}
+
+// --- ADR 0003: non-JSON input formats ---
+
+// The filter evaluates rules against CSV rows and still emits JSON — its output
+// format is deliberately unchanged (ADR 0003).
+func TestFilter_CSVInputRulesApplyJSONOut(t *testing.T) {
+	nc, js, cleanup := harness.StartEmbeddedJetStream(t)
+	defer cleanup()
+
+	entry := &FilterEntry{
+		NodeID:         "f1",
+		Config:         &FilterNodeConfig{Rules: []FilterRule{{Field: "keep", Operator: "equals", Value: "yes"}}},
+		PredIsConsumer: true,
+	}
+	s := newTestFilterService(newMemStore(), entry)
+	s.nc = nc
+	s.pub = messaging.NewPublisher(js)
+	if err := s.Start(context.Background()); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	defer s.Stop()
+
+	out := make(chan *envelope.Envelope, 4)
+	sub, err := nc.Subscribe("vrsky.data.tenant-x.pipeline.conn-1", func(m *nats.Msg) {
+		var env envelope.Envelope
+		if json.Unmarshal(m.Data, &env) == nil && env.Metadata != nil {
+			if v, _ := env.Metadata["_last_processed_by"].(string); v == "f1" {
+				out <- &env
+			}
+		}
+	})
+	if err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+	defer func() { _ = sub.Unsubscribe() }()
+
+	env := envelope.New()
+	env.TenantID = "tenant-x"
+	env.IntegrationID = "conn-1"
+	env.ContentType = "text/csv"
+	env.Payload = []byte("keep,v\nyes,1\nno,2\nyes,3\n")
+	data, _ := json.Marshal(env)
+	if _, err := js.Publish("vrsky.data.tenant-x.pipeline.conn-1", data); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+
+	select {
+	case got := <-out:
+		var rows []map[string]interface{}
+		if err := json.Unmarshal(got.Payload, &rows); err != nil {
+			t.Fatalf("filter output should be JSON: %v (%s)", err, got.Payload)
+		}
+		if len(rows) != 2 {
+			t.Errorf("rules should have kept 2 CSV rows, got %d: %v", len(rows), rows)
+		}
+		for _, r := range rows {
+			if r["keep"] != "yes" {
+				t.Errorf("wrong row kept: %v", r)
+			}
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("no republished envelope for a CSV input")
+	}
+}
+
+// An over-cap CSV takes the streaming path — the ADR 0002 machinery now carries
+// non-JSON formats too, so a multi-GB CSV never buffers.
+func TestFilter_StreamsOverCapCSV(t *testing.T) {
+	store := newMemStore()
+	entry := &FilterEntry{
+		NodeID:         "f1",
+		Config:         &FilterNodeConfig{InputFormat: "csv", Rules: []FilterRule{{Field: "keep", Operator: "equals", Value: "yes"}}},
+		PredIsConsumer: true,
+	}
+	_, _, js, out, done := startStreamingFilter(t, store, entry)
+	defer done()
+
+	var sb strings.Builder
+	sb.WriteString("keep,pad\n")
+	for i := 0; i < 200; i++ {
+		keep := "no"
+		if i%2 == 0 {
+			keep = "yes"
+		}
+		sb.WriteString(keep + "," + strings.Repeat("x", 40) + "\n")
+	}
+	msg := refEnvelopeMsg(t, store, []byte(sb.String()))
+	// refEnvelopeMsg stamps JSON; this payload is CSV.
+	patchContentType(t, msg, "text/csv")
+	if _, err := js.Publish(msg.Subject, msg.Data); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+
+	select {
+	case got := <-out:
+		body := got.Payload
+		if got.PayloadRef != "" {
+			body, _, _ = store.Get(context.Background(), got.PayloadRef)
+		}
+		var rows []map[string]interface{}
+		if err := json.Unmarshal(body, &rows); err != nil {
+			t.Fatalf("streamed CSV output should be JSON: %v", err)
+		}
+		if len(rows) != 100 {
+			t.Errorf("expected 100 kept rows from a streamed CSV, got %d", len(rows))
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("no republished envelope from the streamed CSV")
+	}
+}
+
+// patchContentType rewrites the ContentType on an already-marshalled envelope
+// message, so the streaming helpers can be reused for non-JSON payloads.
+func patchContentType(t *testing.T, msg *nats.Msg, ct string) {
+	t.Helper()
+	var env envelope.Envelope
+	if err := json.Unmarshal(msg.Data, &env); err != nil {
+		t.Fatalf("patch content type: %v", err)
+	}
+	env.ContentType = ct
+	data, err := json.Marshal(&env)
+	if err != nil {
+		t.Fatalf("patch content type: %v", err)
+	}
+	msg.Data = data
 }

--- a/src/cmd/data-filter/input.go
+++ b/src/cmd/data-filter/input.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"github.com/ValueRetail/vrsky/pkg/envelope"
+	"github.com/ValueRetail/vrsky/pkg/records"
+)
+
+// inputOptions maps the node's input_* config onto reader options (ADR 0003).
+func (cfg *FilterNodeConfig) inputOptions() records.Options {
+	opts := records.Options{
+		NoHeader:   cfg.InputCsvNoHeader,
+		TrimSpace:  cfg.InputCsvTrimSpace,
+		RecordPath: cfg.InputXmlRecordPath,
+		AttrPrefix: cfg.InputXmlAttrPrefix,
+		TextKey:    cfg.InputXmlTextKey,
+	}
+	if d := []rune(cfg.InputCsvDelimiter); len(d) > 0 {
+		opts.Delimiter = d[0]
+	}
+	return opts
+}
+
+// inputFormat resolves the format for this envelope: explicit node config
+// first, then the ContentType the consumer stamped, then a sniff, then json.
+func (cfg *FilterNodeConfig) inputFormat(env *envelope.Envelope) string {
+	head := env.Payload
+	if len(head) > records.SniffLen {
+		head = head[:records.SniffLen]
+	}
+	return records.Detect(cfg.InputFormat, env.ContentType, head)
+}
+
+// parsePayload produces the value the filter evaluates rules against.
+//
+// JSON keeps its ORIGINAL json.Unmarshal path rather than routing through
+// pkg/records: the two agree on ordinary payloads, but the old path has
+// long-standing edge behaviour that existing pipelines may rely on, and zero
+// regression for JSON was an accepted ADR condition. The new readers serve only
+// the formats that previously did not work at all.
+func parsePayload(cfg *FilterNodeConfig, env *envelope.Envelope) (interface{}, error) {
+	format := cfg.inputFormat(env)
+	if format == records.FormatJSON {
+		var data interface{}
+		if err := json.Unmarshal(env.Payload, &data); err != nil {
+			return nil, fmt.Errorf("payload is not valid JSON: %w", err)
+		}
+		return data, nil
+	}
+
+	r, err := records.New(format, bytes.NewReader(env.Payload), cfg.inputOptions())
+	if err != nil {
+		return nil, err
+	}
+	recs, err := records.ReadAll(r)
+	if err != nil {
+		return nil, fmt.Errorf("parse %s payload: %w", format, err)
+	}
+	out := make([]interface{}, len(recs))
+	for i, rec := range recs {
+		out[i] = map[string]interface{}(rec)
+	}
+	return out, nil
+}

--- a/src/cmd/data-filter/main.go
+++ b/src/cmd/data-filter/main.go
@@ -414,6 +414,13 @@ func (s *FilterService) processFilterEntry(ctx context.Context, connectionID, su
 	env := *origEnv
 	env.ID = uuid.New().String()
 	env.Payload = newPayload
+	// The filter always emits JSON, whatever the input format was (ADR 0003).
+	// Saying so matters: the next node auto-detects from ContentType, and
+	// inheriting "text/csv" here would make it parse this JSON as CSV.
+	env.ContentType = "application/json"
+	// Never inherit the INPUT's size/checksum/ref — they describe a different
+	// payload. OffloadIfLarge re-stamps them when it spills.
+	env.PayloadRef, env.PayloadSize, env.Checksum = "", int64(len(newPayload)), ""
 	env.Metadata = make(map[string]interface{})
 	for k, v := range origEnv.Metadata {
 		env.Metadata[k] = v

--- a/src/cmd/data-filter/main.go
+++ b/src/cmd/data-filter/main.go
@@ -55,6 +55,18 @@ type FilterRule struct {
 }
 
 type FilterNodeConfig struct {
+	// Input parsing (ADR 0003). Empty InputFormat = auto-detect from the
+	// envelope's ContentType, then a content sniff, then json. The filter's
+	// OUTPUT stays JSON regardless of input format — add a converter after it
+	// to emit another format.
+	InputFormat        string `json:"input_format"`          // "", "json", "ndjson", "csv", "tsv", "xml", "yaml"
+	InputCsvDelimiter  string `json:"input_csv_delimiter"`   // "" = sniff
+	InputCsvNoHeader   bool   `json:"input_csv_no_header"`   // treat the first row as data
+	InputCsvTrimSpace  bool   `json:"input_csv_trim_space"`  // trim whitespace in values
+	InputXmlRecordPath string `json:"input_xml_record_path"` // REQUIRED for xml, e.g. "Orders.Order"
+	InputXmlAttrPrefix string `json:"input_xml_attr_prefix"` // default "@"
+	InputXmlTextKey    string `json:"input_xml_text_key"`    // default "#text"
+
 	Rules         []FilterRule `json:"rules"`
 	Logic         string       `json:"logic"`          // "and", "or" (default "and")
 	ExtractFields []string     `json:"extract_fields"` // JSON paths to keep
@@ -318,9 +330,10 @@ func (s *FilterService) processFilterEntry(ctx context.Context, connectionID, su
 		return s.streamFilterEntry(ctx, connectionID, origEnv, entry)
 	}
 
-	var data interface{}
-	if err := json.Unmarshal(origEnv.Payload, &data); err != nil {
-		s.emitEvent(connectionID, FilterEvent{Type: "error", Message: "Invalid JSON payload", Time: now()})
+	// Parse the payload in whatever format this node accepts (ADR 0003).
+	data, perr := parsePayload(entry.Config, origEnv)
+	if perr != nil {
+		s.emitEvent(connectionID, FilterEvent{Type: "error", Message: "Payload parse failed: " + perr.Error(), Time: now()})
 		return nil
 	}
 

--- a/src/cmd/data-filter/streaming.go
+++ b/src/cmd/data-filter/streaming.go
@@ -1,14 +1,18 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 
 	"github.com/google/uuid"
 
 	"github.com/ValueRetail/vrsky/pkg/claimcheck"
 	"github.com/ValueRetail/vrsky/pkg/envelope"
+	"github.com/ValueRetail/vrsky/pkg/records"
 )
 
 // streamFilterEntry is the record-streaming path (ADR 0002 phase B): the input
@@ -34,15 +38,24 @@ func (s *FilterService) streamFilterEntry(ctx context.Context, connectionID stri
 	}
 	defer rc.Close()
 
-	dec := json.NewDecoder(rc)
-	tok, err := dec.Token()
-	if err != nil {
-		s.emitEvent(connectionID, FilterEvent{Type: "error", Message: "Streamed payload is not valid JSON: " + err.Error(), Time: now()})
-		return nil // will never parse — ack, like the buffered invalid-JSON path
+	// Resolve the input format and build a streaming reader for it (ADR 0003):
+	// csv/tsv, json, ndjson and xml all parse incrementally, so a multi-GB
+	// payload in any of them streams; yaml buffers per document and is declined.
+	head := make([]byte, records.SniffLen)
+	n, _ := io.ReadFull(rc, head)
+	head = head[:n]
+	body := io.MultiReader(bytes.NewReader(head), rc)
+
+	format := records.Detect(cfg.InputFormat, origEnv.ContentType, head)
+	if !records.Streams(format) {
+		return fmt.Errorf("filter node %s: %s input cannot be streamed (payload is %d bytes, over the %d-byte rehydrate cap); raise %s to buffer it",
+			entry.NodeID, format, origEnv.PayloadSize, s.rehydrateMax, claimcheck.EnvRehydrateMax)
 	}
-	if d, ok := tok.(json.Delim); !ok || d != '[' {
-		return fmt.Errorf("filter node %s: only JSON array payloads can be streamed; this payload (%d bytes) starts with %v — raise %s to buffer it",
-			entry.NodeID, origEnv.PayloadSize, tok, claimcheck.EnvRehydrateMax)
+	opts := cfg.inputOptions()
+	opts.RequireSequence = true // a lone top-level value would buffer the whole payload
+	reader, rerr := records.New(format, body, opts)
+	if rerr != nil {
+		return fmt.Errorf("filter node %s: %w", entry.NodeID, rerr)
 	}
 
 	hasRules := len(cfg.Rules) > 0
@@ -83,13 +96,23 @@ func (s *FilterService) streamFilterEntry(ctx context.Context, connectionID stri
 		return nil
 	}
 
-	for dec.More() {
-		var rec interface{}
-		if derr := dec.Decode(&rec); derr != nil {
-			spool.Abort(s.logger)
-			s.emitEvent(connectionID, FilterEvent{Type: "error", Message: "Streamed payload record is not valid JSON: " + derr.Error(), Time: now()})
-			return nil // deterministic — ack, matching the buffered invalid-JSON path
+	for {
+		parsedRec, derr := reader.Next()
+		if derr == io.EOF {
+			break
 		}
+		if derr != nil {
+			spool.Abort(s.logger)
+			if errors.Is(derr, records.ErrNotASequence) {
+				// Well-formed but unstreamable (a lone top-level value): decline
+				// so it reaches the DLQ, rather than acking it away.
+				return fmt.Errorf("filter node %s: %w (payload is %d bytes, over the %d-byte rehydrate cap); raise %s to buffer it",
+					entry.NodeID, derr, origEnv.PayloadSize, s.rehydrateMax, claimcheck.EnvRehydrateMax)
+			}
+			s.emitEvent(connectionID, FilterEvent{Type: "error", Message: "Streamed payload record is malformed: " + derr.Error(), Time: now()})
+			return nil // deterministic — ack, matching the buffered parse-failure path
+		}
+		var rec interface{} = map[string]interface{}(parsedRec)
 
 		obj, isMap := rec.(map[string]interface{})
 		if hasRules {

--- a/src/cmd/data-filter/streaming.go
+++ b/src/cmd/data-filter/streaming.go
@@ -69,6 +69,10 @@ func (s *FilterService) streamFilterEntry(ctx context.Context, connectionID stri
 	env := *origEnv
 	env.ID = uuid.New().String()
 	env.Payload, env.PayloadRef, env.Checksum, env.PayloadSize = nil, "", "", 0
+	// The filter always emits JSON, whatever the input format was (ADR 0003).
+	// Without this the next node auto-detects from the INPUT's content type and
+	// mis-parses this JSON — e.g. reads a streamed CSV pipeline's JSON as CSV.
+	env.ContentType = "application/json"
 	env.Metadata = make(map[string]interface{})
 	for k, v := range origEnv.Metadata {
 		env.Metadata[k] = v

--- a/src/cmd/db-producer/main.go
+++ b/src/cmd/db-producer/main.go
@@ -653,7 +653,6 @@ func testConnectionHandler() http.HandlerFunc {
 
 func now() string { return time.Now().UTC().Format(time.RFC3339) }
 
-
 // ServesConnection reports whether this connection has a matching destination —
 // mirroring Deliver's own "no config -> not ours" semantics — so the SDK can
 // ack foreign connections before rehydrating large payloads (sdk.ConnectionScoped).

--- a/src/cmd/front-systems-producer/service.go
+++ b/src/cmd/front-systems-producer/service.go
@@ -212,7 +212,6 @@ func (p *frontSystemsProducer) getConfig(ctx context.Context, connectionID, tena
 	return nil, errors.New("no front_systems producer node found")
 }
 
-
 // ServesConnection reports whether this connection has a Front Systems destination —
 // mirroring Deliver's own "no config -> not ours" semantics — so the SDK can
 // ack foreign connections before rehydrating large payloads (sdk.ConnectionScoped).

--- a/src/cmd/http-producer/main.go
+++ b/src/cmd/http-producer/main.go
@@ -616,7 +616,6 @@ func (p *httpProducer) eventsHandler() http.HandlerFunc {
 
 func now() string { return time.Now().UTC().Format(time.RFC3339) }
 
-
 // ServesConnection reports whether this connection has a matching HTTP destination —
 // mirroring Deliver's own "no config -> not ours" semantics — so the SDK can
 // ack foreign connections before rehydrating large payloads (sdk.ConnectionScoped).

--- a/src/cmd/kafka-producer/service.go
+++ b/src/cmd/kafka-producer/service.go
@@ -219,7 +219,6 @@ func (p *kafkaProducer) getTargets(ctx context.Context, connID, tenantID string)
 	return targets, nil
 }
 
-
 // ServesConnection reports whether this connection has a matching destination —
 // mirroring Deliver's own "no config -> not ours" semantics — so the SDK can
 // ack foreign connections before rehydrating large payloads (sdk.ConnectionScoped).

--- a/src/cmd/rabbitmq-producer/service.go
+++ b/src/cmd/rabbitmq-producer/service.go
@@ -209,7 +209,6 @@ func (p *rabbitProducer) getTargets(ctx context.Context, connID, tenantID string
 	return targets, nil
 }
 
-
 // ServesConnection reports whether this connection has a matching destination —
 // mirroring Deliver's own "no config -> not ours" semantics — so the SDK can
 // ack foreign connections before rehydrating large payloads (sdk.ConnectionScoped).

--- a/src/cmd/sftp-producer/service.go
+++ b/src/cmd/sftp-producer/service.go
@@ -314,7 +314,6 @@ func (p *sftpProducer) getTargets(ctx context.Context, connID, tenantID string) 
 	return targets, nil
 }
 
-
 // ServesConnection reports whether this connection has a matching destination —
 // mirroring Deliver's own "no config -> not ours" semantics — so the SDK can
 // ack foreign connections before rehydrating large payloads (sdk.ConnectionScoped).

--- a/src/cmd/sitoo-producer/service.go
+++ b/src/cmd/sitoo-producer/service.go
@@ -235,7 +235,6 @@ func (p *sitooProducer) getSitooConfig(ctx context.Context, connectionID, tenant
 	return nil, errors.New("no sitoo producer node found")
 }
 
-
 // ServesConnection reports whether this connection has a Sitoo destination —
 // mirroring Deliver's own "no config -> not ours" semantics — so the SDK can
 // ack foreign connections before rehydrating large payloads (sdk.ConnectionScoped).

--- a/src/cmd/spill-e2e/main.go
+++ b/src/cmd/spill-e2e/main.go
@@ -49,6 +49,7 @@ type recordGen struct {
 	buf     []byte
 	done    bool
 	pad     string
+	csv     bool
 }
 
 func (g *recordGen) Read(p []byte) (int, error) {
@@ -56,24 +57,43 @@ func (g *recordGen) Read(p []byte) (int, error) {
 		if g.done {
 			return 0, io.EOF
 		}
-		switch {
-		case g.i == 0:
-			g.buf = []byte("[")
-		case g.written >= g.target:
-			g.buf = []byte("]")
-			g.done = true
-		default:
-			keep := "no"
-			if g.i%2 == 1 {
-				keep = "yes"
+		if g.csv {
+			// CSV: a header row then one row per record. Exercises the ADR 0003
+			// streaming CSV reader end to end.
+			switch {
+			case g.i == 0:
+				g.buf = []byte("keep,i,pad\n")
+			case g.written >= g.target:
+				g.done = true
+				return 0, io.EOF
+			default:
+				keep := "no"
+				if g.i%2 == 1 {
+					keep = "yes"
+				}
+				g.buf = []byte(fmt.Sprintf("%s,%d,%s\n", keep, g.i, g.pad))
 			}
-			sep := ","
-			if g.i == 1 {
-				sep = ""
+			g.i++
+		} else {
+			switch {
+			case g.i == 0:
+				g.buf = []byte("[")
+			case g.written >= g.target:
+				g.buf = []byte("]")
+				g.done = true
+			default:
+				keep := "no"
+				if g.i%2 == 1 {
+					keep = "yes"
+				}
+				sep := ","
+				if g.i == 1 {
+					sep = ""
+				}
+				g.buf = []byte(fmt.Sprintf(`%s{"keep":%q,"i":%d,"pad":%q}`, sep, keep, g.i, g.pad))
 			}
-			g.buf = []byte(fmt.Sprintf(`%s{"keep":%q,"i":%d,"pad":%q}`, sep, keep, g.i, g.pad))
+			g.i++
 		}
-		g.i++
 	}
 	n := copy(p, g.buf)
 	g.buf = g.buf[n:]
@@ -90,7 +110,11 @@ func envOr(k, def string) string {
 
 func main() {
 	sizeMB := flag.Int64("mb", 1024, "approximate payload size in MiB")
+	format := flag.String("format", "json", "payload format to generate: json | csv")
 	flag.Parse()
+	if *format != "json" && *format != "csv" {
+		log.Fatalf("unsupported -format %q (json|csv)", *format)
+	}
 	ctx := context.Background()
 
 	// Defaults match the TEST compose stack; override via env to target another
@@ -109,10 +133,13 @@ func main() {
 	env.TenantID = tenant
 	env.IntegrationID = connID
 	env.ContentType = "application/json"
+	if *format == "csv" {
+		env.ContentType = "text/csv"
+	}
 	key := fmt.Sprintf("spill/%s/%s/%s", tenant, connID, env.ID)
 
 	// Stream-generate the payload into MinIO, hashing and counting as we go.
-	gen := &recordGen{target: *sizeMB << 20, pad: strings.Repeat("x", 1024)}
+	gen := &recordGen{target: *sizeMB << 20, pad: strings.Repeat("x", 1024), csv: *format == "csv"}
 	h := sha256.New()
 	counted := io.TeeReader(gen, h)
 	start := time.Now()
@@ -122,8 +149,11 @@ func main() {
 	env.PayloadRef = key
 	env.PayloadSize = gen.written
 	env.Checksum = "sha256:" + hex.EncodeToString(h.Sum(nil))
-	totalRecords := gen.i - 2 // minus '[' and ']' emissions
-	fmt.Printf("UPLOADED  %.1f MiB, %d records, in %s\n", float64(gen.written)/(1<<20), totalRecords, time.Since(start).Round(time.Millisecond))
+	totalRecords := gen.i - 2 // json: minus the '[' and ']' emissions
+	if *format == "csv" {
+		totalRecords = gen.i - 1 // csv: minus the header row
+	}
+	fmt.Printf("UPLOADED  %.1f MiB %s, %d records, in %s\n", float64(gen.written)/(1<<20), *format, totalRecords, time.Since(start).Round(time.Millisecond))
 
 	// Watch for the transform outputs before publishing.
 	nc, err := nats.Connect(envOr("SPILL_E2E_NATS_URL", "nats://127.0.0.1:4222"))

--- a/src/cmd/visma-producer/service.go
+++ b/src/cmd/visma-producer/service.go
@@ -196,7 +196,6 @@ func (p *vismaProducer) getConfig(ctx context.Context, connectionID, tenantID st
 	return nil, errors.New("no visma producer node found")
 }
 
-
 // ServesConnection reports whether this connection has a Visma destination —
 // mirroring Deliver's own "no config -> not ours" semantics — so the SDK can
 // ack foreign connections before rehydrating large payloads (sdk.ConnectionScoped).

--- a/src/pkg/claimcheck/spool.go
+++ b/src/pkg/claimcheck/spool.go
@@ -146,7 +146,13 @@ func (s *Spool) Abort(logger *slog.Logger) {
 func (s *Spool) Result() SpoolResult {
 	if !s.spilled {
 		// Copy: the caller owns the result; the spool may be reused/GC'd.
-		return SpoolResult{Inline: append([]byte(nil), s.buf.Bytes()...)}
+		// make() rather than append(nil, ...) so an EMPTY output is a non-nil
+		// empty slice: callers distinguish inline from spilled by Inline != nil,
+		// and a nil here would make an empty result look like a spill with no
+		// reference — a malformed envelope.
+		inline := make([]byte, s.buf.Len())
+		copy(inline, s.buf.Bytes())
+		return SpoolResult{Inline: inline}
 	}
 	return SpoolResult{
 		Ref:      s.key,

--- a/src/pkg/claimcheck/spool_test.go
+++ b/src/pkg/claimcheck/spool_test.go
@@ -141,3 +141,20 @@ func TestSpool_AbortDeletesSpilledObject(t *testing.T) {
 		t.Errorf("expected one delete, got %v", store.deleted)
 	}
 }
+
+// An empty output must come back as inline-but-empty, not as a nil Inline —
+// callers read Inline != nil as "did not spill", so nil would make an empty
+// result look like a spill with no reference and publish a broken envelope.
+func TestSpool_EmptyOutputIsInlineNotNil(t *testing.T) {
+	sp := NewSpool(context.Background(), newSpoolStore(), "spill/t/c/x", "", 1024)
+	if err := sp.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	res := sp.Result()
+	if res.Inline == nil {
+		t.Fatal("empty output must be a non-nil empty slice, not nil")
+	}
+	if len(res.Inline) != 0 || res.Ref != "" {
+		t.Errorf("unexpected result: %+v", res)
+	}
+}

--- a/src/pkg/records/csv.go
+++ b/src/pkg/records/csv.go
@@ -1,0 +1,147 @@
+package records
+
+import (
+	"bufio"
+	"encoding/csv"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// csvReader turns delimited text into records: the header row supplies the
+// keys, each subsequent row a record. Values stay strings — CSV carries no type
+// information, and guessing (is "0123" a number? is "2026-01-02" a date?)
+// silently corrupts data, so coercion is left to explicit mapping (ADR 0003).
+type csvReader struct {
+	rd      *csv.Reader
+	headers []string
+	trim    bool
+}
+
+func newCSVReader(br *bufio.Reader, opts Options) (*csvReader, error) {
+	delim := opts.Delimiter
+	if delim == 0 {
+		var err error
+		if delim, err = sniffDelimiter(br); err != nil {
+			return nil, err
+		}
+	}
+
+	rd := csv.NewReader(br)
+	rd.Comma = delim
+	rd.FieldsPerRecord = -1 // tolerate ragged rows; missing cells become ""
+	rd.LazyQuotes = true
+	rd.TrimLeadingSpace = opts.TrimSpace
+
+	c := &csvReader{rd: rd, trim: opts.TrimSpace}
+	if !opts.NoHeader {
+		header, err := rd.Read()
+		if err == io.EOF {
+			return c, nil // empty input: Next() reports EOF
+		}
+		if err != nil {
+			return nil, fmt.Errorf("csv: read header: %w", err)
+		}
+		c.headers = normaliseHeaders(header)
+	}
+	return c, nil
+}
+
+func (c *csvReader) Next() (Record, error) {
+	row, err := c.rd.Read()
+	if err == io.EOF {
+		return nil, io.EOF
+	}
+	if err != nil {
+		return nil, fmt.Errorf("csv: %w", err)
+	}
+
+	// Headerless input: synthesise stable column names from the first row's width.
+	if c.headers == nil {
+		c.headers = make([]string, len(row))
+		for i := range row {
+			c.headers[i] = fmt.Sprintf("column_%d", i+1)
+		}
+	}
+
+	rec := make(Record, len(c.headers))
+	for i, h := range c.headers {
+		v := ""
+		if i < len(row) {
+			v = row[i]
+		}
+		if c.trim {
+			v = strings.TrimSpace(v)
+		}
+		rec[h] = v
+	}
+	// Rows wider than the header keep their extra cells under synthesised names
+	// rather than being silently truncated.
+	for i := len(c.headers); i < len(row); i++ {
+		rec[fmt.Sprintf("column_%d", i+1)] = row[i]
+	}
+	return rec, nil
+}
+
+// sniffDelimiter picks the delimiter from the first line by counting
+// candidates outside quotes. Comma wins ties, matching the format's default.
+func sniffDelimiter(br *bufio.Reader) (rune, error) {
+	peek, err := br.Peek(4096)
+	if err != nil && err != io.EOF && err != bufio.ErrBufferFull {
+		return 0, fmt.Errorf("csv: sniff delimiter: %w", err)
+	}
+	line := string(peek)
+	if i := strings.IndexAny(line, "\r\n"); i >= 0 {
+		line = line[:i]
+	}
+
+	best, bestCount := ',', -1
+	inQuote := false
+	counts := map[rune]int{',': 0, ';': 0, '\t': 0, '|': 0}
+	for _, r := range line {
+		if r == '"' {
+			inQuote = !inQuote
+			continue
+		}
+		if inQuote {
+			continue
+		}
+		if _, ok := counts[r]; ok {
+			counts[r]++
+		}
+	}
+	// Deterministic order so ties resolve the same way every run.
+	for _, r := range []rune{',', ';', '\t', '|'} {
+		if counts[r] > bestCount {
+			best, bestCount = r, counts[r]
+		}
+	}
+	return best, nil
+}
+
+// normaliseHeaders makes column names usable as record keys: blanks become
+// column_N and duplicates get suffixed, so neither collides into one field.
+// Mirrors what the UI's schema preview already does for delimited samples.
+func normaliseHeaders(header []string) []string {
+	out := make([]string, len(header))
+	seen := make(map[string]int, len(header))
+	for i, h := range header {
+		name := strings.TrimSpace(h)
+		// Strip a UTF-8 BOM on the first column — Excel writes one and it would
+		// otherwise become part of the key.
+		if i == 0 {
+			name = strings.TrimPrefix(name, "\ufeff")
+		}
+		if name == "" {
+			name = fmt.Sprintf("column_%d", i+1)
+		}
+		if n := seen[name]; n > 0 {
+			seen[name] = n + 1
+			name = fmt.Sprintf("%s_%d", name, n+1)
+		} else {
+			seen[name] = 1
+		}
+		out[i] = name
+	}
+	return out
+}

--- a/src/pkg/records/detect.go
+++ b/src/pkg/records/detect.go
@@ -1,0 +1,97 @@
+package records
+
+import (
+	"strings"
+)
+
+// SniffLen is how many leading bytes Detect needs. Callers on the streaming
+// path should peek (not consume) this much.
+const SniffLen = 512
+
+// Detect resolves the input format for a payload, in the order established by
+// ADR 0003:
+//
+//  1. explicit node config — the operator's word is final;
+//  2. the envelope's ContentType — consumers already stamp it from the
+//     filename extension and a content sniff;
+//  3. a sniff of the payload head — last resort;
+//  4. json — the historical default, so existing pipelines are unaffected.
+//
+// It never returns an error: an unresolvable payload falls through to json and
+// fails at parse time with a message about the actual content, which is more
+// useful than a detection error.
+func Detect(explicit, contentType string, head []byte) string {
+	if f := strings.TrimSpace(explicit); f != "" && !strings.EqualFold(f, "auto") {
+		return Normalise(f)
+	}
+	if f := fromContentType(contentType); f != "" {
+		return f
+	}
+	if f := sniff(head); f != "" {
+		return f
+	}
+	return FormatJSON
+}
+
+// fromContentType maps the media types consumers actually stamp (plus the
+// common synonyms external systems send) onto formats.
+func fromContentType(ct string) string {
+	ct = strings.ToLower(strings.TrimSpace(ct))
+	if i := strings.IndexByte(ct, ';'); i >= 0 { // drop "; charset=utf-8"
+		ct = strings.TrimSpace(ct[:i])
+	}
+	switch ct {
+	case "application/json", "text/json":
+		return FormatJSON
+	case "application/x-ndjson", "application/ndjson", "application/jsonl":
+		return FormatNDJSON
+	case "text/csv", "application/csv":
+		return FormatCSV
+	case "text/tab-separated-values", "text/tsv":
+		return FormatTSV
+	case "application/xml", "text/xml":
+		return FormatXML
+	case "application/yaml", "text/yaml", "application/x-yaml", "text/x-yaml":
+		return FormatYAML
+	}
+	// text/plain and application/octet-stream are deliberately unresolved:
+	// they carry no format information, so the sniff gets a turn.
+	return ""
+}
+
+// sniff inspects the payload head. Conservative by design — it only claims a
+// format on an unambiguous marker, leaving anything else to the json default.
+func sniff(head []byte) string {
+	s := strings.TrimSpace(string(head))
+	if s == "" {
+		return ""
+	}
+	switch s[0] {
+	case '{':
+		// A single object, or NDJSON's first line. Both parse identically.
+		return FormatJSON
+	case '[':
+		return FormatJSON
+	case '<':
+		if strings.HasPrefix(s, "<?xml") || strings.HasPrefix(s, "<!") || len(s) > 1 {
+			return FormatXML
+		}
+	case '-':
+		if strings.HasPrefix(s, "---") { // YAML document marker
+			return FormatYAML
+		}
+	}
+	// A delimited first line with a consistent separator is very likely CSV/TSV.
+	if line, _, ok := strings.Cut(s, "\n"); ok || s != "" {
+		if !ok {
+			line = s
+		}
+		if strings.Count(line, "\t") >= 1 {
+			return FormatTSV
+		}
+		if strings.Count(line, ",") >= 1 || strings.Count(line, ";") >= 1 {
+			return FormatCSV
+		}
+	}
+	return ""
+}

--- a/src/pkg/records/json.go
+++ b/src/pkg/records/json.go
@@ -1,0 +1,98 @@
+package records
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+// jsonReader handles JSON and NDJSON with one implementation, because
+// encoding/json's stream decoder already accepts both shapes:
+//
+//	[{...},{...}]     a JSON array   -> one record per element
+//	{...}\n{...}      concatenated   -> one record per value (NDJSON)
+//	{...}             a single object -> one record
+//
+// Non-object elements (numbers, strings, nested arrays) are skipped rather than
+// failing the payload, matching the buffered transforms' long-standing
+// behaviour of dropping non-map rows.
+type jsonReader struct {
+	dec     *json.Decoder
+	inArray bool
+	started bool
+}
+
+func newJSONReader(r io.Reader) *jsonReader {
+	return &jsonReader{dec: json.NewDecoder(r)}
+}
+
+func (j *jsonReader) Next() (Record, error) {
+	if !j.started {
+		j.started = true
+		// Peek the first token: '[' means array-of-records, anything else means
+		// a value stream that the loop below decodes directly.
+		tok, err := j.dec.Token()
+		if err == io.EOF {
+			return nil, io.EOF
+		}
+		if err != nil {
+			return nil, fmt.Errorf("json: %w", err)
+		}
+		if d, ok := tok.(json.Delim); ok && d == '[' {
+			j.inArray = true
+		} else {
+			// Not an array — rewind isn't possible, so re-decode this value from
+			// the token we already consumed. Only '{' can start a record; other
+			// scalars are skipped by falling through to the normal loop.
+			if d, ok := tok.(json.Delim); ok && d == '{' {
+				rec := Record{}
+				if err := decodeObjectBody(j.dec, rec); err != nil {
+					return nil, err
+				}
+				return rec, nil
+			}
+		}
+	}
+
+	for {
+		if j.inArray && !j.dec.More() {
+			return nil, io.EOF
+		}
+		var v interface{}
+		if err := j.dec.Decode(&v); err != nil {
+			if err == io.EOF {
+				return nil, io.EOF
+			}
+			return nil, fmt.Errorf("json: %w", err)
+		}
+		if rec, ok := v.(map[string]interface{}); ok {
+			return rec, nil
+		}
+		// Skip non-object entries (parity with the buffered path).
+	}
+}
+
+// decodeObjectBody finishes decoding an object whose opening '{' was already
+// consumed by a Token() call.
+func decodeObjectBody(dec *json.Decoder, into Record) error {
+	for dec.More() {
+		keyTok, err := dec.Token()
+		if err != nil {
+			return fmt.Errorf("json: %w", err)
+		}
+		key, ok := keyTok.(string)
+		if !ok {
+			return fmt.Errorf("json: object key is not a string")
+		}
+		var val interface{}
+		if err := dec.Decode(&val); err != nil {
+			return fmt.Errorf("json: %w", err)
+		}
+		into[key] = val
+	}
+	// Consume the closing '}'.
+	if _, err := dec.Token(); err != nil {
+		return fmt.Errorf("json: %w", err)
+	}
+	return nil
+}

--- a/src/pkg/records/json.go
+++ b/src/pkg/records/json.go
@@ -17,13 +17,14 @@ import (
 // failing the payload, matching the buffered transforms' long-standing
 // behaviour of dropping non-map rows.
 type jsonReader struct {
-	dec     *json.Decoder
-	inArray bool
-	started bool
+	dec        *json.Decoder
+	inArray    bool
+	started    bool
+	requireSeq bool
 }
 
-func newJSONReader(r io.Reader) *jsonReader {
-	return &jsonReader{dec: json.NewDecoder(r)}
+func newJSONReader(r io.Reader, requireSequence bool) *jsonReader {
+	return &jsonReader{dec: json.NewDecoder(r), requireSeq: requireSequence}
 }
 
 func (j *jsonReader) Next() (Record, error) {
@@ -41,6 +42,9 @@ func (j *jsonReader) Next() (Record, error) {
 		if d, ok := tok.(json.Delim); ok && d == '[' {
 			j.inArray = true
 		} else {
+			if j.requireSeq {
+				return nil, fmt.Errorf("json: decoding it would buffer the whole payload: %w", ErrNotASequence)
+			}
 			// Not an array — rewind isn't possible, so re-decode this value from
 			// the token we already consumed. Only '{' can start a record; other
 			// scalars are skipped by falling through to the normal loop.

--- a/src/pkg/records/records.go
+++ b/src/pkg/records/records.go
@@ -14,10 +14,18 @@ package records
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
 )
+
+// ErrNotASequence is returned when RequireSequence is set and the payload turns
+// out to be a single value rather than a sequence of records. Callers on the
+// streaming path should treat it as a structural refusal (decline/NAK), not as
+// a malformed-data ack: the payload is well-formed, it simply cannot be
+// processed under a memory bound.
+var ErrNotASequence = errors.New("payload is a single value, not a sequence of records")
 
 // Record is one parsed row/element/object. Values are whatever the format
 // naturally yields: JSON/YAML produce typed values, CSV produces strings, XML
@@ -48,6 +56,13 @@ type Options struct {
 	Delimiter rune // 0 = sniff from the header line
 	NoHeader  bool // true: synthesise column_1..column_N instead of consuming a header row
 	TrimSpace bool // trim leading/trailing space in values
+	// RequireSequence rejects inputs that are a single value rather than a
+	// sequence of records. The streaming transform paths set it: a lone
+	// top-level JSON object is ONE record, so decoding it necessarily
+	// materialises the whole payload — which is the very OOM the streaming path
+	// exists to avoid. The buffered path leaves it false, where single objects
+	// are both fine and long-standing behaviour.
+	RequireSequence bool
 	// XML.
 	RecordPath string // REQUIRED: dotted path to the repeating record element, e.g. "Orders.Order"
 	AttrPrefix string // attribute key prefix, default "@"
@@ -75,10 +90,11 @@ func New(format string, r io.Reader, opts Options) (Reader, error) {
 
 	switch format {
 	case FormatJSON:
-		return newJSONReader(r), nil
+		return newJSONReader(r, opts.RequireSequence), nil
 	case FormatNDJSON:
 		// NDJSON is JSON's concatenated-value case; one decoder handles both.
-		return newJSONReader(r), nil
+		// It is inherently a sequence, so RequireSequence never applies.
+		return newJSONReader(r, false), nil
 	case FormatCSV, FormatTSV:
 		return newCSVReader(bufio.NewReader(r), opts)
 	case FormatXML:

--- a/src/pkg/records/records.go
+++ b/src/pkg/records/records.go
@@ -1,0 +1,135 @@
+// Package records turns a payload in any supported input format into a stream
+// of records, so the pipeline transforms (data-filter, data-converter) can
+// accept CSV, XML, NDJSON and YAML the same way they have always accepted JSON
+// (ADR 0003).
+//
+// Every reader is constructed from an io.Reader, so one implementation serves
+// both transform paths: the buffered path wraps the payload in a
+// bytes.Reader, and the streaming path (ADR 0002) hands over the spill
+// object's stream directly. csv/tsv, ndjson, json and xml are truly streaming —
+// memory is bounded by the largest single record, not the payload. yaml streams
+// per document but must buffer an individual document (a library limitation),
+// so an over-cap single-document YAML declines like other un-streamable inputs.
+package records
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// Record is one parsed row/element/object. Values are whatever the format
+// naturally yields: JSON/YAML produce typed values, CSV produces strings, XML
+// produces strings plus nested maps/slices.
+type Record = map[string]interface{}
+
+// Reader yields records until io.EOF.
+type Reader interface {
+	Next() (Record, error)
+}
+
+// Supported input formats.
+const (
+	FormatJSON   = "json"
+	FormatNDJSON = "ndjson"
+	FormatCSV    = "csv"
+	FormatTSV    = "tsv"
+	FormatXML    = "xml"
+	FormatYAML   = "yaml"
+)
+
+// Options carries the per-format configuration. Formats expose the knobs that
+// decide whether parsing is *correct*, rather than assuming a house style
+// (ADR 0003): a wrong delimiter or record path silently produces wrong data,
+// so both are configurable and, for XML, mandatory.
+type Options struct {
+	// CSV/TSV.
+	Delimiter rune // 0 = sniff from the header line
+	NoHeader  bool // true: synthesise column_1..column_N instead of consuming a header row
+	TrimSpace bool // trim leading/trailing space in values
+	// XML.
+	RecordPath string // REQUIRED: dotted path to the repeating record element, e.g. "Orders.Order"
+	AttrPrefix string // attribute key prefix, default "@"
+	TextKey    string // key for mixed text content, default "#text"
+}
+
+func (o Options) withDefaults(format string) Options {
+	if o.AttrPrefix == "" {
+		o.AttrPrefix = "@"
+	}
+	if o.TextKey == "" {
+		o.TextKey = "#text"
+	}
+	if o.Delimiter == 0 && format == FormatTSV {
+		o.Delimiter = '\t'
+	}
+	return o
+}
+
+// New builds a Reader for format over r. An unknown or non-convertible format
+// is an error naming it, never a silent fallback to JSON.
+func New(format string, r io.Reader, opts Options) (Reader, error) {
+	format = Normalise(format)
+	opts = opts.withDefaults(format)
+
+	switch format {
+	case FormatJSON:
+		return newJSONReader(r), nil
+	case FormatNDJSON:
+		// NDJSON is JSON's concatenated-value case; one decoder handles both.
+		return newJSONReader(r), nil
+	case FormatCSV, FormatTSV:
+		return newCSVReader(bufio.NewReader(r), opts)
+	case FormatXML:
+		if strings.TrimSpace(opts.RecordPath) == "" {
+			return nil, fmt.Errorf("xml input requires a record path (input_xml_record_path): XML has no inherent record shape, e.g. \"Orders.Order\"")
+		}
+		return newXMLReader(r, opts), nil
+	case FormatYAML:
+		return newYAMLReader(r), nil
+	default:
+		return nil, fmt.Errorf("unsupported input format %q (supported: json, ndjson, csv, tsv, xml, yaml)", format)
+	}
+}
+
+// Normalise maps aliases and casing onto the canonical format names.
+func Normalise(format string) string {
+	switch strings.ToLower(strings.TrimSpace(format)) {
+	case "", FormatJSON:
+		return FormatJSON
+	case FormatNDJSON, "jsonl", "json-lines", "ndjson-lines":
+		return FormatNDJSON
+	case FormatCSV:
+		return FormatCSV
+	case FormatTSV, "tab", "tab-separated":
+		return FormatTSV
+	case FormatXML:
+		return FormatXML
+	case FormatYAML, "yml":
+		return FormatYAML
+	default:
+		return strings.ToLower(strings.TrimSpace(format))
+	}
+}
+
+// Streams reports whether a format parses incrementally. yaml is the exception:
+// it streams per document but buffers each one, so a single huge document
+// cannot be processed under a memory bound.
+func Streams(format string) bool { return Normalise(format) != FormatYAML }
+
+// ReadAll drains a Reader. Used by the buffered transform path and by tests;
+// the streaming path consumes Next() directly.
+func ReadAll(r Reader) ([]Record, error) {
+	var out []Record
+	for {
+		rec, err := r.Next()
+		if err == io.EOF {
+			return out, nil
+		}
+		if err != nil {
+			return out, err
+		}
+		out = append(out, rec)
+	}
+}

--- a/src/pkg/records/records_test.go
+++ b/src/pkg/records/records_test.go
@@ -1,0 +1,284 @@
+package records
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func mustRead(t *testing.T, format, payload string, opts Options) []Record {
+	t.Helper()
+	r, err := New(format, strings.NewReader(payload), opts)
+	if err != nil {
+		t.Fatalf("New(%s): %v", format, err)
+	}
+	recs, err := ReadAll(r)
+	if err != nil {
+		t.Fatalf("ReadAll(%s): %v", format, err)
+	}
+	return recs
+}
+
+// --- CSV / TSV ---
+
+func TestCSV_HeaderAndRows(t *testing.T) {
+	recs := mustRead(t, FormatCSV, "name,qty\nwidget,3\ngadget,7\n", Options{})
+	want := []Record{
+		{"name": "widget", "qty": "3"},
+		{"name": "gadget", "qty": "7"},
+	}
+	if !reflect.DeepEqual(recs, want) {
+		t.Errorf("got %v, want %v", recs, want)
+	}
+}
+
+// Values stay strings — the accepted ADR decision. A leading-zero SKU must not
+// become the number 123.
+func TestCSV_ValuesStayStrings(t *testing.T) {
+	recs := mustRead(t, FormatCSV, "sku,price\n0123,4.50\n", Options{})
+	if recs[0]["sku"] != "0123" {
+		t.Errorf("sku = %#v, want the string \"0123\"", recs[0]["sku"])
+	}
+	if recs[0]["price"] != "4.50" {
+		t.Errorf("price = %#v, want the string \"4.50\"", recs[0]["price"])
+	}
+}
+
+func TestCSV_QuotedFieldsWithDelimitersAndNewlines(t *testing.T) {
+	recs := mustRead(t, FormatCSV, "name,note\n\"Doe, John\",\"line1\nline2\"\n", Options{})
+	if recs[0]["name"] != "Doe, John" {
+		t.Errorf("quoted delimiter mishandled: %#v", recs[0]["name"])
+	}
+	if recs[0]["note"] != "line1\nline2" {
+		t.Errorf("embedded newline mishandled: %#v", recs[0]["note"])
+	}
+}
+
+func TestCSV_RaggedRowsAndWideRows(t *testing.T) {
+	recs := mustRead(t, FormatCSV, "a,b,c\n1,2\n1,2,3,4\n", Options{})
+	if recs[0]["c"] != "" {
+		t.Errorf("short row should pad with empty, got %#v", recs[0]["c"])
+	}
+	if recs[1]["column_4"] != "4" {
+		t.Errorf("wide row should keep the extra cell, got %v", recs[1])
+	}
+}
+
+func TestCSV_BlankAndDuplicateHeaders(t *testing.T) {
+	recs := mustRead(t, FormatCSV, "id,,id\n1,2,3\n", Options{})
+	if recs[0]["id"] != "1" || recs[0]["column_2"] != "2" || recs[0]["id_2"] != "3" {
+		t.Errorf("header normalisation wrong: %v", recs[0])
+	}
+}
+
+func TestCSV_SniffsSemicolonAndTab(t *testing.T) {
+	semi := mustRead(t, FormatCSV, "a;b\n1;2\n", Options{})
+	if semi[0]["a"] != "1" || semi[0]["b"] != "2" {
+		t.Errorf("semicolon sniff failed: %v", semi[0])
+	}
+	tsv := mustRead(t, FormatTSV, "a\tb\n1\t2\n", Options{})
+	if tsv[0]["a"] != "1" || tsv[0]["b"] != "2" {
+		t.Errorf("tsv failed: %v", tsv[0])
+	}
+}
+
+func TestCSV_ExplicitDelimiterBeatsSniff(t *testing.T) {
+	// Commas inside the values would win a sniff; the explicit pipe must hold.
+	recs := mustRead(t, FormatCSV, "a|b\n1,5|2,5\n", Options{Delimiter: '|'})
+	if recs[0]["a"] != "1,5" || recs[0]["b"] != "2,5" {
+		t.Errorf("explicit delimiter ignored: %v", recs[0])
+	}
+}
+
+func TestCSV_NoHeaderSynthesisesColumns(t *testing.T) {
+	recs := mustRead(t, FormatCSV, "1,2\n3,4\n", Options{NoHeader: true, Delimiter: ','})
+	if len(recs) != 2 || recs[0]["column_1"] != "1" || recs[1]["column_2"] != "4" {
+		t.Errorf("no-header mode wrong: %v", recs)
+	}
+}
+
+func TestCSV_EmptyInput(t *testing.T) {
+	if recs := mustRead(t, FormatCSV, "", Options{}); len(recs) != 0 {
+		t.Errorf("empty input should yield no records, got %v", recs)
+	}
+}
+
+// --- JSON / NDJSON ---
+
+func TestJSON_ArrayObjectAndNDJSON(t *testing.T) {
+	arr := mustRead(t, FormatJSON, `[{"a":1},{"a":2}]`, Options{})
+	if len(arr) != 2 || arr[1]["a"] != float64(2) {
+		t.Errorf("array: %v", arr)
+	}
+	single := mustRead(t, FormatJSON, `{"a":1,"b":{"c":2}}`, Options{})
+	if len(single) != 1 || single[0]["a"] != float64(1) {
+		t.Errorf("single object: %v", single)
+	}
+	nd := mustRead(t, FormatNDJSON, "{\"a\":1}\n{\"a\":2}\n", Options{})
+	if len(nd) != 2 || nd[1]["a"] != float64(2) {
+		t.Errorf("ndjson: %v", nd)
+	}
+}
+
+// Parity with the buffered transforms: non-object array entries are skipped,
+// not fatal.
+func TestJSON_SkipsNonObjectEntries(t *testing.T) {
+	recs := mustRead(t, FormatJSON, `[{"a":1},42,"x",{"a":2}]`, Options{})
+	if len(recs) != 2 {
+		t.Errorf("expected the 2 objects, got %v", recs)
+	}
+}
+
+// --- XML ---
+
+func TestXML_RecordPathRequired(t *testing.T) {
+	_, err := New(FormatXML, strings.NewReader("<a/>"), Options{})
+	if err == nil {
+		t.Fatal("xml without a record path must be a config error, not a guess")
+	}
+	if !strings.Contains(err.Error(), "input_xml_record_path") {
+		t.Errorf("error should name the config field, got: %v", err)
+	}
+}
+
+func TestXML_AttributesRepeatsAndNesting(t *testing.T) {
+	doc := `<Orders>
+	  <Order id="7" ns:x="1"><Line>a</Line><Line>b</Line><Ship><City>Oslo</City></Ship></Order>
+	  <Order id="8"><Line>c</Line></Order>
+	</Orders>`
+	recs := mustRead(t, FormatXML, doc, Options{RecordPath: "Orders.Order"})
+	if len(recs) != 2 {
+		t.Fatalf("expected 2 records, got %d: %v", len(recs), recs)
+	}
+	if recs[0]["@id"] != "7" {
+		t.Errorf("attribute mapping: %v", recs[0])
+	}
+	lines, ok := recs[0]["Line"].([]interface{})
+	if !ok || len(lines) != 2 || lines[0] != "a" {
+		t.Errorf("repeated elements should become a slice: %#v", recs[0]["Line"])
+	}
+	ship, ok := recs[0]["Ship"].(Record)
+	if !ok || ship["City"] != "Oslo" {
+		t.Errorf("nested element: %#v", recs[0]["Ship"])
+	}
+	// A single occurrence stays scalar, not a one-element slice.
+	if recs[1]["Line"] != "c" {
+		t.Errorf("single child should stay scalar: %#v", recs[1]["Line"])
+	}
+}
+
+func TestXML_MixedContentAndEmptyElements(t *testing.T) {
+	recs := mustRead(t, FormatXML, `<r><Item>hi<b/>there</Item></r>`, Options{RecordPath: "Item"})
+	if recs[0]["#text"] != "hithere" {
+		t.Errorf("mixed text should land under #text: %v", recs[0])
+	}
+	if recs[0]["b"] != "" {
+		t.Errorf("empty element should be an empty string: %#v", recs[0]["b"])
+	}
+}
+
+func TestXML_SingleSegmentPathMatchesAtAnyDepth(t *testing.T) {
+	recs := mustRead(t, FormatXML, `<a><b><Item><v>1</v></Item></b></a>`, Options{RecordPath: "Item"})
+	if len(recs) != 1 || recs[0]["v"] != "1" {
+		t.Errorf("deep single-segment match failed: %v", recs)
+	}
+}
+
+func TestXML_NonMatchingPathYieldsNothing(t *testing.T) {
+	recs := mustRead(t, FormatXML, `<Orders><Order><a>1</a></Order></Orders>`, Options{RecordPath: "Invoices.Invoice"})
+	if len(recs) != 0 {
+		t.Errorf("a path that matches nothing should yield no records, got %v", recs)
+	}
+}
+
+func TestXML_CustomAttrPrefixAndTextKey(t *testing.T) {
+	recs := mustRead(t, FormatXML, `<r><Item id="1">txt<c/></Item></r>`,
+		Options{RecordPath: "Item", AttrPrefix: "attr_", TextKey: "value"})
+	if recs[0]["attr_id"] != "1" || recs[0]["value"] != "txt" {
+		t.Errorf("custom conventions ignored: %v", recs[0])
+	}
+}
+
+// --- YAML ---
+
+func TestYAML_MappingSequenceAndMultiDoc(t *testing.T) {
+	one := mustRead(t, FormatYAML, "a: 1\nb: x\n", Options{})
+	if len(one) != 1 || one[0]["a"] != 1 || one[0]["b"] != "x" {
+		t.Errorf("mapping doc: %v", one)
+	}
+	seq := mustRead(t, FormatYAML, "- a: 1\n- a: 2\n", Options{})
+	if len(seq) != 2 || seq[1]["a"] != 2 {
+		t.Errorf("sequence doc: %v", seq)
+	}
+	multi := mustRead(t, FormatYAML, "a: 1\n---\na: 2\n", Options{})
+	if len(multi) != 2 || multi[1]["a"] != 2 {
+		t.Errorf("multi-doc: %v", multi)
+	}
+}
+
+func TestYAML_NonStringKeysStringified(t *testing.T) {
+	recs := mustRead(t, FormatYAML, "1: one\ntrue: yes\n", Options{})
+	if recs[0]["1"] != "one" {
+		t.Errorf("numeric key should stringify: %v", recs[0])
+	}
+}
+
+// --- format resolution ---
+
+func TestDetect_Precedence(t *testing.T) {
+	// Explicit config wins over a contradicting content type and body.
+	if got := Detect("csv", "application/json", []byte(`{"a":1}`)); got != FormatCSV {
+		t.Errorf("explicit should win, got %s", got)
+	}
+	// ContentType wins over the body sniff.
+	if got := Detect("", "text/csv", []byte(`{"a":1}`)); got != FormatCSV {
+		t.Errorf("content type should win over sniff, got %s", got)
+	}
+	// charset parameters are ignored.
+	if got := Detect("", "application/xml; charset=utf-8", nil); got != FormatXML {
+		t.Errorf("charset param broke detection, got %s", got)
+	}
+	// Uninformative content types fall through to the sniff.
+	if got := Detect("", "application/octet-stream", []byte("a,b\n1,2")); got != FormatCSV {
+		t.Errorf("sniff should resolve csv, got %s", got)
+	}
+	if got := Detect("", "text/plain", []byte("<?xml version=\"1.0\"?><a/>")); got != FormatXML {
+		t.Errorf("sniff should resolve xml, got %s", got)
+	}
+	// Nothing to go on: json, the historical default.
+	if got := Detect("", "", nil); got != FormatJSON {
+		t.Errorf("default should be json, got %s", got)
+	}
+	// "auto" is treated as unset.
+	if got := Detect("auto", "text/csv", nil); got != FormatCSV {
+		t.Errorf("auto should defer to content type, got %s", got)
+	}
+}
+
+func TestNormaliseAliases(t *testing.T) {
+	for in, want := range map[string]string{
+		"": FormatJSON, "JSON": FormatJSON, "jsonl": FormatNDJSON,
+		"yml": FormatYAML, "TSV": FormatTSV, "  csv  ": FormatCSV,
+	} {
+		if got := Normalise(in); got != want {
+			t.Errorf("Normalise(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestStreams(t *testing.T) {
+	for _, f := range []string{FormatJSON, FormatNDJSON, FormatCSV, FormatTSV, FormatXML} {
+		if !Streams(f) {
+			t.Errorf("%s should stream", f)
+		}
+	}
+	if Streams(FormatYAML) {
+		t.Error("yaml buffers each document and must not claim to stream")
+	}
+}
+
+func TestNew_UnsupportedFormat(t *testing.T) {
+	if _, err := New("parquet", strings.NewReader(""), Options{}); err == nil {
+		t.Fatal("unsupported format must error, not silently fall back to json")
+	}
+}

--- a/src/pkg/records/xml.go
+++ b/src/pkg/records/xml.go
@@ -1,0 +1,191 @@
+package records
+
+import (
+	"encoding/xml"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// xmlReader streams records out of XML by walking tokens and decoding only the
+// subtrees that sit at the configured record path — so memory is bounded by one
+// record, not the document.
+//
+// The record path is REQUIRED and never guessed (ADR 0003): XML has no inherent
+// row concept, and inferring one (deepest repeated element? first list-like
+// child?) silently produces the wrong shape on documents that don't match the
+// heuristic. "Orders.Order" means an <Order> nested anywhere under <Orders>;
+// a single segment ("Order") matches that element at any depth.
+//
+// Element mapping follows the widely-used badgerfish-style convention so the
+// result round-trips predictably:
+//
+//	<Order id="7"><Line>a</Line><Line>b</Line><Note>hi<b/>there</Note></Order>
+//	  -> {"@id":"7", "Line":["a","b"], "Note":{"#text":"hithere","b":""}}
+//
+//	attributes  -> AttrPrefix + name   (default "@id")
+//	leaf text   -> the element's string value
+//	repeats     -> a slice, in document order
+//	mixed text  -> TextKey             (default "#text")
+type xmlReader struct {
+	dec  *xml.Decoder
+	opts Options
+	path []string // element names of the current open path
+	want []string // record path segments
+	done bool
+}
+
+func newXMLReader(r io.Reader, opts Options) *xmlReader {
+	return &xmlReader{
+		dec:  xml.NewDecoder(r),
+		opts: opts,
+		want: splitPath(opts.RecordPath),
+	}
+}
+
+func splitPath(p string) []string {
+	parts := strings.Split(strings.Trim(strings.TrimSpace(p), "./"), ".")
+	out := parts[:0]
+	for _, s := range parts {
+		if s = strings.TrimSpace(s); s != "" {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+func (x *xmlReader) Next() (Record, error) {
+	if x.done {
+		return nil, io.EOF
+	}
+	for {
+		tok, err := x.dec.Token()
+		if err == io.EOF {
+			x.done = true
+			return nil, io.EOF
+		}
+		if err != nil {
+			return nil, fmt.Errorf("xml: %w", err)
+		}
+
+		switch t := tok.(type) {
+		case xml.StartElement:
+			x.path = append(x.path, t.Name.Local)
+			if x.matches() {
+				val, derr := x.decodeElement(t)
+				// Leaving the element: the decoder consumed through its EndElement.
+				x.path = x.path[:len(x.path)-1]
+				if derr != nil {
+					return nil, derr
+				}
+				return asRecord(val, t.Name.Local), nil
+			}
+		case xml.EndElement:
+			if len(x.path) > 0 {
+				x.path = x.path[:len(x.path)-1]
+			}
+		}
+	}
+}
+
+// matches reports whether the currently-open element is a record: the path's
+// segments must appear in order as a suffix of the open path, with the last
+// segment being the element itself. A single-segment path matches at any depth.
+func (x *xmlReader) matches() bool {
+	if len(x.want) == 0 || len(x.path) < len(x.want) {
+		return false
+	}
+	// Last segment must be the current element.
+	if x.path[len(x.path)-1] != x.want[len(x.want)-1] {
+		return false
+	}
+	// Earlier segments must appear in order among the ancestors.
+	ai := len(x.path) - 2
+	for wi := len(x.want) - 2; wi >= 0; wi-- {
+		found := false
+		for ; ai >= 0; ai-- {
+			if x.path[ai] == x.want[wi] {
+				found = true
+				ai--
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}
+
+// asRecord normalises a decoded element value into a Record. A leaf element
+// (plain string) still has to be a record, so it is wrapped under its own name.
+func asRecord(v interface{}, name string) Record {
+	if m, ok := v.(Record); ok {
+		return m
+	}
+	return Record{name: v}
+}
+
+// decodeElement consumes one element (whose StartElement was just read) and
+// returns either a string (leaf, no attributes) or a Record.
+func (x *xmlReader) decodeElement(start xml.StartElement) (interface{}, error) {
+	out := Record{}
+	for _, a := range start.Attr {
+		out[x.opts.AttrPrefix+attrName(a.Name)] = a.Value
+	}
+
+	var text strings.Builder
+	for {
+		tok, err := x.dec.Token()
+		if err == io.EOF {
+			return nil, fmt.Errorf("xml: unexpected end of document inside <%s>", start.Name.Local)
+		}
+		if err != nil {
+			return nil, fmt.Errorf("xml: %w", err)
+		}
+
+		switch t := tok.(type) {
+		case xml.CharData:
+			text.Write([]byte(t))
+		case xml.StartElement:
+			child, cerr := x.decodeElement(t)
+			if cerr != nil {
+				return nil, cerr
+			}
+			addChild(out, t.Name.Local, child)
+		case xml.EndElement:
+			trimmed := strings.TrimSpace(text.String())
+			if len(out) == 0 {
+				// Pure leaf: the element's text is its value ("" when empty).
+				return trimmed, nil
+			}
+			if trimmed != "" {
+				out[x.opts.TextKey] = trimmed
+			}
+			return out, nil
+		}
+	}
+}
+
+// attrName keeps a namespace prefix visible rather than silently dropping it,
+// so <ns:Order ns:id="1"> doesn't collide with an unprefixed id.
+func attrName(n xml.Name) string {
+	if n.Space != "" {
+		return n.Space + ":" + n.Local
+	}
+	return n.Local
+}
+
+// addChild records repeated element names as a slice in document order.
+func addChild(into Record, name string, val interface{}) {
+	prev, exists := into[name]
+	if !exists {
+		into[name] = val
+		return
+	}
+	if slice, ok := prev.([]interface{}); ok {
+		into[name] = append(slice, val)
+		return
+	}
+	into[name] = []interface{}{prev, val}
+}

--- a/src/pkg/records/yaml.go
+++ b/src/pkg/records/yaml.go
@@ -1,0 +1,92 @@
+package records
+
+import (
+	"fmt"
+	"io"
+
+	"gopkg.in/yaml.v3"
+)
+
+// yamlReader decodes a YAML stream document by document. A mapping document is
+// one record; a sequence document yields its mapping elements as records;
+// multi-document streams ("---") continue across documents.
+//
+// Unlike the other readers this is only *partly* streaming: yaml.v3 materialises
+// each document whole, so a single enormous YAML document cannot be processed
+// under a memory bound. Streams() reports false for yaml, and the transforms
+// decline over-cap YAML the way they decline other un-streamable inputs
+// (ADR 0002 phase C policy) instead of quietly buffering it.
+type yamlReader struct {
+	dec     *yaml.Decoder
+	pending []Record
+	done    bool
+}
+
+func newYAMLReader(r io.Reader) *yamlReader {
+	return &yamlReader{dec: yaml.NewDecoder(r)}
+}
+
+func (y *yamlReader) Next() (Record, error) {
+	for {
+		if len(y.pending) > 0 {
+			rec := y.pending[0]
+			y.pending = y.pending[1:]
+			return rec, nil
+		}
+		if y.done {
+			return nil, io.EOF
+		}
+
+		var doc interface{}
+		if err := y.dec.Decode(&doc); err != nil {
+			if err == io.EOF {
+				y.done = true
+				return nil, io.EOF
+			}
+			return nil, fmt.Errorf("yaml: %w", err)
+		}
+
+		switch v := normaliseYAML(doc).(type) {
+		case Record:
+			return v, nil
+		case []interface{}:
+			for _, item := range v {
+				if rec, ok := item.(Record); ok {
+					y.pending = append(y.pending, rec)
+				}
+			}
+			// A sequence of scalars yields nothing; loop to the next document.
+		}
+		// Scalar documents carry no record; skip to the next one.
+	}
+}
+
+// normaliseYAML converts yaml.v3's map[string]interface{} / nested values into
+// the same shape JSON produces. yaml.v3 already decodes mappings with string
+// keys as map[string]interface{}, but non-string keys (`1: x`, `true: y`)
+// arrive as map[interface{}]interface{} inside older nodes — stringify those so
+// downstream code never has to special-case them.
+func normaliseYAML(v interface{}) interface{} {
+	switch t := v.(type) {
+	case map[string]interface{}:
+		out := make(Record, len(t))
+		for k, val := range t {
+			out[k] = normaliseYAML(val)
+		}
+		return out
+	case map[interface{}]interface{}:
+		out := make(Record, len(t))
+		for k, val := range t {
+			out[fmt.Sprintf("%v", k)] = normaliseYAML(val)
+		}
+		return out
+	case []interface{}:
+		out := make([]interface{}, len(t))
+		for i, val := range t {
+			out[i] = normaliseYAML(val)
+		}
+		return out
+	default:
+		return v
+	}
+}

--- a/ui/src/components/Pipeline/PropertyEditor.tsx
+++ b/ui/src/components/Pipeline/PropertyEditor.tsx
@@ -2573,6 +2573,7 @@ function ConverterConfig({
   deployedConnectionId?: string
 }) {
   const outputFormat = (config.output_format as string) || ''
+  const inputFormat = (config.input_format as string) || ''
   const csvDelimiter = (config.csv_delimiter as string) || ','
   const csvHeaders = (config.csv_headers as boolean) !== false
   const textTemplate = (config.text_template as string) || ''
@@ -2866,6 +2867,41 @@ function ConverterConfig({
   return (
     <DndContext sensors={sensors} onDragStart={onDragStart} onDragEnd={onDragEnd}>
     <div className="space-y-3">
+      {/* Input Format (ADR 0003) — what arrives; blank auto-detects from the
+          source's content type, so existing pipelines keep working untouched. */}
+      <StyledSelect
+        label="Input Format"
+        value={inputFormat}
+        onChange={(v) => setConfig({ ...config, input_format: v })}
+        options={[
+          { value: '', label: 'Auto-detect (from source)' },
+          { value: 'json', label: 'JSON' },
+          { value: 'ndjson', label: 'NDJSON (line-delimited JSON)' },
+          { value: 'csv', label: 'CSV' },
+          { value: 'tsv', label: 'TSV (Tab-separated)' },
+          { value: 'xml', label: 'XML' },
+          { value: 'yaml', label: 'YAML' },
+        ]}
+      />
+
+      {(inputFormat === 'csv' || inputFormat === 'tsv') && (
+        <StyledInput
+          label="Input delimiter (blank = detect)"
+          placeholder=","
+          value={(config.input_csv_delimiter as string) || ''}
+          onChange={(v) => setConfig({ ...config, input_csv_delimiter: v })}
+        />
+      )}
+
+      {inputFormat === 'xml' && (
+        <StyledInput
+          label="XML record path (required)"
+          placeholder="Orders.Order"
+          value={(config.input_xml_record_path as string) || ''}
+          onChange={(v) => setConfig({ ...config, input_xml_record_path: v })}
+        />
+      )}
+
       {/* Output Format */}
       <StyledSelect
         label="Output Format"


### PR DESCRIPTION
Design pass **and** the implementation — all five input formats, since "I need them all". The transforms now accept any supported format; **CSV → JSON** and **XML → CSV** both work, and the output side is untouched.

## What's here

**`pkg/records`** — one `Reader` interface (`Next()` → record, `io.EOF`), every reader built from an `io.Reader` so the *same* implementation serves the buffered path and the ADR 0002 streaming path with no format branching at the call sites. **A multi-GB CSV or XML streams record-by-record**, exactly like JSON did. 23 tests, 86.4% coverage.

Per-format config where it decides whether parsing is *correct*, per your "do the same for other file types":

- **CSV/TSV** — delimiter configurable or sniffed (`, ; tab |`, outside quotes), header normalisation (blank → `column_N`, duplicates suffixed, BOM stripped), ragged rows pad, wide rows keep extras, optional no-header and trim. Values stay strings.
- **XML** — `input_xml_record_path` **required** (never guessed); attributes → `@name`, repeats → slice in document order, mixed text → `#text`, namespace prefixes preserved; attr-prefix and text-key configurable. Token-walking stdlib decoder, no new dependency.
- **JSON/NDJSON** — one decoder covers arrays, single objects, concatenated values.
- **YAML** — mapping/sequence/multi-doc, non-string keys stringified.

**Detection**: explicit config → `ContentType` → head sniff → json, so existing pipelines are untouched.

## Two things the work surfaced — fixed deliberately, not papered over

1. **`ErrNotASequence` / `RequireSequence`.** My new JSON reader happily accepts a lone top-level object — which on the *streaming* path would decode a multi-GB object whole, the exact OOM ADR 0002 exists to prevent. The streaming callers now require a sequence and treat the refusal as a structural **decline (NAK → DLQ)**, distinct from malformed data (which still acks). Caught by an existing test, which is what it was there for.
2. **The converter's no-op short-circuit.** "No mappings and no output format = do nothing" was correct when every input was JSON. A CSV input with nothing else configured means *"parse this CSV and give me JSON"* — real work. The guard now asks whether the node transcodes.

**JSON keeps its original `json.Unmarshal` path** rather than routing through the new readers: the two agree on ordinary payloads, but the old path has long-standing edge behaviour pipelines may rely on, and zero regression for JSON was an accepted condition.

## UI

Converter editor gains an **Input Format** selector (blank = auto-detect, so existing nodes are unchanged), with the CSV delimiter and the required XML record path shown conditionally.

## Also in here (separate commit)

`style: gofmt the ServesConnection additions` — my #203 change left 11 producer files unformatted in main. CI missed it because golangci-lint's default linters don't include gofmt. Formatting only.

## Verification

`go build ./...`, **full-repo `go test ./...`**, golangci-lint on the touched packages, and the UI suite (**305 tests**) all pass. The touched UI file carries the same **19** pre-existing lint errors as main — no new debt.

Tests worth noting: CSV→JSON, XML→CSV end-to-end through the real transform; auto-detect from ContentType; mapping applied to CSV records; XML-without-record-path names the config field; JSON behaviour unchanged; filter rules over CSV emitting JSON; and an **over-cap CSV going through the streaming path**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)